### PR TITLE
Add match legend next to header brand

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -408,6 +408,13 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   gap: 18px;
   padding: 12px 0;
 }
+.topnav__cluster {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
 .brand {
   display: inline-flex;
   align-items: center;
@@ -440,6 +447,60 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   letter-spacing: .04em;
   text-transform: none;
 }
+.match-legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(12, 20, 36, .88), rgba(20, 30, 52, .88));
+  border: 1px solid rgba(118, 177, 255, .26);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, .05),
+    0 12px 26px rgba(4, 12, 24, .45);
+  font-size: var(--fs-1);
+  color: color-mix(in oklab, var(--text) 88%, white 6%);
+  flex-wrap: wrap;
+  max-width: min(420px, 48vw);
+}
+.match-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1 1 180px;
+}
+.match-legend__swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, .4);
+  background: var(--legend-color, rgba(118, 177, 255, .92));
+}
+.match-legend__details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.match-legend__slot {
+  font-size: .72rem;
+  font-weight: 700;
+  letter-spacing: .18em;
+  text-transform: uppercase;
+  color: rgba(232, 244, 255, .82);
+}
+.match-legend__text {
+  font-size: var(--fs-1);
+  color: color-mix(in oklab, var(--muted) 78%, white 8%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: min(220px, 32vw);
+}
+.match-legend[hidden] {
+  display: none !important;
+}
 .topnav nav {
   display: flex;
   gap: 8px;
@@ -459,6 +520,18 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 }
 .topnav a:hover::after, .topnav a.active::after { transform: scaleX(1); }
 .topnav a:focus-visible { box-shadow: var(--ring); border-color: color-mix(in oklab, var(--accent-2) 30%, var(--border)); }
+
+@media (max-width: 1024px) {
+  .match-legend {
+    max-width: min(360px, 60vw);
+  }
+}
+
+@media (max-width: 860px) {
+  .match-legend {
+    display: none !important;
+  }
+}
 
 /* 4a) About page ----------------------------------------------------- */
 .about-hero {

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -15,12 +15,15 @@
 <body>
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
-          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
-        </span>
-        <span class="brand__text">PokerBench</span>
-      </a>
+      <div class="topnav__cluster">
+        <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+          <span class="brand__mark">
+            <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+          </span>
+          <span class="brand__text">PokerBench</span>
+        </a>
+        <div class="match-legend" id="matchLegend" hidden aria-live="polite"></div>
+      </div>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
         <a class="pill" href="/web/matrix.html">Matrix</a>
@@ -501,6 +504,50 @@
             icon: companyIconPath('', B.model),
           };
         }
+        const legendEl = $('#matchLegend');
+        if (legendEl) {
+          const legendItems = [
+            { slot: 'A', color: '#39d98a', meta: metaMap.A || null },
+            { slot: 'B', color: '#d6c29b', meta: metaMap.B || null },
+          ].map(entry => {
+            const meta = entry.meta || {};
+            const modelName = trimModelName(meta.model || '');
+            const companyName = (meta.company || '').trim();
+            const pieces = [];
+            if (modelName) pieces.push(safe(modelName));
+            if (companyName) {
+              const lowerModel = modelName.toLowerCase();
+              const lowerCompany = companyName.toLowerCase();
+              if (!lowerModel.includes(lowerCompany)) {
+                pieces.push(safe(companyName));
+              }
+            }
+            const hasInfo = pieces.length > 0;
+            const desc = hasInfo ? pieces.join(' · ') : 'Awaiting matchup';
+            return {
+              hasInfo,
+              html: `
+                <div class="match-legend__item">
+                  <span class="match-legend__swatch" style="--legend-color:${entry.color}"></span>
+                  <div class="match-legend__details">
+                    <span class="match-legend__slot">${entry.slot}</span>
+                    <span class="match-legend__text">${desc}</span>
+                  </div>
+                </div>
+              `,
+            };
+          });
+
+          const hasLegend = legendItems.some(item => item.hasInfo);
+          if (hasLegend) {
+            legendEl.hidden = false;
+            legendEl.innerHTML = legendItems.map(item => item.html).join('');
+          } else {
+            legendEl.hidden = true;
+            legendEl.innerHTML = '';
+          }
+        }
+
         drawElo(document.getElementById('eloChart'), ptsA, ptsB, metaMap);
 
         if (!match.ended_at) {
@@ -551,6 +598,11 @@
       $('#parts').innerHTML = `<div class="empty-state">Participants will show once a match has run.</div>`;
       $('#mix').innerHTML = `<div class="empty-state">Action mix will appear after the first duel.</div>`;
       document.getElementById('eloChart').innerHTML = '';
+      const legendEl = $('#matchLegend');
+      if (legendEl) {
+        legendEl.hidden = true;
+        legendEl.innerHTML = '';
+      }
     }
 
     load();


### PR DESCRIPTION
## Summary
- add a header legend next to the PokerBench brand that maps player colors to the active models
- render the legend from the latest match data, including model and company details when available
- style the legend to blend with the existing top navigation and collapse on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc60e18564832d9c8235e85b912ce6