### PR TITLE
Fix judge accuracy persistence and expose via API

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -2036,10 +2036,10 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 				if accMap, err := db.MatchJudgeAccuracy(context.Background(), matchID); err != nil {
 					log.Printf("MatchJudgeAccuracy failed for match %d: %v", matchID, err)
 				} else {
-					if acc, ok := accMap["A"]; ok {
+					if acc, ok := accMap[botAID]; ok {
 						judgeGoodA, judgeTotalA = acc.Good, acc.Total
 					}
-					if acc, ok := accMap["B"]; ok {
+					if acc, ok := accMap[botBID]; ok {
 						judgeGoodB, judgeTotalB = acc.Good, acc.Total
 					}
 				}
@@ -2052,6 +2052,9 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 		}
 		if err := db.UpdateBotRatings(context.Background(), botBID, elo.B, gB.Rating, gB.RD, gB.Volatility, 1, handsB, judgeGoodB, judgeTotalB); err != nil {
 			log.Printf("UpdateBotRatings(B) failed: %v", err)
+		}
+		if err := db.SyncJudgeAccuracy(context.Background(), botAID, botBID); err != nil {
+			log.Printf("SyncJudgeAccuracy failed: %v", err)
 		}
 
 		if err := db.CompleteMatch(context.Background(), matchID); err != nil {


### PR DESCRIPTION
## Summary
- persist Monte-Carlo judge accuracy counts per bot using bot IDs
- refresh stored judge accuracy totals from aggregated evaluations after each match
- surface judge accuracy data consistently in leaderboard and API responses

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc0ab3e828832d9964cee533f27cac