### PR TITLE
Restyle navigation logo and rebuild site footer

### DIFF
--- a/server/web/about.html
+++ b/server/web/about.html
@@ -18,10 +18,13 @@
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -32,8 +35,11 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <section class="card about-hero">
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <section class="card about-hero">
       <div>
         <div class="about-hero__eyebrow">About PokerBench</div>
         <h1>Deterministic evaluation for heads-up LLM poker agents</h1>
@@ -57,9 +63,9 @@
           <div class="about-metric__caption">Post-match rollouts estimate EV accuracy so prompt regressions surface immediately.</div>
         </div>
       </div>
-    </section>
+      </section>
 
-    <section class="card about-section">
+      <section class="card about-section">
       <h2>Scientific pillars</h2>
       <p class="muted">Every capability is designed to be audited, replayed, and repeated without hidden randomness.</p>
       <ul class="about-list">
@@ -69,9 +75,9 @@
         <li><strong>Telemetry-first logging.</strong> Structured action logs, stack snapshots, and board states back the Replay, History, and analytics views.</li>
         <li><strong>Provider agnostic.</strong> Any OpenAI-compatible endpoint (OpenAI, Azure, OpenRouter, Together, Groq, &hellip;) can be slotted in.</li>
       </ul>
-    </section>
+      </section>
 
-    <section class="card about-section">
+      <section class="card about-section">
       <h2>System architecture at a glance</h2>
       <p class="muted">A lean Go stack keeps the benchmark predictable and inspectable.</p>
       <div class="about-grid about-grid--columns">
@@ -96,9 +102,9 @@
           <p class="muted">Normalized tables (<code>matches</code>, <code>action_logs</code>, <code>bot_ratings</code>, &hellip;) persist every hand, rating, and telemetry stream.</p>
         </article>
       </div>
-    </section>
+      </section>
 
-    <section class="card about-section">
+      <section class="card about-section">
       <h2>Experimental modes</h2>
       <div class="about-grid about-grid--columns">
         <article class="about-block">
@@ -174,18 +180,48 @@
         <li><strong>Security awareness.</strong> Secrets stay in <code>secrets/</code>, and the stack is ship-ready via Docker or local binaries.</li>
         <li><strong>Open science.</strong> Released under AGPL-3.0-or-later with transparent schemas, logs, and UI so results can be audited end-to-end.</li>
       </ul>
-    </section>
-  </div>
+      </section>
+    </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -96,6 +96,12 @@ html, body {
   background-attachment: fixed;
   font: var(--fs-2)/1.6 var(--font-sans);
   overflow-x: hidden;
+  min-height: 100%;
+}
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 body::before {
   content: "";
@@ -129,6 +135,16 @@ img, svg, video, canvas, audio, iframe, embed, object { display: block; }
 a, a:visited { color: inherit; text-decoration: none; }
 button, input, select, textarea { font: inherit; color: inherit; }
 :focus-visible { outline: none; box-shadow: var(--ring); border-color: transparent; }
+
+.page-content {
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+.page-content > .wrap,
+.page-content > .wrap--wide {
+  flex: 1 0 auto;
+}
 
 .muted { color: var(--muted); }
 .mono  { font-family: var(--font-mono); }
@@ -374,34 +390,63 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 .footer { color: var(--muted); font-size: var(--fs-1); text-align: center; padding: 8px; }
 
 /* 4) Top Navigation --------------------------------------------------- */
-.topnav {
-  position: sticky; top: 0; left: 0; right: 0; z-index: 40;
-  display: flex; align-items: center; justify-content: space-between; gap: 12px;
-  padding: 12px 16px;
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
   border-bottom: 1px solid var(--border);
   background: linear-gradient(180deg, rgba(26,26,46,.94), rgba(22,33,62,.94));
   backdrop-filter: blur(6px);
   box-shadow: 0 6px 12px rgba(0,0,0,.35);
 }
+.topnav {
+  width: min(1920px, calc(100vw - 56px));
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 12px 0;
+}
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   font-weight: 900;
   letter-spacing: .2px;
   color: var(--text);
   text-decoration: none;
 }
-.brand img {
-  height: 44px;
-  width: auto;
-  display: block;
+.brand__mark {
+  width: clamp(64px, 4.5vw, 72px);
+  height: clamp(64px, 4.5vw, 72px);
+  border-radius: 20px;
+  padding: 6px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, rgba(135, 206, 235, .28), rgba(45, 90, 160, .36));
+  box-shadow:
+    inset 0 0 0 1px rgba(255,255,255,.12),
+    0 8px 20px rgba(0,0,0,.45);
+}
+.brand__mark img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 14px rgba(0,0,0,.35));
 }
 .brand__text {
-  font-size: var(--fs-4);
+  font-size: clamp(1.25rem, 1.1rem + .6vw, 1.6rem);
+  letter-spacing: .04em;
   text-transform: none;
 }
-.topnav nav { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; justify-content: flex-end; }
+.topnav nav {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
 .topnav a {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 8px 12px; border: 1px solid transparent; border-radius: 6px; color: var(--text);
@@ -597,62 +642,204 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 .btn.secondary { background: linear-gradient(90deg, var(--slate-7), var(--slate-8)); color: var(--slate-12); }
 .btn.danger { background: linear-gradient(90deg, var(--err-9), hsl(345 85% 56%)); color: #fff; }
 
-/* 6) Footer ---------------------------------------------------------- */
 .site-footer {
+  margin-top: auto;
+  position: relative;
   border-top: 1px solid rgba(255,255,255,.08);
-  background: linear-gradient(180deg, rgba(9, 14, 24, .94), rgba(7, 10, 18, .96));
-  padding: 32px 16px 40px;
+  background: linear-gradient(180deg, rgba(9, 14, 24, .96), rgba(7, 10, 18, .98));
+  padding: 52px 0 36px;
+  overflow: hidden;
 }
-.site-footer__inner {
-  width: min(1200px, calc(100vw - 48px));
+.site-footer::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(540px 280px at 12% 24%, rgba(135, 206, 235, .18), transparent 70%),
+    radial-gradient(520px 260px at 88% 18%, rgba(255, 107, 53, .16), transparent 68%);
+  opacity: .75;
+  pointer-events: none;
+}
+.site-footer__shell {
+  position: relative;
+  width: min(1280px, calc(100vw - 64px));
   margin: 0 auto;
   display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-  align-items: center;
-  justify-content: space-between;
-  color: color-mix(in oklab, var(--muted) 80%, white 6%);
+  flex-direction: column;
+  gap: 36px;
+  color: color-mix(in oklab, var(--muted) 82%, white 8%);
   font-size: var(--fs-1);
 }
+.site-footer__top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px 36px;
+  align-items: center;
+  justify-content: space-between;
+}
 .site-footer__brand {
+  display: grid;
+  gap: 12px;
+  max-width: min(480px, 100%);
+}
+.site-footer__logo {
+  display: inline-flex;
+  align-items: center;
+  filter: drop-shadow(0 10px 24px rgba(0,0,0,.45));
+}
+.site-footer__logo img {
+  height: clamp(52px, 5vw, 64px);
+  width: auto;
+}
+.site-footer__tagline {
+  margin: 0;
+  font-size: var(--fs-2);
+  line-height: 1.5;
+  color: color-mix(in oklab, var(--muted) 78%, white 12%);
+}
+.site-footer__cta {
+  display: grid;
+  gap: 12px;
+  text-align: right;
+}
+.site-footer__cta-label {
+  text-transform: uppercase;
+  letter-spacing: .4em;
+  font-size: .72rem;
+  color: color-mix(in oklab, var(--muted) 60%, white 8%);
+}
+.site-footer__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.site-footer__button {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  color: inherit;
+  padding: 10px 18px;
+  border-radius: 999px;
   font-weight: 700;
-  letter-spacing: .12em;
-  text-transform: uppercase;
+  letter-spacing: .02em;
+  transition: transform var(--dur-2) var(--ease-2), box-shadow var(--dur-2) var(--ease-2), background var(--dur-2) var(--ease-2);
+  background: linear-gradient(120deg, rgba(135, 206, 235, .85), rgba(45, 90, 160, .95));
+  color: #0a1020;
+  border: 1px solid rgba(255,255,255,.15);
+  box-shadow: 0 14px 30px rgba(36, 72, 128, .35);
 }
-.site-footer__brand img {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  box-shadow: 0 0 0 1px rgba(255,255,255,.08);
+.site-footer__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px rgba(36, 72, 128, .4);
+}
+.site-footer__button--outline {
+  background: transparent;
+  color: color-mix(in oklab, var(--muted) 92%, white 20%);
+  border-color: rgba(135, 206, 235, .4);
+  box-shadow: 0 10px 24px rgba(0,0,0,.32);
+}
+.site-footer__button--outline:hover {
+  background: rgba(135, 206, 235, .12);
 }
 .site-footer__links {
-  display: inline-flex;
-  gap: 16px;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 24px;
 }
-.site-footer__links a {
+.site-footer__column {
+  display: grid;
+  gap: 10px;
+}
+.site-footer__heading {
+  font-size: .78rem;
+  text-transform: uppercase;
+  letter-spacing: .36em;
+  color: color-mix(in oklab, var(--muted) 68%, white 12%);
+  font-weight: 800;
+}
+.site-footer__link {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  color: color-mix(in oklab, var(--muted) 96%, white 18%);
   font-weight: 600;
-  color: color-mix(in oklab, var(--muted) 90%, white 12%);
-  transition: color var(--dur-2) var(--ease-2);
+  transition: color var(--dur-2) var(--ease-2), transform var(--dur-2) var(--ease-2);
 }
-.site-footer__links a:hover {
+.site-footer__link::after {
+  content: "→";
+  font-size: .85em;
+  opacity: 0;
+  transform: translateX(-6px);
+  transition: opacity var(--dur-2) var(--ease-2), transform var(--dur-2) var(--ease-2);
+}
+.site-footer__link:hover {
+  color: white;
+  transform: translateX(2px);
+}
+.site-footer__link:hover::after {
+  opacity: 1;
+  transform: translateX(0);
+}
+.site-footer__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 24px;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 24px;
+  border-top: 1px solid rgba(255,255,255,.08);
+  color: color-mix(in oklab, var(--muted) 70%, white 10%);
+}
+.site-footer__copy {
+  margin: 0;
+  font-size: calc(var(--fs-1) * .95);
+}
+.site-footer__credit {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+.site-footer__credit a {
+  font-weight: 700;
+  color: color-mix(in oklab, var(--muted) 95%, white 20%);
+}
+.site-footer__credit a:hover {
   color: white;
 }
 
-@media (max-width: 600px) {
-  .site-footer__inner {
-    justify-content: center;
-    text-align: center;
+@media (max-width: 1024px) {
+  .topnav {
+    width: min(100%, calc(100vw - 40px));
+    padding: 12px 0;
   }
-  .site-footer__links {
+}
+@media (max-width: 720px) {
+  .topnav {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 16px;
+  }
+  .topnav nav {
     justify-content: center;
+  }
+  .site-footer {
+    padding: 48px 0 32px;
+  }
+  .site-footer__shell {
+    width: min(100%, calc(100vw - 40px));
+    gap: 28px;
+  }
+  .site-footer__top {
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+  }
+  .site-footer__cta {
+    text-align: left;
+    width: 100%;
+  }
+  .site-footer__actions {
+    justify-content: flex-start;
   }
 }
 .btn.warn   { background: linear-gradient(90deg, var(--warn-9), hsl(32 94% 58%)); color: #1d1200; }

--- a/server/web/bot.html
+++ b/server/web/bot.html
@@ -222,10 +222,13 @@
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -236,57 +239,90 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
-      <div>
-        <h1 id="title">Bot</h1>
-        <div id="sub" class="muted"></div>
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
+        <div>
+          <h1 id="title">Bot</h1>
+          <div id="sub" class="muted"></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="kvs" id="meta"></div>
+        <div id="playstyle" style="margin-top:10px"></div>
+      </div>
+
+      <div class="card">
+        <h2>Recent Matches</h2>
+        <table class="table-compact">
+          <thead>
+            <tr>
+              <th class="num">Match</th>
+              <th>Created</th>
+              <th>Ended</th>
+              <th>Label</th>
+              <th>Opponent</th>
+              <th class="num">Start</th>
+              <th class="num">End</th>
+              <th class="num">Wins</th>
+              <th class="num">Hands</th>
+              <th class="num">Net</th>
+              <th class="num">Check</th>
+              <th class="num">Call</th>
+              <th class="num">Raise</th>
+              <th class="num">Fold</th>
+            </tr>
+          </thead>
+          <tbody id="tbody"><tr><td colspan="14">Loading…</td></tr></tbody>
+        </table>
       </div>
     </div>
-
-    <div class="card">
-      <div class="kvs" id="meta"></div>
-      <div id="playstyle" style="margin-top:10px"></div>
-    </div>
-
-    <div class="card">
-      <h2>Recent Matches</h2>
-      <table class="table-compact">
-        <thead>
-          <tr>
-            <th class="num">Match</th>
-            <th>Created</th>
-            <th>Ended</th>
-            <th>Label</th>
-            <th>Opponent</th>
-            <th class="num">Start</th>
-            <th class="num">End</th>
-            <th class="num">Wins</th>
-            <th class="num">Hands</th>
-            <th class="num">Net</th>
-            <th class="num">Check</th>
-            <th class="num">Call</th>
-            <th class="num">Raise</th>
-            <th class="num">Fold</th>
-          </tr>
-        </thead>
-        <tbody id="tbody"><tr><td colspan="14">Loading…</td></tr></tbody>
-      </table>
-    </div>
-  </div>
+  </main>
 
   <!-- floating tooltip node (populated via JS) -->
   <div id="tip-pop" class="tooltip-pop" aria-live="polite"></div>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -674,10 +674,13 @@
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -688,8 +691,11 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card elo-card">
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card elo-card">
       <div class="elo-card__header">
         <div>
           <h1>Elo Over Time</h1>
@@ -709,18 +715,48 @@
         </div>
         <div id="legend" class="chart-legend"></div>
       </div>
+      </div>
     </div>
-  </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -40,10 +40,13 @@
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -54,42 +57,75 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
-      <div>
-        <h1>Match History</h1>
-        <div class="muted">Select a match to watch its replay.</div>
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
+        <div>
+          <h1>Match History</h1>
+          <div class="muted">Select a match to watch its replay.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <table>
+          <thead>
+            <tr>
+              <th class="num">ID</th>
+              <th>Created</th>
+              <th>Ended</th>
+              <th>Models</th>
+              <th class="num">Blinds</th>
+              <th class="num">Start</th>
+              <th class="num">Pairs</th>
+              <th class="num">Replay</th>
+            </tr>
+          </thead>
+          <tbody id="tbody"><tr><td colspan="8">Loading…</td></tr></tbody>
+        </table>
       </div>
     </div>
-
-    <div class="card">
-      <table>
-        <thead>
-          <tr>
-            <th class="num">ID</th>
-            <th>Created</th>
-            <th>Ended</th>
-            <th>Models</th>
-            <th class="num">Blinds</th>
-            <th class="num">Start</th>
-            <th class="num">Pairs</th>
-            <th class="num">Replay</th>
-          </tr>
-        </thead>
-        <tbody id="tbody"><tr><td colspan="8">Loading…</td></tr></tbody>
-      </table>
-    </div>
-  </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -13,10 +13,13 @@
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -27,97 +30,130 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card hero" id="hero">
-      <div class="hero__grid">
-        <div class="hero__intro">
-          <div class="hero__brand">
-            <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench logo">
-            <div>
-              <div class="hero__eyebrow">AI Poker Benchmark</div>
-              <h1 class="hero__title">PokerBench</h1>
-              <p class="muted">Head-to-head results and rankings for competitive poker agents.</p>
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card hero" id="hero">
+        <div class="hero__grid">
+          <div class="hero__intro">
+            <div class="hero__brand">
+              <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo">
+              <div>
+                <div class="hero__eyebrow">AI Poker Benchmark</div>
+                <h1 class="hero__title">PokerBench</h1>
+                <p class="muted">Head-to-head results and rankings for competitive poker agents.</p>
+              </div>
+            </div>
+            <div class="hero__cta">
+              <a class="btn" href="/web/leaderboard.html">View Leaderboard</a>
             </div>
           </div>
-          <div class="hero__cta">
-            <a class="btn" href="/web/leaderboard.html">View Leaderboard</a>
-          </div>
-        </div>
-        <div class="hero__stats" id="heroStats">
-          <div class="hero__stat">
-            <span class="hero__label">Latest Match</span>
-            <span class="hero__value" id="matchStatus">Loading…</span>
-          </div>
-          <div class="hero__stat">
-            <span class="hero__label">Blinds</span>
-            <span class="hero__value" id="matchBlinds">—</span>
-          </div>
-          <div class="hero__stat">
-            <span class="hero__label">Start Stack</span>
-            <span class="hero__value" id="matchStack">—</span>
-          </div>
-          <div class="hero__stat">
-            <span class="hero__label">Mirrored Pairs</span>
-            <span class="hero__value" id="matchPairs">—</span>
+          <div class="hero__stats" id="heroStats">
+            <div class="hero__stat">
+              <span class="hero__label">Latest Match</span>
+              <span class="hero__value" id="matchStatus">Loading…</span>
+            </div>
+            <div class="hero__stat">
+              <span class="hero__label">Blinds</span>
+              <span class="hero__value" id="matchBlinds">—</span>
+            </div>
+            <div class="hero__stat">
+              <span class="hero__label">Start Stack</span>
+              <span class="hero__value" id="matchStack">—</span>
+            </div>
+            <div class="hero__stat">
+              <span class="hero__label">Mirrored Pairs</span>
+              <span class="hero__value" id="matchPairs">—</span>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <div class="row">
-      <div class="card" id="leaderboardCard">
-        <div class="card__header">
-          <h2>Leaderboard Snapshot</h2>
-          <div class="muted">Top Elo performers right now.</div>
+      <div class="row">
+        <div class="card" id="leaderboardCard">
+          <div class="card__header">
+            <h2>Leaderboard Snapshot</h2>
+            <div class="muted">Top Elo performers right now.</div>
+          </div>
+          <div id="leaderboardPreview" class="lb-preview"></div>
+          <div id="lbEmpty" class="empty-state" hidden>Leaderboard data will appear after the first match.</div>
+          <a class="btn ghost" href="/web/leaderboard.html">Open full leaderboard</a>
         </div>
-        <div id="leaderboardPreview" class="lb-preview"></div>
-        <div id="lbEmpty" class="empty-state" hidden>Leaderboard data will appear after the first match.</div>
-        <a class="btn ghost" href="/web/leaderboard.html">Open full leaderboard</a>
-      </div>
-      <div class="card" id="metaCard">
-        <div class="card__header">
-          <h2>Match Details</h2>
-          <div class="muted">Key settings for the current duel.</div>
+        <div class="card" id="metaCard">
+          <div class="card__header">
+            <h2>Match Details</h2>
+            <div class="muted">Key settings for the current duel.</div>
+          </div>
+          <div id="meta" class="kvs-grid"></div>
         </div>
-        <div id="meta" class="kvs-grid"></div>
       </div>
-    </div>
 
-    <div class="card" id="participantsCard">
-      <div class="card__header">
-        <h2>Participants</h2>
-        <div class="muted">Starting stacks, finishing stacks, and wins.</div>
+      <div class="card" id="participantsCard">
+        <div class="card__header">
+          <h2>Participants</h2>
+          <div class="muted">Starting stacks, finishing stacks, and wins.</div>
+        </div>
+        <div id="parts" class="participants-grid"></div>
       </div>
-      <div id="parts" class="participants-grid"></div>
-    </div>
 
-    <div class="row">
-      <div class="card" id="mixCard">
-        <div class="card__header">
-          <h2>Action Mix</h2>
-          <div class="muted">Share of checks, calls, raises, and folds.</div>
+      <div class="row">
+        <div class="card" id="mixCard">
+          <div class="card__header">
+            <h2>Action Mix</h2>
+            <div class="muted">Share of checks, calls, raises, and folds.</div>
+          </div>
+          <div id="mix" class="mix-grid"></div>
         </div>
-        <div id="mix" class="mix-grid"></div>
-      </div>
-      <div class="card" id="eloCard">
-        <div class="card__header">
-          <h2>Elo Timeline</h2>
-          <div class="muted">Includes start/end and per pair (after_pair).</div>
+        <div class="card" id="eloCard">
+          <div class="card__header">
+            <h2>Elo Timeline</h2>
+            <div class="muted">Includes start/end and per pair (after_pair).</div>
+          </div>
+          <svg id="eloChart" viewBox="0 0 600 140" preserveAspectRatio="none"></svg>
         </div>
-        <svg id="eloChart" viewBox="0 0 600 140" preserveAspectRatio="none"></svg>
       </div>
     </div>
-  </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -279,10 +279,13 @@ function rowHTML(i, r){
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -293,17 +296,20 @@ function rowHTML(i, r){
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card lb-card">
-      <div class="lb-card__header">
-        <div>
-          <h1>Leaderboard</h1>
-          <div class="muted">Elo with career hands, win%, and net chips.</div>
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card lb-card">
+        <div class="lb-card__header">
+          <div>
+            <h1>Leaderboard</h1>
+            <div class="muted">Elo with career hands, win%, and net chips.</div>
+          </div>
         </div>
-      </div>
-      <div class="lb-card__body">
-        <div class="lb-table-wrap">
-          <table class="lb-table">
+        <div class="lb-card__body">
+          <div class="lb-table-wrap">
+            <table class="lb-table">
             <colgroup>
               <col style="width:56px" />
               <col style="width:260px" />
@@ -331,19 +337,49 @@ function rowHTML(i, r){
             <tbody id="tbody"><tr><td colspan="9">Loading...</td></tr></tbody>
           </table>
         </div>
+        </div>
       </div>
     </div>
-  </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/live.html
+++ b/server/web/live.html
@@ -32,10 +32,13 @@
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -46,28 +49,61 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
-      <div>
-        <h1>Live Viewer</h1>
-        <div class="muted">Connect with <code>?match_id=&lt;id&gt;</code>. Streams per-action logs for replay.</div>
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
+        <div>
+          <h1>Live Viewer</h1>
+          <div class="muted">Connect with <code>?match_id=&lt;id&gt;</code>. Streams per-action logs for replay.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="log"></div>
       </div>
     </div>
-
-    <div class="card">
-      <div class="log"></div>
-    </div>
-  </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -67,10 +67,13 @@
   </script>
 </head>
 <body>
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -81,24 +84,57 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card">
-      <h1>Win Percentage Matrix</h1>
-      <div class="muted">Cell shows A’s win rate vs B (hand-level). Heat indicates stronger advantage.</div>
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card">
+        <h1>Win Percentage Matrix</h1>
+        <div class="muted">Cell shows A’s win rate vs B (hand-level). Heat indicates stronger advantage.</div>
+      </div>
+
+      <div class="card" id="matrix">Loading…</div>
     </div>
-
-    <div class="card" id="matrix">Loading…</div>
-  </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -290,10 +290,13 @@
   </script>
 </head>
 <body class="replay-theme">
-  <div class="wrap wrap--wide">
+  <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench"/>
+        <span class="brand__mark">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
+        <span class="brand__text">PokerBench</span>
       </a>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -304,18 +307,21 @@
         <a class="pill" href="/web/about.html">About</a>
       </nav>
     </div>
+  </header>
 
-    <div class="card">
-      <h1>Replay</h1>
-      <div class="muted">Latest match loads automatically. Switch below.</div>
-      <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap; margin-top:6px">
-        <label class="muted" for="matchSel">Match</label>
-        <select id="matchSel" class="pill" style="background:#0f1712; border-color: var(--line); color: var(--text)"></select>
-        <div id="map" class="muted" style="margin-left:auto; display:flex; gap:8px; flex-wrap:wrap"></div>
+  <main class="page-content">
+    <div class="wrap wrap--wide">
+      <div class="card">
+        <h1>Replay</h1>
+        <div class="muted">Latest match loads automatically. Switch below.</div>
+        <div style="display:flex; gap:12px; align-items:center; flex-wrap:wrap; margin-top:6px">
+          <label class="muted" for="matchSel">Match</label>
+          <select id="matchSel" class="pill" style="background:#0f1712; border-color: var(--line); color: var(--text)"></select>
+          <div id="map" class="muted" style="margin-left:auto; display:flex; gap:8px; flex-wrap:wrap"></div>
+        </div>
       </div>
-    </div>
 
-    <div class="card replay">
+      <div class="card replay">
       <div class="table">
         <div class="controls" style="grid-column:1/4">
           <div class="group">
@@ -363,18 +369,48 @@
         </div>
 
       </div>
+      </div>
     </div>
-  </div>
+  </main>
 
   <footer class="site-footer">
-    <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/PokerBenchlogo.svg" alt="PokerBench emblem"/>
-        <span>PokerBench</span>
-      </a>
+    <div class="site-footer__shell">
+      <div class="site-footer__top">
+        <div class="site-footer__brand">
+          <a class="site-footer__logo" href="/web/index.html">
+            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
+          </a>
+          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
+        </div>
+        <div class="site-footer__cta">
+          <span class="site-footer__cta-label">Follow the project</span>
+          <div class="site-footer__actions">
+            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
+            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          </div>
+        </div>
+      </div>
       <div class="site-footer__links">
-        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X: @PokerAIArena</a>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Explore</span>
+          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
+          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
+          <a class="site-footer__link" href="/web/history.html">History</a>
+          <a class="site-footer__link" href="/web/about.html">About</a>
+        </div>
+        <div class="site-footer__column">
+          <span class="site-footer__heading">Connect</span>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
+          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
+        </div>
+      </div>
+      <div class="site-footer__meta">
+        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
+        <div class="site-footer__credit">
+          <span>Crafted by</span>
+          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
+        </div>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- enlarge the navigation brand to use the PokerBench SVG badge with a text lockup across every page
- rebuild the global footer with a GitHub call-to-action, link columns, and refreshed styling while keeping it sticky
- wrap the static pages in `<main class="page-content">` so the footer reliably anchors to the viewport bottom

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc59e881c0832d923357e602bdd242