### PR TITLE
Enhance Elo chart interactions and layout

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -133,6 +133,32 @@ button, input, select, textarea { font: inherit; color: inherit; }
 .muted { color: var(--muted); }
 .mono  { font-family: var(--font-mono); }
 
+.org-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.org-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+.org-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.org-icon.org-icon--dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, rgba(106, 160, 255, .9), rgba(159, 210, 255, 1));
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, .28);
+}
+
 h1 { font-size: var(--fs-5); line-height: 1.2; margin: 0 0 var(--sp-2); letter-spacing: .2px; }
 h2 { font-size: var(--fs-4); line-height: 1.25; margin: 0 0 var(--sp-2); }
 h3 { font-size: var(--fs-3); line-height: 1.3; margin: 0 0 var(--sp-1); }
@@ -145,7 +171,14 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 }
 
 /* 2) Layout ----------------------------------------------------------- */
-.wrap { width: min(1400px, 96vw); margin: 24px auto; display: grid; gap: 16px; }
+.wrap { width: min(1600px, calc(100vw - 48px)); margin: 32px auto; display: grid; gap: 24px; }
+.wrap--wide { width: min(1920px, calc(100vw - 56px)); margin: 24px auto 64px; }
+@media (max-width: 1024px) {
+  .wrap--wide { width: min(100%, calc(100vw - 32px)); margin: 20px auto 40px; }
+}
+@media (max-width: 640px) {
+  .wrap--wide { width: min(100%, calc(100vw - 24px)); margin: 16px auto 32px; }
+}
 .row  { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 @media (max-width: 900px) { .row { grid-template-columns: 1fr; } }
 .section, .stack { display: grid; gap: var(--sp-3); }
@@ -302,42 +335,186 @@ svg text { fill: hsl(240 20% 56%); font-family: var(--font-sans); }
 .table { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px; align-items: center; justify-items: center; padding: 12px; }
 
 /* Leaderboard v2 (namespaced: lb-*) --------------------------------- */
-.lb-wrap{ border-radius: 14px; border:1px solid var(--border); background: hsl(210 20% 10% / .9); box-shadow: 0 10px 24px rgba(0,0,0,.35); overflow:auto }
-.lb-table{ width:100%; table-layout: auto; border-collapse: collapse }
-.lb-table th, .lb-table td{ padding: 12px; border-bottom: 1px solid var(--line); vertical-align: middle; white-space: nowrap; overflow:hidden; text-overflow: ellipsis }
-.lb-table thead th{ background: hsl(210 22% 14% / .94); color: var(--muted); font-weight: 800 }
-.lb-table .num{ text-align: right; font-variant-numeric: tabular-nums }
-/* Leaderboard readability tweaks */
-.lb-table tbody tr:nth-child(odd){ background: hsl(216 36% 18% / .78); }
-.lb-table tbody tr:nth-child(even){ background: hsl(216 32% 16% / .62); }
-.lb-table tbody tr:hover{ background: hsl(210 70% 36% / .35); }
-.lb-table td{ color: #f3f7ff; }
-.lb-table .lb-model .name{ color: #f8fbff; font-weight: 700; }
-.lb-table .lb-org .txt{ color: #d8e9ff; }
-.lb-table td .pill.ghost{ color: #d6ecff; border-color: rgba(214,236,255,.35); }
+.lb-card {
+  padding: 0;
+  border-radius: 28px;
+  border: 1px solid rgba(118, 177, 255, .24);
+  background:
+    radial-gradient(140% 160% at 95% 0%, rgba(77, 246, 180, .18), transparent 64%),
+    radial-gradient(120% 150% at 8% 0%, rgba(118, 177, 255, .18), transparent 70%),
+    linear-gradient(180deg, rgba(12, 20, 38, .96), rgba(8, 14, 28, .94));
+  box-shadow: 0 38px 74px rgba(4, 12, 24, .56);
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.lb-card__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 32px 40px 28px;
+  background: linear-gradient(180deg, rgba(8, 16, 30, .9), rgba(8, 14, 26, .78));
+  border-bottom: 1px solid rgba(118, 177, 255, .28);
+}
+.lb-card__header h1 { margin-bottom: 8px; }
+.lb-card__body {
+  padding: 0 40px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+.lb-table-wrap {
+  border-radius: 24px;
+  border: 1px solid rgba(118, 177, 255, .26);
+  background: linear-gradient(180deg, rgba(8, 16, 30, .92), rgba(6, 12, 24, .94));
+  box-shadow: 0 32px 60px rgba(4, 12, 24, .48);
+  overflow: auto;
+  scrollbar-color: rgba(118, 177, 255, .45) rgba(10, 20, 34, .6);
+}
+.lb-table {
+  width: 100%;
+  min-width: 1100px;
+  border-collapse: collapse;
+  table-layout: auto;
+}
+.lb-table th,
+.lb-table td {
+  padding: 18px 24px;
+  border-bottom: 1px solid rgba(118, 177, 255, .16);
+  vertical-align: middle;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.lb-table thead th {
+  background: rgba(6, 14, 26, .82);
+  color: rgba(210, 228, 255, .9);
+  font-size: .8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .72px;
+}
+.lb-table tbody tr {
+  background: rgba(10, 24, 46, .64);
+}
+.lb-table tbody tr:nth-child(even) {
+  background: rgba(12, 28, 52, .58);
+}
+.lb-table tbody tr:hover {
+  background: linear-gradient(90deg, rgba(118, 177, 255, .28), rgba(77, 246, 180, .24));
+}
+.lb-table .num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.lb-table td { color: #f4f8ff; }
+.lb-table .lb-model .name {
+  color: #f8fbff;
+  font-weight: 700;
+}
+.lb-table .lb-org .txt {
+  color: rgba(206, 224, 255, .78);
+  font-size: .78rem;
+  letter-spacing: .2px;
+}
+.lb-table td .pill.ghost {
+  color: #d6ecff;
+  border-color: rgba(214, 236, 255, .35);
+}
+.lb-table th:nth-child(3),
+.lb-table td:nth-child(3),
+.lb-table th:nth-child(6),
+.lb-table td:nth-child(6) {
+  text-align: center;
+}
+.lb-table th.sortable {
+  cursor: pointer;
+  position: relative;
+  padding-right: 18px;
+}
+.lb-table th.sortable::after {
+  content: '⇅';
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: .72;
+}
+.lb-table th.sortable[data-dir="asc"]::after { content: '▲'; }
+.lb-table th.sortable[data-dir="desc"]::after { content: '▼'; }
+.lb-model {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+.lb-model .org-icon {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #9fd2ff;
+}
+.lb-model .org-icon img,
+.lb-model .org-icon svg {
+  width: 100%;
+  height: 100%;
+}
+.lb-model .name {
+  flex: 1;
+  min-width: 0;
+  text-decoration: none;
+  color: inherit;
+}
+.lb-model .name:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.lb-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 6px;
+  background: linear-gradient(135deg, #6aa0ff, #9fd2ff);
+  border: 1px solid rgba(255, 255, 255, .18);
+}
+.lb-badge {
+  padding: 3px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 12px;
+  color: var(--muted);
+}
+.lb-org {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  white-space: nowrap;
+}
+.lb-org .org-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #9fd2ff;
+}
+.lb-org .org-icon img,
+.lb-org .org-icon svg {
+  width: 100%;
+  height: 100%;
+}
+.lb-org .txt {
+  color: rgba(206, 224, 255, .75);
+  font-size: .75rem;
+  letter-spacing: .18px;
+}
 
-/* Center Elo (col 3) and Win% (col 6) */
-.lb-table th:nth-child(3), .lb-table td:nth-child(3),
-.lb-table th:nth-child(6), .lb-table td:nth-child(6){ text-align: center }
-
-/* Sortable header affordance */
-.lb-table th.sortable{ cursor:pointer; position:relative; padding-right: 18px }
-.lb-table th.sortable::after{ content:'⇅'; position:absolute; right:6px; top:50%; transform: translateY(-50%); opacity:.65 }
-.lb-table th.sortable[data-dir="asc"]::after{ content:'▲' }
-.lb-table th.sortable[data-dir="desc"]::after{ content:'▼' }
-.lb-model{ display:flex; align-items:center; gap:10px; min-width:0 }
-.lb-model svg{ width:18px; height:18px; color:#9fd2ff }
-.lb-model img.icon{ width:18px; height:18px; display:block }
-.lb-model .name{ flex:1; min-width:0; text-decoration:none; color:inherit }
-.lb-model .name:hover{ text-decoration: underline; text-underline-offset: 2px }
-.lb-dot{ width:14px; height:14px; border-radius:4px; background: linear-gradient(135deg, #6aa0ff, #9fd2ff); border:1px solid rgba(255,255,255,.18) }
-.lb-badge{ padding:3px 6px; border-radius:999px; border:1px solid var(--border); font-size:12px; color: var(--muted) }
-/* Org cell */
-.lb-org{ display:flex; align-items:center; gap:6px; white-space:nowrap }
-.lb-org svg{ width:14px; height:14px; display:inline-block; color:#9fd2ff }
-.lb-org .txt{ color: var(--muted); font-size: 12px }
-@media (max-width: 720px){ .lb-table th:nth-child(6), .lb-table td:nth-child(6){ display:none } }
-@media (max-width: 600px){ .lb-table th:nth-child(4), .lb-table td:nth-child(4){ display:none } }
+@media (max-width: 1024px) { .lb-table-wrap { max-height: none; } }
+@media (max-width: 720px) { .lb-table th:nth-child(6), .lb-table td:nth-child(6) { display: none; } }
+@media (max-width: 600px) { .lb-table th:nth-child(4), .lb-table td:nth-child(4) { display: none; } }
 
 /* Felt */
 .felt {
@@ -834,37 +1011,129 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
 
 /* Elo chart ----------------------------------------------------------- */
 .elo-card {
-  background: linear-gradient(180deg, hsl(210 24% 14% / .92), hsl(220 24% 12% / .92));
-  border: 1px solid rgba(123, 163, 255, .18);
-  box-shadow: 0 24px 48px rgba(4, 12, 24, .55);
+  padding: 0;
+  border-radius: 30px;
+  border: 1px solid rgba(123, 180, 255, .24);
+  background:
+    radial-gradient(140% 150% at 88% 0%, rgba(77, 246, 180, .2), transparent 70%),
+    radial-gradient(160% 140% at 10% 0%, rgba(118, 177, 255, .2), transparent 72%),
+    linear-gradient(180deg, rgba(12, 18, 34, .96), rgba(6, 10, 20, .94));
+  box-shadow: 0 44px 82px rgba(4, 12, 24, .6);
+  overflow: hidden;
+  backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
 }
-
+.elo-card__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 32px 40px 28px;
+  background: linear-gradient(180deg, rgba(8, 16, 30, .9), rgba(8, 14, 26, .76));
+  border-bottom: 1px solid rgba(123, 180, 255, .28);
+  flex-wrap: wrap;
+}
+.elo-card__header h1 { margin-bottom: 8px; }
+.elo-card__filters {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  flex: 1;
+}
+.filter-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(132, 196, 255, .32);
+  background: rgba(10, 24, 42, .7);
+  color: rgba(204, 224, 255, .9);
+  font-size: .86rem;
+  font-weight: 600;
+  letter-spacing: .2px;
+  cursor: pointer;
+  transition:
+    transform var(--dur-1) var(--ease-2),
+    box-shadow var(--dur-1) var(--ease-2),
+    border-color var(--dur-1) var(--ease-2),
+    background var(--dur-1) var(--ease-2);
+}
+.filter-chip .filter-chip__content {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.filter-chip .org-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.filter-chip .org-icon img,
+.filter-chip .org-icon svg {
+  width: 100%;
+  height: 100%;
+}
+.filter-chip .filter-chip__text { white-space: nowrap; }
+.filter-chip .filter-chip__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(118, 177, 255, .85), rgba(77, 246, 180, .78));
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, .28);
+}
+.filter-chip:hover {
+  transform: translateY(-1px);
+  border-color: rgba(132, 196, 255, .5);
+  background: rgba(16, 34, 58, .78);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, .35);
+}
+.filter-chip.active {
+  color: #07101c;
+  background: linear-gradient(90deg, rgba(118, 177, 255, .95), rgba(77, 246, 180, .88));
+  border-color: transparent;
+  box-shadow: 0 20px 40px rgba(26, 140, 255, .35);
+}
+.filter-chip.active .filter-chip__text { font-weight: 700; }
+.filter-chip:focus-visible { outline: none; box-shadow: var(--ring); }
+.elo-card__body {
+  padding: 32px 40px 40px;
+  display: grid;
+  gap: 28px;
+}
 .elo-chart {
   position: relative;
-  border-radius: 18px;
-  background: radial-gradient(120% 140% at 10% 0%, rgba(97, 188, 255, .12), transparent 60%),
-              radial-gradient(120% 160% at 90% 30%, rgba(76, 255, 173, .12), transparent 60%),
-              linear-gradient(180deg, hsl(216 24% 16% / .92), hsl(216 24% 12% / .94));
-  border: 1px solid rgba(118, 177, 255, .2);
-  padding: 20px;
+  border-radius: 26px;
+  background:
+    radial-gradient(140% 180% at 6% 0%, rgba(97, 188, 255, .18), transparent 70%),
+    radial-gradient(160% 180% at 96% 18%, rgba(77, 246, 180, .2), transparent 68%),
+    linear-gradient(180deg, rgba(8, 18, 32, .95), rgba(8, 14, 26, .92));
+  border: 1px solid rgba(118, 177, 255, .3);
+  padding: 32px;
   overflow: hidden;
 }
-
 .elo-chart svg {
   width: 100%;
   height: auto;
-  min-height: 340px;
+  min-height: 460px;
   display: block;
-  filter: drop-shadow(0 12px 28px rgba(0,0,0,.45));
+  filter: drop-shadow(0 18px 34px rgba(0, 0, 0, .45));
   touch-action: none;
 }
-
 .chart-crosshair {
-  stroke: rgba(255,255,255,.28);
+  stroke: rgba(255,255,255,.32);
   stroke-dasharray: 4 4;
   pointer-events: none;
 }
-
 .chart-marker {
   fill: rgba(255,255,255,.95);
   stroke-width: 3;
@@ -872,86 +1141,178 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
   filter: drop-shadow(0 0 8px rgba(0,0,0,.35));
   pointer-events: none;
 }
-
 .chart-tooltip {
   position: absolute;
-  min-width: 180px;
-  border-radius: 12px;
-  padding: 12px 14px;
-  background: linear-gradient(180deg, rgba(10,18,28,.92), rgba(14,24,38,.92));
+  min-width: 220px;
+  border-radius: 16px;
+  padding: 16px 18px;
+  background: linear-gradient(180deg, rgba(10,18,28,.95), rgba(14,26,42,.94));
   border: 1px solid rgba(132, 196, 255, .32);
-  box-shadow: 0 18px 32px rgba(0,0,0,.45);
+  box-shadow: 0 22px 38px rgba(0,0,0,.45);
   color: #f5fbff;
   pointer-events: none;
-  transform: translate(-50%, calc(-100% - 16px));
+  transform: translate(-50%, calc(-100% - 18px));
   opacity: 0;
   visibility: hidden;
   transition: opacity .18s var(--ease-2), visibility .18s var(--ease-2);
   z-index: 5;
 }
-
 .chart-tooltip.visible {
   opacity: 1;
   visibility: visible;
 }
-
 .chart-tooltip__time {
   font-weight: 700;
   letter-spacing: .35px;
-  margin-bottom: 6px;
+  margin-bottom: 8px;
 }
-
 .chart-tooltip__series {
   display: grid;
-  gap: 6px;
+  gap: 8px;
 }
-
 .chart-tooltip__row {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 16px;
   font-size: 0.92rem;
 }
-
 .chart-tooltip__label {
   display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  color: rgba(230, 244, 255, .82);
+  align-items: flex-start;
+  gap: 10px;
+  color: rgba(230, 244, 255, .86);
+  min-width: 0;
 }
-
+.chart-tooltip__text {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+.chart-tooltip__names {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  line-height: 1.2;
+  min-width: 0;
+}
+.chart-tooltip__model {
+  font-weight: 700;
+  white-space: nowrap;
+}
+.chart-tooltip__company {
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .35px;
+  color: rgba(230, 244, 255, .65);
+}
 .chart-tooltip__value {
   font-variant-numeric: tabular-nums;
   font-weight: 600;
   color: #ffffff;
 }
-
 .chart-bullet {
   width: 10px;
   height: 10px;
   border-radius: 999px;
   box-shadow: 0 0 0 2px rgba(0,0,0,.35);
+  flex-shrink: 0;
 }
-
 .chart-legend {
+  display: grid;
+  gap: 16px;
+  padding: 24px 26px;
+  border-radius: 26px;
+  background: linear-gradient(180deg, rgba(10, 18, 32, .9), rgba(6, 12, 24, .9));
+  border: 1px solid rgba(123, 180, 255, .24);
+  box-shadow: 0 30px 60px rgba(4, 12, 24, .48);
+  margin-top: 0;
+  align-self: stretch;
+  max-height: 100%;
+  overflow-y: auto;
+}
+.chart-legend__item {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 14px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, .04);
+  color: rgba(230, 240, 255, .9);
+  border: 1px solid rgba(123, 180, 255, .16);
+  min-width: 0;
 }
-
-.chart-legend .pill {
+.chart-legend__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px rgba(0,0,0,.2);
+  background: var(--legend-color, rgba(118, 177, 255, .92));
+}
+.chart-legend__label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.chart-legend__label .org-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.chart-legend__label .org-icon img,
+.chart-legend__label .org-icon svg {
+  width: 100%;
+  height: 100%;
+}
+.chart-legend__text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.chart-legend__model {
   font-weight: 700;
-  letter-spacing: .35px;
-  color: #0c121a;
-  border: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #f6fbff;
+}
+.chart-legend__company {
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .38px;
+  color: rgba(196, 216, 255, .68);
 }
 
+@media (min-width: 1280px) {
+  .elo-card__body {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 1.1fr);
+    align-items: stretch;
+  }
+  .chart-legend {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1024px) {
+  .elo-card__filters { justify-content: flex-start; }
+  .filter-chips { justify-content: flex-start; }
+}
 @media (max-width: 820px) {
-  .elo-chart svg { min-height: 280px; }
+  .elo-card__body { padding: 24px; }
+  .elo-chart { padding: 22px; }
+  .elo-chart svg { min-height: 360px; }
+  .chart-legend { grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); }
 }
-
+@media (max-width: 640px) {
+  .elo-card__header { flex-direction: column; align-items: flex-start; }
+  .elo-card__filters { width: 100%; }
+  .filter-chips { width: 100%; justify-content: flex-start; }
+}
 
 /* Replay: prevent long model names from breaking layout */
 #turn { max-width: 48ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -9,15 +9,64 @@
     <script>
     const palette = ['#4df6b4', '#76b0ff', '#ffd166', '#f08cf0', '#ff6d6d', '#9de7ff', '#c4f98b', '#b59bff'];
     const state = {
-      dims: { width: 1100, height: 420 },
+      dims: { width: 1100, height: 440 },
       pad: { top: 48, right: 70, bottom: 64, left: 78 },
       baseline: 1500,
       plots: [],
-      flat: []
+      flat: [],
+      flatSorted: [],
+      fullSeries: [],
+      currentSeries: [],
+      companies: [],
+      selectedCompany: 'all',
+      resizeTimer: null,
+      resizeBound: null,
+      lastHoverKey: null
     };
     const dateFormatter = new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
     const shortDate = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
     const $ = (sel) => document.querySelector(sel);
+
+    function canonicalCompany(company) {
+      const trimmed = (company || 'OpenAI').trim();
+      return trimmed ? trimmed : 'OpenAI';
+    }
+
+    function companyKey(company) {
+      return canonicalCompany(company).toLowerCase();
+    }
+
+    function openaiIconMarkup() {
+      return `<svg class="org-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.31 1.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg>`;
+    }
+
+    function companyIconMarkup(company, model) {
+      const c = (company || '').trim().toLowerCase();
+      const m = (model || '').trim().toLowerCase();
+      if (!c || c === 'openai') return openaiIconMarkup();
+      const inc = (s) => c.includes(s) || m.startsWith(`${s}/`) || m.includes(`/${s}`);
+      if (inc('deepseek')) return '<img class="org-icon" src="/web/img/deepseek-color.svg" alt="DeepSeek"/>';
+      if (inc('xai') || inc('grok')) return '<img class="org-icon" src="/web/img/xai.svg" alt="xAI"/>';
+      if (inc('anthropic')) return '<img class="org-icon" src="/web/img/anthropic.svg" alt="Anthropic"/>';
+      if (inc('meta') || inc('llama')) return '<img class="org-icon" src="/web/img/meta.svg" alt="Meta"/>';
+      if (inc('google') || inc('gemini')) return '<img class="org-icon" src="/web/img/google.svg" alt="Google"/>';
+      if (inc('mistral')) return '<img class="org-icon" src="/web/img/mistral.svg" alt="Mistral"/>';
+      if (inc('groq')) return '<img class="org-icon" src="/web/img/groq.svg" alt="Groq"/>';
+      if (inc('together')) return '<img class="org-icon" src="/web/img/together.svg" alt="Together"/>';
+      if (inc('perplexity')) return '<img class="org-icon" src="/web/img/perplexity.svg" alt="Perplexity"/>';
+      if (inc('azure')) return '<img class="org-icon" src="/web/img/azure.svg" alt="Azure"/>';
+      if (inc('openrouter')) return '<img class="org-icon" src="/web/img/openrouter.svg" alt="OpenRouter"/>';
+      if (inc('cohere')) return '<img class="org-icon" src="/web/img/cohere.svg" alt="Cohere"/>';
+      if (inc('fireworks')) return '<img class="org-icon" src="/web/img/fireworks.svg" alt="Fireworks"/>';
+      return '<span class="org-icon org-icon--dot" aria-hidden="true"></span>';
+    }
+
+    function createIconElement(markup) {
+      if (!markup) return null;
+      const tpl = document.createElement('template');
+      tpl.innerHTML = markup.trim();
+      return tpl.content.firstElementChild;
+    }
 
     document.addEventListener('DOMContentLoaded', () => {
       highlightNav();
@@ -41,10 +90,26 @@
       const map = new Map();
       rows.forEach(r => {
         if (r.bot_id == null) return;
+        const model = (r.model || '').trim();
+        const company = canonicalCompany(r.company);
         let entry = map.get(r.bot_id);
         if (!entry) {
-          entry = { botId: r.bot_id, meta: { model: (r.model || '').trim(), company: r.company || '' }, pts: [] };
+          entry = {
+            botId: r.bot_id,
+            meta: {
+              model,
+              company,
+              companyKey: companyKey(company),
+              iconMarkup: companyIconMarkup(company, model)
+            },
+            pts: []
+          };
           map.set(r.bot_id, entry);
+        } else {
+          entry.meta.model = model || entry.meta.model;
+          entry.meta.company = company;
+          entry.meta.companyKey = companyKey(company);
+          entry.meta.iconMarkup = companyIconMarkup(company, model || entry.meta.model);
         }
         const when = new Date(r.when);
         if (Number.isNaN(when.getTime())) return;
@@ -54,36 +119,74 @@
       return Array.from(map.values());
     }
 
+    function buildCompanyIndex(series) {
+      const map = new Map();
+      series.forEach(entry => {
+        const key = entry.meta.companyKey || 'openai';
+        if (!map.has(key)) {
+          map.set(key, {
+            key,
+            label: canonicalCompany(entry.meta.company),
+            iconMarkup: entry.meta.iconMarkup
+          });
+        }
+      });
+      return Array.from(map.values()).sort((a, b) => a.label.localeCompare(b.label));
+    }
+
     function draw(series) {
       const chartWrap = document.querySelector('.elo-chart');
+      if (!chartWrap) return;
       const svg = document.getElementById('chart');
       const tooltip = chartWrap.querySelector('.chart-tooltip');
       const tooltipTime = tooltip.querySelector('.chart-tooltip__time');
       const tooltipSeries = tooltip.querySelector('.chart-tooltip__series');
       const legend = document.getElementById('legend');
-      const { width: w, height: h } = state.dims;
-      const pad = state.pad;
+
+      state.currentSeries = Array.isArray(series) ? series.slice() : [];
 
       const mk = (tag) => document.createElementNS('http://www.w3.org/2000/svg', tag);
 
       svg.innerHTML = '';
-      svg.setAttribute('viewBox', `0 0 ${w} ${h}`);
+      legend.innerHTML = '';
+      tooltip.classList.remove('visible');
+
+      const rect = chartWrap.getBoundingClientRect();
+      const width = Math.max(720, rect.width || state.dims.width);
+      const height = Math.max(420, Math.min(width * 0.56, (window.innerHeight || 900) * 0.7));
+      state.dims.width = width;
+      state.dims.height = height;
+
+      const pad = { ...state.pad };
+      if (width < 980) {
+        pad.left = 70;
+        pad.right = 70;
+      }
+      if (width < 780) {
+        pad.left = 56;
+        pad.right = 56;
+        pad.bottom = 74;
+      }
+
+      svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
       svg.style.cursor = 'crosshair';
 
       state.plots = [];
       state.flat = [];
-      legend.innerHTML = '';
-      tooltip.classList.remove('visible');
+      state.flatSorted = [];
+      state.lastHoverKey = null;
 
       const allPts = [];
       series.forEach(entry => entry.pts.forEach(p => allPts.push(p)));
       if (!allPts.length) {
         const msg = mk('text');
         msg.setAttribute('x', String(pad.left));
-        msg.setAttribute('y', String(h / 2));
+        msg.setAttribute('y', String(height / 2));
         msg.setAttribute('fill', '#5b7089');
         msg.setAttribute('font-size', '14');
-        msg.textContent = 'No duels logged yet.';
+        msg.textContent = state.selectedCompany !== 'all'
+          ? 'No duels logged yet for this company.'
+          : 'No duels logged yet.';
         svg.appendChild(msg);
         return;
       }
@@ -104,8 +207,8 @@
       }
       const baseValue = Math.min(Math.max(state.baseline, yMin), yMax);
 
-      const x = (time) => pad.left + ((time - tMin) * (w - pad.left - pad.right)) / (tMax - tMin);
-      const y = (val) => h - pad.bottom - ((val - yMin) * (h - pad.top - pad.bottom)) / (yMax - yMin);
+      const x = (time) => pad.left + ((time - tMin) * (width - pad.left - pad.right)) / (tMax - tMin);
+      const y = (val) => height - pad.bottom - ((val - yMin) * (height - pad.top - pad.bottom)) / (yMax - yMin);
 
       const defs = mk('defs');
       const bgGrad = mk('linearGradient');
@@ -123,8 +226,8 @@
       const bg = mk('rect');
       bg.setAttribute('x', '0');
       bg.setAttribute('y', '0');
-      bg.setAttribute('width', String(w));
-      bg.setAttribute('height', String(h));
+      bg.setAttribute('width', String(width));
+      bg.setAttribute('height', String(height));
       bg.setAttribute('fill', 'url(#chart-bg)');
       svg.appendChild(bg);
 
@@ -139,7 +242,7 @@
         const yy = y(value);
         const line = mk('line');
         line.setAttribute('x1', String(pad.left));
-        line.setAttribute('x2', String(w - pad.right));
+        line.setAttribute('x2', String(width - pad.right));
         line.setAttribute('y1', String(yy));
         line.setAttribute('y2', String(yy));
         line.setAttribute('opacity', i === yTicks ? '0.45' : '0.25');
@@ -163,13 +266,13 @@
         line.setAttribute('x1', String(xx));
         line.setAttribute('x2', String(xx));
         line.setAttribute('y1', String(pad.top));
-        line.setAttribute('y2', String(h - pad.bottom));
+        line.setAttribute('y2', String(height - pad.bottom));
         line.setAttribute('opacity', '0.22');
         grid.appendChild(line);
 
         const label = mk('text');
         label.setAttribute('x', String(xx));
-        label.setAttribute('y', String(h - pad.bottom + 20));
+        label.setAttribute('y', String(height - pad.bottom + 20));
         label.setAttribute('text-anchor', 'middle');
         label.setAttribute('fill', '#6f8099');
         label.setAttribute('font-size', '11');
@@ -180,7 +283,7 @@
       svg.appendChild(grid);
 
       const axis = mk('path');
-      axis.setAttribute('d', `M ${pad.left} ${pad.top} V ${h - pad.bottom} H ${w - pad.right}`);
+      axis.setAttribute('d', `M ${pad.left} ${pad.top} V ${height - pad.bottom} H ${width - pad.right}`);
       axis.setAttribute('stroke', 'rgba(255,255,255,.35)');
       axis.setAttribute('fill', 'none');
       axis.setAttribute('stroke-width', '1.2');
@@ -193,7 +296,7 @@
       const crosshair = mk('line');
       crosshair.classList.add('chart-crosshair');
       crosshair.setAttribute('y1', String(pad.top));
-      crosshair.setAttribute('y2', String(h - pad.bottom));
+      crosshair.setAttribute('y2', String(height - pad.bottom));
       crosshair.setAttribute('x1', String(pad.left));
       crosshair.setAttribute('x2', String(pad.left));
       crosshair.setAttribute('opacity', '0');
@@ -283,26 +386,54 @@
         markerGroup.appendChild(marker);
 
         const plot = { meta: entry.meta, color: stroke, points: pts, marker };
+        pts.forEach(p => {
+          p.plot = plot;
+          p.hoverKey = String(p.timeMs);
+        });
         plots.push(plot);
       });
 
       state.plots = plots;
-      state.flat = plots.flatMap(plot => plot.points.map(pt => ({ ...pt, plot })));
+      state.flat = plots.flatMap(plot => plot.points);
+      state.flatSorted = state.flat.slice().sort((a, b) => a.x - b.x);
 
       if (!plots.length) return;
 
       plots.forEach(plot => {
-        const pill = document.createElement('span');
-        pill.className = 'pill';
-        pill.style.background = plot.color;
-        pill.textContent = plot.meta.model || 'Unknown';
-        legend.appendChild(pill);
+        const item = document.createElement('div');
+        item.className = 'chart-legend__item';
+        item.style.setProperty('--legend-color', plot.color);
+
+        const swatch = document.createElement('span');
+        swatch.className = 'chart-legend__swatch';
+        item.appendChild(swatch);
+
+        const label = document.createElement('div');
+        label.className = 'chart-legend__label';
+        const iconEl = createIconElement(plot.meta.iconMarkup);
+        if (iconEl) label.appendChild(iconEl);
+
+        const textWrap = document.createElement('div');
+        textWrap.className = 'chart-legend__text';
+        const modelEl = document.createElement('span');
+        modelEl.className = 'chart-legend__model';
+        modelEl.textContent = plot.meta.model || 'Unknown';
+        const companyEl = document.createElement('span');
+        companyEl.className = 'chart-legend__company';
+        companyEl.textContent = canonicalCompany(plot.meta.company);
+        textWrap.appendChild(modelEl);
+        textWrap.appendChild(companyEl);
+
+        label.appendChild(textWrap);
+        item.appendChild(label);
+        legend.appendChild(item);
       });
 
       function hideHover() {
         tooltip.classList.remove('visible');
         crosshair.setAttribute('opacity', '0');
         plots.forEach(plot => (plot.marker.style.display = 'none'));
+        state.lastHoverKey = null;
       }
 
       function showAtPoint(point) {
@@ -340,9 +471,24 @@
           bullet.style.background = pt.color;
           label.appendChild(bullet);
 
-          const text = document.createElement('span');
-          text.textContent = pt.meta.model || 'Unknown';
-          label.appendChild(text);
+          const textWrap = document.createElement('div');
+          textWrap.className = 'chart-tooltip__text';
+          const iconEl = createIconElement(pt.meta.iconMarkup);
+          if (iconEl) textWrap.appendChild(iconEl);
+
+          const names = document.createElement('div');
+          names.className = 'chart-tooltip__names';
+          const modelEl = document.createElement('span');
+          modelEl.className = 'chart-tooltip__model';
+          modelEl.textContent = pt.meta.model || 'Unknown';
+          const companyEl = document.createElement('span');
+          companyEl.className = 'chart-tooltip__company';
+          companyEl.textContent = canonicalCompany(pt.meta.company);
+          names.appendChild(modelEl);
+          names.appendChild(companyEl);
+          textWrap.appendChild(names);
+
+          label.appendChild(textWrap);
 
           const value = document.createElement('div');
           value.className = 'chart-tooltip__value';
@@ -354,10 +500,10 @@
         });
 
         const chartRect = chartWrap.getBoundingClientRect();
-        const relX = (point.x / w) * chartRect.width;
-        const relY = (point.y / h) * chartRect.height;
-        const clampedX = Math.min(Math.max(relX, 80), chartRect.width - 80);
-        const clampedY = Math.min(Math.max(relY, 90), chartRect.height - 16);
+        const relX = (point.x / width) * chartRect.width;
+        const relY = (point.y / height) * chartRect.height;
+        const clampedX = Math.min(Math.max(relX, 96), chartRect.width - 96);
+        const clampedY = Math.min(Math.max(relY, 90), chartRect.height - 24);
 
         tooltip.style.left = `${clampedX}px`;
         tooltip.style.top = `${clampedY}px`;
@@ -371,33 +517,136 @@
         pt.x = evt.clientX;
         pt.y = evt.clientY;
         const svgPoint = pt.matrixTransform(ctm.inverse());
-        if (svgPoint.x < pad.left || svgPoint.x > w - pad.right || svgPoint.y < pad.top || svgPoint.y > h - pad.bottom) {
+        if (svgPoint.x < pad.left || svgPoint.x > width - pad.right || svgPoint.y < pad.top || svgPoint.y > height - pad.bottom) {
           hideHover();
           return;
         }
-        if (!state.flat.length) {
+        if (!state.flatSorted.length) {
           hideHover();
           return;
+        }
+        const sorted = state.flatSorted;
+        let lo = 0;
+        let hi = sorted.length - 1;
+        while (lo < hi) {
+          const mid = Math.floor((lo + hi) / 2);
+          if (sorted[mid].x < svgPoint.x) {
+            lo = mid + 1;
+          } else {
+            hi = mid;
+          }
         }
         let best = null;
         let bestDist = Infinity;
-        state.flat.forEach(p => {
-          const dist = Math.abs(svgPoint.x - p.x);
+        const start = Math.max(0, lo - 6);
+        const end = Math.min(sorted.length - 1, lo + 6);
+        for (let i = start; i <= end; i++) {
+          const candidate = sorted[i];
+          const dx = svgPoint.x - candidate.x;
+          const dy = svgPoint.y - candidate.y;
+          const dist = Math.hypot(dx, dy);
           if (dist < bestDist) {
             bestDist = dist;
-            best = p;
+            best = candidate;
           }
-        });
+        }
         if (!best) {
           hideHover();
           return;
         }
+        const hoverKey = best.hoverKey || String(best.timeMs);
+        if (state.lastHoverKey === hoverKey) return;
+        state.lastHoverKey = hoverKey;
         showAtPoint(best);
       }
 
       svg.addEventListener('pointermove', handlePointer);
       svg.addEventListener('pointerdown', handlePointer);
+      svg.addEventListener('pointerenter', handlePointer);
       svg.addEventListener('pointerleave', hideHover);
+    }
+
+    function createFilterButton(key, label, iconMarkup) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'filter-chip';
+      btn.setAttribute('data-key', key);
+      const content = document.createElement('span');
+      content.className = 'filter-chip__content';
+      if (iconMarkup) {
+        const iconEl = createIconElement(iconMarkup);
+        if (iconEl) content.appendChild(iconEl);
+      } else {
+        const dot = document.createElement('span');
+        dot.className = 'filter-chip__dot';
+        content.appendChild(dot);
+      }
+      const textEl = document.createElement('span');
+      textEl.className = 'filter-chip__text';
+      textEl.textContent = label;
+      content.appendChild(textEl);
+      btn.appendChild(content);
+      return btn;
+    }
+
+    function updateFilterButtons() {
+      document.querySelectorAll('#companyFilters .filter-chip').forEach(btn => {
+        const key = btn.getAttribute('data-key');
+        const active = key === state.selectedCompany;
+        btn.classList.toggle('active', active);
+        btn.setAttribute('aria-pressed', active ? 'true' : 'false');
+      });
+    }
+
+    function renderCompanyFilters() {
+      const host = document.getElementById('companyFilters');
+      if (!host) return;
+      host.innerHTML = '';
+      host.appendChild(createFilterButton('all', 'All companies'));
+      state.companies.forEach(entry => {
+        host.appendChild(createFilterButton(entry.key, entry.label, entry.iconMarkup));
+      });
+      updateFilterButtons();
+    }
+
+    function applyFilters() {
+      const key = state.selectedCompany;
+      const filtered = key === 'all'
+        ? state.fullSeries
+        : state.fullSeries.filter(entry => entry.meta.companyKey === key);
+      const sorted = filtered.slice().sort((a, b) => {
+        const aLast = a.pts.length ? a.pts[a.pts.length - 1].elo : -Infinity;
+        const bLast = b.pts.length ? b.pts[b.pts.length - 1].elo : -Infinity;
+        return bLast - aLast;
+      });
+      draw(sorted);
+    }
+
+    function bindFilterEvents() {
+      const host = document.getElementById('companyFilters');
+      if (!host || host.dataset.bound === 'true') return;
+      host.addEventListener('click', evt => {
+        const btn = evt.target.closest('button.filter-chip');
+        if (!btn) return;
+        const key = btn.getAttribute('data-key');
+        if (!key || key === state.selectedCompany) return;
+        state.selectedCompany = key;
+        updateFilterButtons();
+        applyFilters();
+      });
+      host.dataset.bound = 'true';
+    }
+
+    function handleResize() {
+      clearTimeout(state.resizeTimer);
+      state.resizeTimer = setTimeout(() => {
+        if (state.currentSeries && state.currentSeries.length) {
+          draw(state.currentSeries);
+        } else {
+          draw(state.currentSeries || []);
+        }
+        state.lastHoverKey = null;
+      }, 150);
     }
 
     async function getJSON(url, fallback) {
@@ -423,17 +672,21 @@
         when: r.when,
         elo: r.elo
       }));
-      const grouped = groupByBot(rows).sort((a, b) => {
-        const aLast = a.pts.length ? a.pts[a.pts.length - 1].elo : -Infinity;
-        const bLast = b.pts.length ? b.pts[b.pts.length - 1].elo : -Infinity;
-        return bLast - aLast;
-      });
-      draw(grouped);
+      const grouped = groupByBot(rows);
+      state.fullSeries = grouped;
+      state.companies = buildCompanyIndex(grouped);
+      renderCompanyFilters();
+      bindFilterEvents();
+      if (!state.resizeBound) {
+        state.resizeBound = handleResize;
+        window.addEventListener('resize', state.resizeBound);
+      }
+      applyFilters();
     }
   </script>
 </head>
 <body>
-  <div class="wrap">
+  <div class="wrap wrap--wide">
     <div class="topnav">
       <div class="brand">AI Poker Lab</div>
       <nav style="display:flex; gap:8px; align-items:center">
@@ -446,20 +699,26 @@
       </nav>
     </div>
 
-    <div class="card">
-      <h1>Elo Over Time</h1>
-      <div class="muted">End-of-match Elo per bot across all duels.</div>
-    </div>
-
     <div class="card elo-card">
-      <div class="elo-chart">
-        <svg id="chart"></svg>
-        <div class="chart-tooltip">
-          <div class="chart-tooltip__time"></div>
-          <div class="chart-tooltip__series"></div>
+      <div class="elo-card__header">
+        <div>
+          <h1>Elo Over Time</h1>
+          <div class="muted">End-of-match Elo per bot across all duels.</div>
+        </div>
+        <div class="elo-card__filters">
+          <div id="companyFilters" class="filter-chips"></div>
         </div>
       </div>
-      <div id="legend" class="chart-legend"></div>
+      <div class="elo-card__body">
+        <div class="elo-chart">
+          <svg id="chart"></svg>
+          <div class="chart-tooltip">
+            <div class="chart-tooltip__time"></div>
+            <div class="chart-tooltip__series"></div>
+          </div>
+        </div>
+        <div id="legend" class="chart-legend"></div>
+      </div>
     </div>
   </div>
 </body>

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -18,6 +18,11 @@
 
     const $   = s => document.querySelector(s);
     const fmt = n => Number(n||0).toLocaleString();
+    const escapeHtml = (s = '') => s.replace(/[&<>"']/g, ch => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[ch]));
+    const canonicalCompany = (company) => {
+      const trimmed = (company || 'OpenAI').trim();
+      return trimmed || 'OpenAI';
+    };
     const dateFmt = (iso) => {
       const d = new Date(iso);
       return d.toLocaleString([], { year:'numeric', month:'short', day:'2-digit', hour:'2-digit', minute:'2-digit' });
@@ -78,37 +83,42 @@
       return { hasData: true, display: `${pct}% (${good}/${total})`, ratio, good, total };
     }
 
-    function openaiIcon(){
-      return `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.311.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg>`;
+        function openaiIcon(){
+      return `<svg class="org-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M14.949 6.547a3.94 3.94 0 0 0-.348-3.273 4.11 4.11 0 0 0-4.4-1.934A4.1 4.1 0 0 0 8.423.2 4.15 4.15 0 0 0 6.305.086a4.1 4.1 0 0 0-1.891.948 4.04 4.04 0 0 0-1.158 1.753 4.1 4.1 0 0 0-1.563.679A4 4 0 0 0 .554 4.72a3.99 3.99 0 0 0 .502 4.731 3.94 3.94 0 0 0 .346 3.274 4.11 4.11 0 0 0 4.402 1.933c.382.425.852.764 1.377.995.526.231 1.095.35 1.67.346 1.78.002 3.358-1.132 3.901-2.804a4.1 4.1 0 0 0 1.563-.68 4 4 0 0 0 1.14-1.253 3.99 3.99 0 0 0-.506-4.716m-6.097 8.406a3.05 3.05 0 0 1-1.945-.694l.096-.054 3.23-1.838a.53.53 0 0 0 .265-.455v-4.49l1.366.778q.02.011.025.035v3.722c-.003 1.653-1.361 2.992-3.037 2.996m-6.53-2.75a2.95 2.95 0 0 1-.36-2.01l.095.057L5.29 12.09a.53.53 0 0 0 .527 0l3.949-2.246v1.555a.05.05 0 0 1-.022.041L6.473 13.3c-1.454.826-3.31 1.335-4.15-1.098m-.85-6.94A3.02 3.02 0 0 1 3.07 3.949v3.785a.51.51 0 0 0 .262.451l3.93 2.237-1.366.779a.05.05 0 0 1-.048 0L2.585 9.342a2.98 2.98 0 0 1-1.113-4.094zm11.216 2.571L8.747 5.576l1.362-.776a.05.05 0 0 1 .048 0l3.265 1.86a3 3 0 0 1 1.173 1.207 2.96 2.96 0 0 1-.27 3.2 3.05 3.05 0 0 1-1.36.997V8.279a.52.52 0 0 0-.276-.445m1.36-2.015-.097-.057-3.226-1.855a.53.53 0 0 0-.53 0L6.249 6.153V4.598a.04.04 0 0 1 .019-.04L9.533 2.7a3.07 3.07 0 0 1 3.257.139c.474.325.843.778 1.066 1.303.223.526.289 1.103.191 1.664zM5.503 8.575 4.139 7.8a.05.05 0 0 1-.026-.037V4.049c0-.57.166-1.127.476-1.607s.752-.864 1.275-1.105a3.08 3.08 0 0 1 3.234.41l-.096.054-3.23 1.838a.53.53 0 0 0-.265.455zm.742-1.577 1.758-1 1.762 1v2l-1.755 1-1.762-1z"/></svg>`;
     }
 
-    function orgCell(company){
-      const c = (company||'OpenAI').trim();
-      return `<span class="lb-org"><span class="txt">${c}</span></span>`;
+    function companyIconMarkup(company, model){
+      const c = (company||'').trim().toLowerCase();
+      const m = (model||'').trim().toLowerCase();
+      if (!c || c === 'openai') return openaiIcon();
+      const inc = (s)=> c.includes(s) || m.startsWith(s+'/') || m.includes('/'+s);
+      if (inc('deepseek')) return '<img class="org-icon" src="/web/img/deepseek-color.svg" alt="DeepSeek"/>';
+      if (inc('xai') || inc('grok')) return '<img class="org-icon" src="/web/img/xai.svg" alt="xAI"/>';
+      if (inc('anthropic')) return '<img class="org-icon" src="/web/img/anthropic.svg" alt="Anthropic"/>';
+      if (inc('meta') || inc('llama')) return '<img class="org-icon" src="/web/img/meta.svg" alt="Meta"/>';
+      if (inc('google') || inc('gemini')) return '<img class="org-icon" src="/web/img/google.svg" alt="Google"/>';
+      if (inc('mistral')) return '<img class="org-icon" src="/web/img/mistral.svg" alt="Mistral"/>';
+      if (inc('groq')) return '<img class="org-icon" src="/web/img/groq.svg" alt="Groq"/>';
+      if (inc('together')) return '<img class="org-icon" src="/web/img/together.svg" alt="Together"/>';
+      if (inc('perplexity')) return '<img class="org-icon" src="/web/img/perplexity.svg" alt="Perplexity"/>';
+      if (inc('azure')) return '<img class="org-icon" src="/web/img/azure.svg" alt="Azure"/>';
+      if (inc('openrouter')) return '<img class="org-icon" src="/web/img/openrouter.svg" alt="OpenRouter"/>';
+      if (inc('cohere')) return '<img class="org-icon" src="/web/img/cohere.svg" alt="Cohere"/>';
+      if (inc('fireworks')) return '<img class="org-icon" src="/web/img/fireworks.svg" alt="Fireworks"/>';
+      return '<span class="org-icon org-icon--dot" aria-hidden="true"></span>';
+    }
+
+    function orgCell(company, model){
+      const label = escapeHtml(canonicalCompany(company));
+      const icon = companyIconMarkup(company, model);
+      return `<span class="lb-org">${icon}<span class="txt">${label}</span></span>`;
     }
 
     function modelIcon(company, model){
-      const c = (company||'').trim().toLowerCase();
-      const m = (model||'').trim().toLowerCase();
-      if (c === 'openai' || c === '') return openaiIcon();
-      const inc = (s)=> c.includes(s) || m.startsWith(s+'/') || m.includes('/'+s);
-      if (inc('deepseek')) return '<img class="icon" src="/web/img/deepseek-color.svg" alt="DeepSeek"/>';
-      if (inc('xai') || inc('grok')) return '<img class="icon" src="/web/img/xai.svg" alt="xAI"/>';
-      if (inc('anthropic')) return '<img class="icon" src="/web/img/anthropic.svg" alt="Anthropic"/>';
-      if (inc('meta') || inc('llama')) return '<img class="icon" src="/web/img/meta.svg" alt="Meta"/>';
-      if (inc('google') || inc('gemini')) return '<img class="icon" src="/web/img/google.svg" alt="Google"/>';
-      if (inc('mistral')) return '<img class="icon" src="/web/img/mistral.svg" alt="Mistral"/>';
-      if (inc('groq')) return '<img class="icon" src="/web/img/groq.svg" alt="Groq"/>';
-      if (inc('together')) return '<img class="icon" src="/web/img/together.svg" alt="Together"/>';
-      if (inc('perplexity')) return '<img class="icon" src="/web/img/perplexity.svg" alt="Perplexity"/>';
-      if (inc('azure')) return '<img class="icon" src="/web/img/azure.svg" alt="Azure"/>';
-      if (inc('openrouter')) return '<img class="icon" src="/web/img/openrouter.svg" alt="OpenRouter"/>';
-      if (inc('cohere')) return '<img class="icon" src="/web/img/cohere.svg" alt="Cohere"/>';
-      if (inc('fireworks')) return '<img class="icon" src="/web/img/fireworks.svg" alt="Fireworks"/>';
-      return '<span class="lb-dot" aria-hidden="true"></span>';
+      return companyIconMarkup(company, model);
     }
 
-    function rowHTML(i, r){
+function rowHTML(i, r){
       const full  = trim1(r.model||'');
       const short = trimModelName(full);
       const title = full.replace(/"/g,'&quot;');
@@ -126,7 +136,7 @@
           </div>
         </td>
         <td class="num">${Number(r.elo||0).toFixed(1)}</td>
-        <td>${orgCell(r.company)}</td>
+        <td>${orgCell(r.company, r.model)}</td>
         <td class="num">${fmt(hands)}</td>
         <td class="num">${Math.max(0,Math.min(100, Number(r.win_rate_pct||0)))}%<span class="sub">${ciTxt}</span></td>
         <td class="num">${judge.hasData ? judge.display : 'n/a'}</td>
@@ -269,7 +279,7 @@
   </script>
 </head>
 <body>
-  <div class="wrap">
+  <div class="wrap wrap--wide">
     <div class="topnav">
       <div class="brand">AI Poker Lab</div>
       <nav style="display:flex; gap:8px; align-items:center">
@@ -282,41 +292,44 @@
       </nav>
     </div>
 
-    <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
-      <div>
-        <h1>Leaderboard</h1>
-        <div class="muted">Elo with career hands, win%, and net chips.</div>
+    <div class="card lb-card">
+      <div class="lb-card__header">
+        <div>
+          <h1>Leaderboard</h1>
+          <div class="muted">Elo with career hands, win%, and net chips.</div>
+        </div>
       </div>
-    </div>
-
-    <div class="card lb-wrap">
-      <table class="lb-table">
-        <colgroup>
-          <col style="width:56px" />
-          <col style="width:260px" />
-          <col style="width:110px" />
-          <col style="width:120px" />
-          <col style="width:120px" />
-          <col style="width:160px" />
-          <col style="width:120px" />
-          <col style="width:130px" />
-          <col style="width:220px" />
-        </colgroup>
-        <thead>
-          <tr>
-            <th class="num">#</th>
-            <th>Model</th>
-            <th class="num sortable" data-sort="elo" title="Sort by Elo">Elo</th>
-            <th>Org</th>
-            <th class="num sortable" data-sort="hands" title="Sort by Hands">Hands</th>
-            <th class="num sortable" data-sort="win" title="Sort by Win %">Win%</th>
-            <th class="num sortable" data-sort="acc" title="Sort by Judge Accuracy">Acc</th>
-            <th class="num sortable" data-sort="net" title="Sort by Net">Net</th>
-            <th class="sortable" data-sort="updated" title="Sort by Updated">Updated</th>
-          </tr>
-        </thead>
-        <tbody id="tbody"><tr><td colspan="9">Loading...</td></tr></tbody>
-      </table>
+      <div class="lb-card__body">
+        <div class="lb-table-wrap">
+          <table class="lb-table">
+            <colgroup>
+              <col style="width:56px" />
+              <col style="width:260px" />
+              <col style="width:110px" />
+              <col style="width:120px" />
+              <col style="width:120px" />
+              <col style="width:160px" />
+              <col style="width:120px" />
+              <col style="width:130px" />
+              <col style="width:220px" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th class="num">#</th>
+                <th>Model</th>
+                <th class="num sortable" data-sort="elo" title="Sort by Elo">Elo</th>
+                <th>Org</th>
+                <th class="num sortable" data-sort="hands" title="Sort by Hands">Hands</th>
+                <th class="num sortable" data-sort="win" title="Sort by Win %">Win%</th>
+                <th class="num sortable" data-sort="acc" title="Sort by Judge Accuracy">Acc</th>
+                <th class="num sortable" data-sort="net" title="Sort by Net">Net</th>
+                <th class="sortable" data-sort="updated" title="Sort by Updated">Updated</th>
+              </tr>
+            </thead>
+            <tbody id="tbody"><tr><td colspan="9">Loading...</td></tr></tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- Widen the leaderboard container, restyle its card/table shell, and render organization icons beside both model names and the Org column
- Refresh the Elo page layout with the wide wrapper, redesigned card/legend styles, and company filter chips that show vendor icons
- Refactor the Elo chart logic to support company filtering, faster hover detection with cached keys, and responsive redraws on resize

## Testing
- `go test ./...` *(fails: hangs while downloading modules in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8d1ea1a8832dab52639743a05a07