### PR TITLE
Relocate match legend to Elo card

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -408,6 +408,13 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   gap: 18px;
   padding: 12px 0;
 }
+.topnav__cluster {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
 .brand {
   display: inline-flex;
   align-items: center;
@@ -440,6 +447,56 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   letter-spacing: .04em;
   text-transform: none;
 }
+.elo-mini-legend {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin: 8px 0 16px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background: rgba(12, 20, 36, .68);
+  border: 1px solid rgba(118, 177, 255, .22);
+  font-size: var(--fs-1);
+  color: color-mix(in oklab, var(--muted) 82%, white 10%);
+}
+.elo-mini-legend__item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.elo-mini-legend__swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, .38);
+  background: var(--legend-color, rgba(118, 177, 255, .92));
+  flex-shrink: 0;
+}
+.elo-mini-legend__label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.elo-mini-legend__slot {
+  font-size: .65rem;
+  font-weight: 700;
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: rgba(224, 236, 255, .78);
+}
+.elo-mini-legend__text {
+  color: color-mix(in oklab, var(--text) 74%, white 6%);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: min(240px, 46vw);
+}
+.elo-mini-legend[hidden] {
+  display: none !important;
+}
 .topnav nav {
   display: flex;
   gap: 8px;
@@ -459,6 +516,16 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 }
 .topnav a:hover::after, .topnav a.active::after { transform: scaleX(1); }
 .topnav a:focus-visible { box-shadow: var(--ring); border-color: color-mix(in oklab, var(--accent-2) 30%, var(--border)); }
+
+@media (max-width: 640px) {
+  .elo-mini-legend {
+    padding: 8px 10px;
+    gap: 12px;
+  }
+  .elo-mini-legend__text {
+    max-width: min(200px, 60vw);
+  }
+}
 
 /* 4a) About page ----------------------------------------------------- */
 .about-hero {

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -15,12 +15,14 @@
 <body>
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
-          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
-        </span>
-        <span class="brand__text">PokerBench</span>
-      </a>
+      <div class="topnav__cluster">
+        <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+          <span class="brand__mark">
+            <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+          </span>
+          <span class="brand__text">PokerBench</span>
+        </a>
+      </div>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
         <a class="pill" href="/web/matrix.html">Matrix</a>
@@ -110,6 +112,7 @@
             <h2>Elo Timeline</h2>
             <div class="muted">Includes start/end and per pair (after_pair).</div>
           </div>
+          <div class="elo-mini-legend" id="matchLegend" hidden aria-live="polite"></div>
           <svg id="eloChart" viewBox="0 0 600 140" preserveAspectRatio="none"></svg>
         </div>
       </div>
@@ -501,6 +504,50 @@
             icon: companyIconPath('', B.model),
           };
         }
+        const legendEl = $('#matchLegend');
+        if (legendEl) {
+          const legendItems = [
+            { slot: 'A', color: '#39d98a', meta: metaMap.A || null },
+            { slot: 'B', color: '#d6c29b', meta: metaMap.B || null },
+          ].map(entry => {
+            const meta = entry.meta || {};
+            const modelName = trimModelName(meta.model || '');
+            const companyName = (meta.company || '').trim();
+            const pieces = [];
+            if (modelName) pieces.push(safe(modelName));
+            if (companyName) {
+              const lowerModel = modelName.toLowerCase();
+              const lowerCompany = companyName.toLowerCase();
+              if (!lowerModel.includes(lowerCompany)) {
+                pieces.push(safe(companyName));
+              }
+            }
+            const hasInfo = pieces.length > 0;
+            const desc = hasInfo ? pieces.join(' · ') : 'Awaiting matchup';
+            return {
+              hasInfo,
+              html: `
+                <div class="elo-mini-legend__item">
+                  <span class="elo-mini-legend__swatch" style="--legend-color:${entry.color}"></span>
+                  <span class="elo-mini-legend__label">
+                    <span class="elo-mini-legend__slot">${entry.slot}</span>
+                    <span class="elo-mini-legend__text">${desc}</span>
+                  </span>
+                </div>
+              `,
+            };
+          });
+
+          const hasLegend = legendItems.some(item => item.hasInfo);
+          if (hasLegend) {
+            legendEl.hidden = false;
+            legendEl.innerHTML = legendItems.map(item => item.html).join('');
+          } else {
+            legendEl.hidden = true;
+            legendEl.innerHTML = '';
+          }
+        }
+
         drawElo(document.getElementById('eloChart'), ptsA, ptsB, metaMap);
 
         if (!match.ended_at) {
@@ -551,6 +598,11 @@
       $('#parts').innerHTML = `<div class="empty-state">Participants will show once a match has run.</div>`;
       $('#mix').innerHTML = `<div class="empty-state">Action mix will appear after the first duel.</div>`;
       document.getElementById('eloChart').innerHTML = '';
+      const legendEl = $('#matchLegend');
+      if (legendEl) {
+        legendEl.hidden = true;
+        legendEl.innerHTML = '';
+      }
     }
 
     load();


### PR DESCRIPTION
## Summary
- move the match color legend from the sticky navigation into the Elo Timeline card
- restyle the legend into a compact block sized for the chart section

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc60e18564832d9c8235e85b912ce6