### PR TITLE
Simplify footer layout and compact navbar logo

### DIFF
--- a/server/web/about.html
+++ b/server/web/about.html
@@ -185,44 +185,19 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -411,32 +411,26 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 .brand {
   display: inline-flex;
   align-items: center;
-  gap: 14px;
-  font-weight: 900;
-  letter-spacing: .2px;
+  gap: 10px;
+  font-weight: 800;
+  letter-spacing: .02em;
   color: var(--text);
   text-decoration: none;
 }
 .brand__mark {
-  width: clamp(64px, 4.5vw, 72px);
-  height: clamp(64px, 4.5vw, 72px);
-  border-radius: 20px;
-  padding: 6px;
-  display: grid;
-  place-items: center;
-  background: linear-gradient(135deg, rgba(135, 206, 235, .28), rgba(45, 90, 160, .36));
-  box-shadow:
-    inset 0 0 0 1px rgba(255,255,255,.12),
-    0 8px 20px rgba(0,0,0,.45);
+  width: clamp(38px, 2.8vw, 44px);
+  height: clamp(38px, 2.8vw, 44px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .brand__mark img {
   width: 100%;
   height: 100%;
   object-fit: contain;
-  filter: drop-shadow(0 8px 14px rgba(0,0,0,.35));
 }
 .brand__text {
-  font-size: clamp(1.25rem, 1.1rem + .6vw, 1.6rem);
+  font-size: clamp(1.05rem, 0.95rem + .4vw, 1.35rem);
   letter-spacing: .04em;
   text-transform: none;
 }
@@ -644,167 +638,65 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 
 .site-footer {
   margin-top: auto;
-  position: relative;
   border-top: 1px solid rgba(255,255,255,.08);
-  background: linear-gradient(180deg, rgba(9, 14, 24, .96), rgba(7, 10, 18, .98));
-  padding: 52px 0 36px;
-  overflow: hidden;
+  background: linear-gradient(180deg, rgba(9, 14, 24, .94), rgba(7, 10, 18, .96));
+  padding: 24px 0;
 }
-.site-footer::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(540px 280px at 12% 24%, rgba(135, 206, 235, .18), transparent 70%),
-    radial-gradient(520px 260px at 88% 18%, rgba(255, 107, 53, .16), transparent 68%);
-  opacity: .75;
-  pointer-events: none;
-}
-.site-footer__shell {
-  position: relative;
-  width: min(1280px, calc(100vw - 64px));
+.site-footer__inner {
+  width: min(1200px, calc(100vw - 48px));
   margin: 0 auto;
   display: flex;
-  flex-direction: column;
-  gap: 36px;
-  color: color-mix(in oklab, var(--muted) 82%, white 8%);
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  color: color-mix(in oklab, var(--muted) 80%, white 10%);
   font-size: var(--fs-1);
 }
-.site-footer__top {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 24px 36px;
-  align-items: center;
-  justify-content: space-between;
-}
 .site-footer__brand {
-  display: grid;
-  gap: 12px;
-  max-width: min(480px, 100%);
-}
-.site-footer__logo {
-  display: inline-flex;
-  align-items: center;
-  filter: drop-shadow(0 10px 24px rgba(0,0,0,.45));
-}
-.site-footer__logo img {
-  height: clamp(52px, 5vw, 64px);
-  width: auto;
-}
-.site-footer__tagline {
-  margin: 0;
-  font-size: var(--fs-2);
-  line-height: 1.5;
-  color: color-mix(in oklab, var(--muted) 78%, white 12%);
-}
-.site-footer__cta {
-  display: grid;
-  gap: 12px;
-  text-align: right;
-}
-.site-footer__cta-label {
-  text-transform: uppercase;
-  letter-spacing: .4em;
-  font-size: .72rem;
-  color: color-mix(in oklab, var(--muted) 60%, white 8%);
-}
-.site-footer__actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
-.site-footer__button {
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 18px;
-  border-radius: 999px;
   font-weight: 700;
-  letter-spacing: .02em;
-  transition: transform var(--dur-2) var(--ease-2), box-shadow var(--dur-2) var(--ease-2), background var(--dur-2) var(--ease-2);
-  background: linear-gradient(120deg, rgba(135, 206, 235, .85), rgba(45, 90, 160, .95));
-  color: #0a1020;
-  border: 1px solid rgba(255,255,255,.15);
-  box-shadow: 0 14px 30px rgba(36, 72, 128, .35);
+  color: color-mix(in oklab, var(--muted) 95%, white 18%);
 }
-.site-footer__button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 34px rgba(36, 72, 128, .4);
+.site-footer__brand img {
+  width: 28px;
+  height: 28px;
+  display: block;
 }
-.site-footer__button--outline {
-  background: transparent;
-  color: color-mix(in oklab, var(--muted) 92%, white 20%);
-  border-color: rgba(135, 206, 235, .4);
-  box-shadow: 0 10px 24px rgba(0,0,0,.32);
-}
-.site-footer__button--outline:hover {
-  background: rgba(135, 206, 235, .12);
-}
-.site-footer__links {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 24px;
-}
-.site-footer__column {
-  display: grid;
-  gap: 10px;
-}
-.site-footer__heading {
-  font-size: .78rem;
-  text-transform: uppercase;
-  letter-spacing: .36em;
-  color: color-mix(in oklab, var(--muted) 68%, white 12%);
-  font-weight: 800;
-}
-.site-footer__link {
+.site-footer__nav {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  color: color-mix(in oklab, var(--muted) 96%, white 18%);
-  font-weight: 600;
-  transition: color var(--dur-2) var(--ease-2), transform var(--dur-2) var(--ease-2);
-}
-.site-footer__link::after {
-  content: "→";
-  font-size: .85em;
-  opacity: 0;
-  transform: translateX(-6px);
-  transition: opacity var(--dur-2) var(--ease-2), transform var(--dur-2) var(--ease-2);
-}
-.site-footer__link:hover {
-  color: white;
-  transform: translateX(2px);
-}
-.site-footer__link:hover::after {
-  opacity: 1;
-  transform: translateX(0);
-}
-.site-footer__meta {
-  display: flex;
+  gap: 16px;
   flex-wrap: wrap;
-  gap: 12px 24px;
-  justify-content: space-between;
-  align-items: center;
-  padding-top: 24px;
-  border-top: 1px solid rgba(255,255,255,.08);
-  color: color-mix(in oklab, var(--muted) 70%, white 10%);
+}
+.site-footer__nav a {
+  font-weight: 600;
+  color: color-mix(in oklab, var(--muted) 90%, white 15%);
+  transition: color var(--dur-2) var(--ease-2);
+}
+.site-footer__nav a:hover {
+  color: white;
 }
 .site-footer__copy {
   margin: 0;
   font-size: calc(var(--fs-1) * .95);
+  color: color-mix(in oklab, var(--muted) 75%, white 12%);
 }
-.site-footer__credit {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-}
-.site-footer__credit a {
-  font-weight: 700;
-  color: color-mix(in oklab, var(--muted) 95%, white 20%);
-}
-.site-footer__credit a:hover {
-  color: white;
+
+@media (max-width: 640px) {
+  .site-footer__inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .site-footer__nav {
+    justify-content: flex-start;
+  }
+  .site-footer__copy {
+    margin-top: 4px;
+  }
 }
 
 @media (max-width: 1024px) {
@@ -821,25 +713,6 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   }
   .topnav nav {
     justify-content: center;
-  }
-  .site-footer {
-    padding: 48px 0 32px;
-  }
-  .site-footer__shell {
-    width: min(100%, calc(100vw - 40px));
-    gap: 28px;
-  }
-  .site-footer__top {
-    flex-direction: column;
-    align-items: flex-start;
-    text-align: left;
-  }
-  .site-footer__cta {
-    text-align: left;
-    width: 100%;
-  }
-  .site-footer__actions {
-    justify-content: flex-start;
   }
 }
 .btn.warn   { background: linear-gradient(90deg, var(--warn-9), hsl(32 94% 58%)); color: #1d1200; }

--- a/server/web/bot.html
+++ b/server/web/bot.html
@@ -286,44 +286,19 @@
   <div id="tip-pop" class="tooltip-pop" aria-live="polite"></div>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -720,44 +720,19 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -89,44 +89,19 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -117,44 +117,19 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -343,44 +343,19 @@ function rowHTML(i, r){
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>

--- a/server/web/live.html
+++ b/server/web/live.html
@@ -67,44 +67,19 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -98,44 +98,19 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -374,44 +374,19 @@
   </main>
 
   <footer class="site-footer">
-    <div class="site-footer__shell">
-      <div class="site-footer__top">
-        <div class="site-footer__brand">
-          <a class="site-footer__logo" href="/web/index.html">
-            <img src="/web/img/PokerBenchNavLong.svg" alt="PokerBench wordmark"/>
-          </a>
-          <p class="site-footer__tagline">Open benchmark tracking head-to-head poker agents.</p>
-        </div>
-        <div class="site-footer__cta">
-          <span class="site-footer__cta-label">Follow the project</span>
-          <div class="site-footer__actions">
-            <a class="site-footer__button" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">Star on GitHub</a>
-            <a class="site-footer__button site-footer__button--outline" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          </div>
-        </div>
-      </div>
-      <div class="site-footer__links">
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Explore</span>
-          <a class="site-footer__link" href="/web/leaderboard.html">Leaderboard</a>
-          <a class="site-footer__link" href="/web/matrix.html">Matrix</a>
-          <a class="site-footer__link" href="/web/history.html">History</a>
-          <a class="site-footer__link" href="/web/about.html">About</a>
-        </div>
-        <div class="site-footer__column">
-          <span class="site-footer__heading">Connect</span>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub Repo</a>
-          <a class="site-footer__link" href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-          <a class="site-footer__link" href="https://twitter.com/PokerAIArena" target="_blank" rel="noopener">X / @PokerAIArena</a>
-        </div>
-      </div>
-      <div class="site-footer__meta">
-        <p class="site-footer__copy">© 2025 PokerBench. All rights reserved.</p>
-        <div class="site-footer__credit">
-          <span>Crafted by</span>
-          <a href="https://github.com/jackkayser2005" target="_blank" rel="noopener">@jackkayser2005</a>
-        </div>
-      </div>
+    <div class="site-footer__inner">
+      <a class="site-footer__brand" href="/web/index.html">
+        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span>PokerBench</span>
+      </a>
+      <nav class="site-footer__nav" aria-label="Footer">
+        <a href="/web/leaderboard.html">Leaderboard</a>
+        <a href="/web/matrix.html">Matrix</a>
+        <a href="/web/history.html">History</a>
+        <a href="/web/about.html">About</a>
+        <a href="https://github.com/jackkayser2005/pokerBench" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+      <p class="site-footer__copy">© 2025 PokerBench</p>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
## Summary
- shrink the navbar brand styling so pokerBenchlogo.svg sits closer to the title and feels lighter
- replace the previous multi-column footer on each static page with a compact bar that keeps only the key links and wordmark
- clean up footer styles and media queries to match the streamlined layout

## Testing
- not run (static HTML/CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68cc5fd1b638832db99e708bf76a7640