### PR TITLE
Add Elo legend next to chart and compact header cards

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -202,7 +202,7 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 .center  { display:grid; place-items:center; }
 
 /* 3) Surfaces / Cards ------------------------------------------------- */
-.card {
+.card { 
   background:
     linear-gradient(180deg, hsl(240 15% 16% / .85), hsl(240 15% 14% / .9)),
     radial-gradient(800px 400px at 10% -10%, rgba(45,90,160,.08), transparent 55%);
@@ -216,6 +216,27 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 .card.ghost { background: hsl(240 15% 14% / .55); backdrop-filter: blur(6px); }
 .card.tight { padding: 12px; }
 .card.spacious { padding: 26px; border-radius: var(--radius-3); }
+.card--compact {
+  padding: 16px 20px;
+  display: grid;
+  gap: 6px;
+  align-items: start;
+}
+.card--compact h1 {
+  margin: 0 0 4px;
+  font-size: clamp(1.4rem, 1.16rem + .8vw, 1.9rem);
+}
+.card--compact .muted {
+  font-size: var(--fs-1);
+  margin-top: 0;
+}
+.card--header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+}
 .card__header { display: flex; flex-direction: column; gap: 4px; margin-bottom: 18px; }
 .card__header h2 { margin: 0; }
 .card__header .muted { font-size: var(--fs-1); }
@@ -477,6 +498,19 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   gap: 2px;
   min-width: 0;
 }
+.match-legend__info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.match-legend__info .org-icon {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
 .match-legend__slot {
   font-size: .72rem;
   font-weight: 700;
@@ -491,6 +525,13 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: min(220px, 32vw);
+}
+.match-legend__info .match-legend__text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.match-legend__text--empty {
+  color: rgba(196, 216, 255, .55);
 }
 .match-legend[hidden] {
   display: none !important;
@@ -1561,15 +1602,54 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
 }
 .elo-card__header {
   display: flex;
-  align-items: flex-end;
+  align-items: stretch;
   justify-content: space-between;
-  gap: 24px;
+  gap: 28px;
   padding: 32px 40px 28px;
   background: linear-gradient(180deg, rgba(8, 16, 30, .9), rgba(8, 14, 26, .76));
   border-bottom: 1px solid rgba(123, 180, 255, .28);
   flex-wrap: wrap;
 }
 .elo-card__header h1 { margin-bottom: 8px; }
+.elo-card__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  flex: 1 1 60%;
+  min-width: 0;
+}
+.elo-card__brand {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.elo-card__logo {
+  width: 58px;
+  height: 58px;
+  border-radius: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(118, 177, 255, .25), rgba(77, 246, 180, .18));
+  border: 1px solid rgba(118, 177, 255, .32);
+  box-shadow: 0 18px 34px rgba(4, 12, 24, .45);
+  backdrop-filter: blur(6px);
+}
+.elo-card__logo img {
+  width: 38px;
+  height: auto;
+  filter: drop-shadow(0 8px 16px rgba(0,0,0,.4));
+}
+.elo-card__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.elo-card__legend {
+  align-self: flex-start;
+  max-width: min(440px, 100%);
+}
 .elo-card__filters {
   display: flex;
   justify-content: flex-end;
@@ -1882,6 +1962,9 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
   .elo-card__header { flex-direction: column; align-items: flex-start; }
   .elo-card__filters { width: 100%; }
   .filter-chips { width: 100%; justify-content: flex-start; }
+  .elo-card__intro { width: 100%; }
+  .elo-card__brand { align-items: flex-start; }
+  .elo-card__legend { width: 100%; }
 }
 
 /* Replay: prevent long model names from breaking layout */

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -67,9 +67,104 @@
       return tpl.content.firstElementChild;
     }
 
+    function trimModelName(s = '') {
+      s = s.trim().replace(/^"+|"+$/g, '');
+      const parts = s.split(/[\/:@]/).filter(Boolean);
+      if (parts.length) s = parts[parts.length - 1];
+      if (s.length > 42) s = s.slice(0, 42) + '…';
+      return s;
+    }
+
+    function normalizeLegendMeta(entry) {
+      if (!entry) return { label: '', model: '', company: '' };
+      const label = String(entry.label || '').trim().toUpperCase();
+      const model = String(entry.model || '').trim();
+      const company = String(entry.company || '').trim();
+      return { label, model, company };
+    }
+
+    function buildLegendEntry(slot, meta) {
+      const host = document.createElement('div');
+      host.className = 'match-legend__item';
+      const color = slot === 'A' ? '#39d98a' : '#d6c29b';
+      host.style.setProperty('--legend-color', color);
+
+      const swatch = document.createElement('span');
+      swatch.className = 'match-legend__swatch';
+      swatch.style.background = color;
+      host.appendChild(swatch);
+
+      const details = document.createElement('div');
+      details.className = 'match-legend__details';
+
+      const slotEl = document.createElement('span');
+      slotEl.className = 'match-legend__slot';
+      slotEl.textContent = slot;
+      details.appendChild(slotEl);
+
+      const infoWrap = document.createElement('div');
+      infoWrap.className = 'match-legend__info';
+      const hasMeta = Boolean((meta.model || '').trim() || (meta.company || '').trim());
+      if (hasMeta) {
+        const iconMarkup = companyIconMarkup(meta.company, meta.model);
+        const iconEl = createIconElement(iconMarkup);
+        if (iconEl) infoWrap.appendChild(iconEl);
+      }
+
+      const textEl = document.createElement('span');
+      textEl.className = 'match-legend__text';
+      const trimmedModel = trimModelName(meta.model || '');
+      const pieces = [];
+      if (trimmedModel) pieces.push(trimmedModel);
+      const canonical = (meta.company || '').trim() ? canonicalCompany(meta.company) : '';
+      const company = canonical;
+      const lowerModel = trimmedModel.toLowerCase();
+      const lowerCompany = company.toLowerCase();
+      const includeCompany = Boolean(company) && !lowerModel.includes(lowerCompany);
+      if (includeCompany) pieces.push(company);
+      const hasInfo = pieces.length > 0;
+      textEl.textContent = hasInfo ? pieces.join(' · ') : 'Awaiting matchup';
+      if (!hasInfo) textEl.classList.add('match-legend__text--empty');
+      infoWrap.appendChild(textEl);
+
+      details.appendChild(infoWrap);
+      host.appendChild(details);
+
+      return { element: host, hasInfo };
+    }
+
+    async function loadMatchLegend() {
+      const host = document.getElementById('eloMatchLegend');
+      if (!host) return;
+      host.innerHTML = '';
+      host.hidden = true;
+      try {
+        const res = await fetch('/api/last-match');
+        if (!res.ok) return;
+        const data = await res.json();
+        const participants = Array.isArray(data?.participants) ? data.participants : [];
+        const map = new Map();
+        participants.forEach(p => {
+          const { label, model, company } = normalizeLegendMeta(p);
+          if (label) map.set(label, { label, model, company });
+        });
+        const slots = ['A', 'B'];
+        const entries = slots.map(slot => buildLegendEntry(slot, map.get(slot) || { label: slot, model: '', company: '' }));
+        const hasLegend = entries.some(entry => entry.hasInfo);
+        if (!hasLegend) return;
+        entries.forEach(entry => host.appendChild(entry.element));
+        host.hidden = false;
+      } catch (err) {
+        if (window.console && typeof window.console.debug === 'function') {
+          window.console.debug('legend load failed', err);
+        }
+      }
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       highlightNav();
       load();
+      loadMatchLegend();
     });
 
     function highlightNav() {
@@ -725,9 +820,17 @@
     <div class="wrap wrap--wide">
       <div class="card elo-card">
       <div class="elo-card__header">
-        <div>
-          <h1>Elo Over Time</h1>
-          <div class="muted">End-of-match Elo per bot across all duels.</div>
+        <div class="elo-card__intro">
+          <div class="elo-card__brand">
+            <span class="elo-card__logo">
+              <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+            </span>
+            <div class="elo-card__heading">
+              <h1>Elo Over Time</h1>
+              <div class="muted">End-of-match Elo per bot across all duels.</div>
+            </div>
+          </div>
+          <div class="match-legend elo-card__legend" id="eloMatchLegend" hidden aria-live="polite"></div>
         </div>
         <div class="elo-card__filters">
           <div id="companyFilters" class="filter-chips"></div>

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -61,7 +61,7 @@
 
   <main class="page-content">
     <div class="wrap wrap--wide">
-      <div class="card" style="display:flex; align-items:center; justify-content:space-between; gap:12px">
+      <div class="card card--compact card--header-row">
         <div>
           <h1>Match History</h1>
           <div class="muted">Select a match to watch its replay.</div>

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -22,7 +22,6 @@
           </span>
           <span class="brand__text">PokerBench</span>
         </a>
-        <div class="match-legend" id="matchLegend" hidden aria-live="polite"></div>
       </div>
       <nav>
         <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
@@ -263,8 +262,9 @@
       iconsGroup.setAttribute('class', 'chart-icons');
       iconsGroup.setAttribute('pointer-events', 'none');
 
-      const placeIcon = (anchor, info, color, vertical = 'top', horizontal = 'center') => {
+      const placeIcon = (anchor, info, color, vertical = 'top', horizontal = 'center', options = {}) => {
         if (!anchor || !info) return;
+        const { forceLabel = false, forceIcon = false } = options || {};
         const size = 28;
         const g = mk('g');
         g.setAttribute('class', 'chart-icon');
@@ -300,22 +300,48 @@
         }
         g.appendChild(bg);
 
-        if (info.icon) {
+        const iconSrc = typeof info.icon === 'string' ? info.icon : '';
+        const labelText = (info.label || '').trim();
+        let rendered = false;
+        if (!forceLabel && iconSrc && (forceIcon || iconSrc)) {
           const img = mk('image');
           img.setAttribute('x', x);
           img.setAttribute('y', y);
           img.setAttribute('width', size);
           img.setAttribute('height', size);
           img.setAttribute('class', 'chart-icon__img');
-          img.setAttribute('href', info.icon);
-          img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', info.icon);
+          img.setAttribute('href', iconSrc);
+          img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconSrc);
           g.appendChild(img);
-        } else if (info.label) {
+          rendered = true;
+        }
+        if (!rendered && labelText) {
           const text = mk('text');
           text.setAttribute('x', cx);
           text.setAttribute('y', cy + 1);
           text.setAttribute('class', 'chart-icon__text');
-          text.textContent = info.label;
+          text.textContent = labelText;
+          g.appendChild(text);
+          rendered = true;
+        }
+        if (!rendered && iconSrc) {
+          const img = mk('image');
+          img.setAttribute('x', x);
+          img.setAttribute('y', y);
+          img.setAttribute('width', size);
+          img.setAttribute('height', size);
+          img.setAttribute('class', 'chart-icon__img');
+          img.setAttribute('href', iconSrc);
+          img.setAttributeNS('http://www.w3.org/1999/xlink', 'href', iconSrc);
+          g.appendChild(img);
+          rendered = true;
+        }
+        if (!rendered && labelText) {
+          const text = mk('text');
+          text.setAttribute('x', cx);
+          text.setAttribute('y', cy + 1);
+          text.setAttribute('class', 'chart-icon__text');
+          text.textContent = labelText;
           g.appendChild(text);
         }
 
@@ -363,9 +389,9 @@
         });
         el.appendChild(dots);
 
-        placeIcon(coords[0], info, color, align, 'left');
+        placeIcon(coords[0], info, color, align, 'left', { forceIcon: true });
         if (coords.length > 1) {
-          placeIcon(coords[coords.length - 1], info, color, align, 'right');
+          placeIcon(coords[coords.length - 1], info, color, align, 'right', { forceLabel: true });
         }
 
         return coords;

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -88,7 +88,7 @@
 
   <main class="page-content">
     <div class="wrap wrap--wide">
-      <div class="card">
+      <div class="card card--compact">
         <h1>Win Percentage Matrix</h1>
         <div class="muted">Cell shows A’s win rate vs B (hand-level). Heat indicates stronger advantage.</div>
       </div>


### PR DESCRIPTION
## Summary
- add a match legend beside the Elo chart header with brand styling and dynamic data
- update the home page mini Elo chart icons to show the company logo at the start and the slot letter at the end
- introduce compact header card styles and apply them to the matrix and history intro panels

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cc6aa6f5a4832d9716ecb09851420f