### PR TITLE
Refine Elo chart tooltip layout

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -1119,7 +1119,7 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
     linear-gradient(180deg, rgba(8, 18, 32, .95), rgba(8, 14, 26, .92));
   border: 1px solid rgba(118, 177, 255, .3);
   padding: 32px;
-  overflow: hidden;
+  overflow: visible;
 }
 .elo-chart svg {
   width: 100%;
@@ -1143,15 +1143,15 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
 }
 .chart-tooltip {
   position: absolute;
-  min-width: 220px;
-  border-radius: 16px;
-  padding: 16px 18px;
+  min-width: 180px;
+  border-radius: 14px;
+  padding: 12px 14px;
   background: linear-gradient(180deg, rgba(10,18,28,.95), rgba(14,26,42,.94));
-  border: 1px solid rgba(132, 196, 255, .32);
-  box-shadow: 0 22px 38px rgba(0,0,0,.45);
+  border: 1px solid rgba(132, 196, 255, .28);
+  box-shadow: 0 18px 32px rgba(0,0,0,.42);
   color: #f5fbff;
   pointer-events: none;
-  transform: translate(-50%, calc(-100% - 18px));
+  transform: translate(-50%, calc(-100% - 12px));
   opacity: 0;
   visibility: hidden;
   transition: opacity .18s var(--ease-2), visibility .18s var(--ease-2);
@@ -1163,58 +1163,72 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
 }
 .chart-tooltip__time {
   font-weight: 700;
-  letter-spacing: .35px;
-  margin-bottom: 8px;
+  letter-spacing: .45px;
+  margin-bottom: 6px;
+  font-size: .78rem;
+  text-transform: uppercase;
+  color: rgba(230, 244, 255, .75);
 }
 .chart-tooltip__series {
   display: grid;
-  gap: 8px;
+  gap: 6px;
 }
 .chart-tooltip__row {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
-  font-size: 0.92rem;
+  gap: 12px;
+  font-size: 0.88rem;
 }
 .chart-tooltip__label {
   display: inline-flex;
-  align-items: flex-start;
-  gap: 10px;
-  color: rgba(230, 244, 255, .86);
-  min-width: 0;
-}
-.chart-tooltip__text {
-  display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
-  min-width: 0;
-}
-.chart-tooltip__names {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  line-height: 1.2;
+  color: rgba(230, 244, 255, .88);
   min-width: 0;
 }
 .chart-tooltip__model {
-  font-weight: 700;
+  font-weight: 600;
   white-space: nowrap;
-}
-.chart-tooltip__company {
-  font-size: .7rem;
-  text-transform: uppercase;
-  letter-spacing: .35px;
-  color: rgba(230, 244, 255, .65);
+  letter-spacing: .25px;
 }
 .chart-tooltip__value {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  min-width: 0;
   font-variant-numeric: tabular-nums;
-  font-weight: 600;
+}
+.chart-tooltip__elo {
+  font-weight: 700;
+  font-size: .95rem;
+  letter-spacing: .3px;
   color: #ffffff;
 }
+.chart-tooltip__delta {
+  font-size: .7rem;
+  font-weight: 600;
+  letter-spacing: .32px;
+  text-transform: uppercase;
+  color: rgba(230, 244, 255, .68);
+}
+.chart-tooltip__delta::before {
+  content: 'Δ ';
+  opacity: .78;
+}
+.chart-tooltip__delta.positive {
+  color: #7dffb8;
+}
+.chart-tooltip__delta.negative {
+  color: #ff9b9b;
+}
+.chart-tooltip__delta.neutral {
+  color: rgba(230, 244, 255, .68);
+}
 .chart-bullet {
-  width: 10px;
-  height: 10px;
+  width: 8px;
+  height: 8px;
   border-radius: 999px;
   box-shadow: 0 0 0 2px rgba(0,0,0,.35);
   flex-shrink: 0;

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -326,15 +326,20 @@
         const group = mk('g');
         svg.appendChild(group);
 
-        const pts = entry.pts.map(pt => ({
-          time: pt.t,
-          timeMs: pt.t.getTime(),
-          elo: pt.elo,
-          x: x(pt.t.getTime()),
-          y: y(pt.elo),
-          meta: entry.meta,
-          color: stroke
-        }));
+        const pts = entry.pts.map((pt, idx) => {
+          const prev = idx > 0 ? entry.pts[idx - 1] : null;
+          const delta = prev ? pt.elo - prev.elo : null;
+          return {
+            time: pt.t,
+            timeMs: pt.t.getTime(),
+            elo: pt.elo,
+            delta,
+            x: x(pt.t.getTime()),
+            y: y(pt.elo),
+            meta: entry.meta,
+            color: stroke
+          };
+        });
 
         const pathData = pts.map((pt, idx) => `${idx === 0 ? 'M' : 'L'} ${pt.x} ${pt.y}`).join(' ');
         const glow = mk('path');
@@ -471,28 +476,36 @@
           bullet.style.background = pt.color;
           label.appendChild(bullet);
 
-          const textWrap = document.createElement('div');
-          textWrap.className = 'chart-tooltip__text';
-          const iconEl = createIconElement(pt.meta.iconMarkup);
-          if (iconEl) textWrap.appendChild(iconEl);
-
-          const names = document.createElement('div');
-          names.className = 'chart-tooltip__names';
           const modelEl = document.createElement('span');
           modelEl.className = 'chart-tooltip__model';
           modelEl.textContent = pt.meta.model || 'Unknown';
-          const companyEl = document.createElement('span');
-          companyEl.className = 'chart-tooltip__company';
-          companyEl.textContent = canonicalCompany(pt.meta.company);
-          names.appendChild(modelEl);
-          names.appendChild(companyEl);
-          textWrap.appendChild(names);
-
-          label.appendChild(textWrap);
+          label.appendChild(modelEl);
 
           const value = document.createElement('div');
           value.className = 'chart-tooltip__value';
-          value.textContent = Math.round(pt.elo).toString();
+          const eloEl = document.createElement('span');
+          eloEl.className = 'chart-tooltip__elo';
+          eloEl.textContent = Math.round(pt.elo).toString();
+          value.appendChild(eloEl);
+
+          const deltaEl = document.createElement('span');
+          deltaEl.className = 'chart-tooltip__delta';
+          if (Number.isFinite(pt.delta)) {
+            const roundedDelta = Math.round(pt.delta);
+            const sign = roundedDelta > 0 ? '+' : '';
+            deltaEl.textContent = `${sign}${roundedDelta}`;
+            if (roundedDelta > 0) {
+              deltaEl.classList.add('positive');
+            } else if (roundedDelta < 0) {
+              deltaEl.classList.add('negative');
+            } else {
+              deltaEl.classList.add('neutral');
+            }
+          } else {
+            deltaEl.textContent = '–';
+            deltaEl.classList.add('neutral');
+          }
+          value.appendChild(deltaEl);
 
           row.appendChild(label);
           row.appendChild(value);
@@ -502,8 +515,8 @@
         const chartRect = chartWrap.getBoundingClientRect();
         const relX = (point.x / width) * chartRect.width;
         const relY = (point.y / height) * chartRect.height;
-        const clampedX = Math.min(Math.max(relX, 96), chartRect.width - 96);
-        const clampedY = Math.min(Math.max(relY, 90), chartRect.height - 24);
+        const clampedX = Math.min(Math.max(relX, 72), chartRect.width - 72);
+        const clampedY = Math.min(Math.max(relY, 78), chartRect.height - 18);
 
         tooltip.style.left = `${clampedX}px`;
         tooltip.style.top = `${clampedY}px`;


### PR DESCRIPTION
## Summary
- shrink the Elo chart tooltip and allow it to sit outside the chart bounds without being clipped
- simplify the tooltip content to only show the model name plus Elo and change from the previous point
- add styling for Elo/delta values with sign-aware coloring so the hover state is easier to parse

## Testing
- no automated tests were run (static front-end change)


------
https://chatgpt.com/codex/tasks/task_e_68cc0a557bc8832d9ca831592f579357