### PR TITLE
Refresh UI palette and organization handling

### DIFF
--- a/server/web/about.html
+++ b/server/web/about.html
@@ -21,7 +21,7 @@
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -187,7 +187,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -38,20 +38,21 @@
   --primary-3: #14B8A6;
   --accent: var(--primary);
   --accent-2: var(--primary-2);
+  --accent-3: #38BDF8;
 
   /* Utility accents */
   --link: #60A5FA;
-  --warn: #F59E0B;
+  --warn: #38BDF8;
   --ok: #14B8A6;
-  --bad: #F97316;
+  --bad: #F43F5E;
 
   /* Status blends */
   --ok-9: #0F9C73;
   --ok-11: #36D8B3;
-  --warn-9: #C47A06;
-  --warn-11: #F7C566;
-  --err-9: #C4570E;
-  --err-11: #F7A66A;
+  --warn-9: #1C9EE7;
+  --warn-11: #7FD8FF;
+  --err-9: #C0284A;
+  --err-11: #F87FA5;
 
   /* Radii, shadows, motion */
   --radius-2: 10px;
@@ -82,8 +83,8 @@
   /* Playing card theme */
   --card-darkBg:  #273244;
   --card-lightBg: #1B2332;
-  --card-darkRed: #F97316;
-  --card-lightRed:#F59E0B;
+  --card-darkRed: #EF4444;
+  --card-lightRed:#FCA5A5;
   --card-darkBlk: #E6EAF2;
   --card-lightBlk:#A9B4C5;
   --card-w: 150px;
@@ -182,6 +183,34 @@ button, input, select, textarea { font: inherit; color: inherit; }
   box-shadow: 0 0 0 1px rgba(230, 234, 242, .28);
 }
 
+.logo-badge {
+  --logo-badge-size: 52px;
+  width: var(--logo-badge-size);
+  height: var(--logo-badge-size);
+  border-radius: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg,
+    color-mix(in oklab, var(--accent) 32%, transparent),
+    color-mix(in oklab, var(--accent-3) 36%, transparent));
+  border: 1px solid color-mix(in oklab, var(--accent-2) 40%, rgba(56, 189, 248, .2));
+  box-shadow: 0 18px 34px rgba(4, 12, 24, .45);
+  backdrop-filter: blur(6px);
+  padding: 6px;
+}
+
+.logo-badge img {
+  width: 72%;
+  height: auto;
+  display: block;
+  filter: drop-shadow(0 8px 16px rgba(0, 0, 0, .35));
+}
+
+.logo-badge--sm { --logo-badge-size: clamp(36px, 2.6vw, 44px); }
+.logo-badge--md { --logo-badge-size: 58px; }
+.logo-badge--lg { --logo-badge-size: clamp(72px, 7vw, 88px); }
+
 h1 { font-size: var(--fs-5); line-height: 1.2; margin: 0 0 var(--sp-2); letter-spacing: .2px; }
 h2 { font-size: var(--fs-4); line-height: 1.25; margin: 0 0 var(--sp-2); }
 h3 { font-size: var(--fs-3); line-height: 1.3; margin: 0 0 var(--sp-1); }
@@ -277,7 +306,7 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 }
 .hero__intro { display: flex; flex-direction: column; gap: 24px; }
 .hero__brand { display: flex; gap: 20px; align-items: center; }
-.hero__brand img { width: 78px; height: auto; filter: drop-shadow(0 12px 24px rgba(0,0,0,.45)); }
+.hero__brand .logo-badge { --logo-badge-size: clamp(76px, 8vw, 92px); }
 .hero__eyebrow { text-transform: uppercase; letter-spacing: .3em; font-size: var(--fs-1); color: color-mix(in oklab, var(--muted) 60%, white 10%); }
 .hero__title { font-size: clamp(2rem, 1.4rem + 2.2vw, 3rem); margin: 4px 0; }
 .hero__cta { display: flex; flex-wrap: wrap; gap: 12px; }
@@ -337,7 +366,9 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   display: grid;
   place-items: center;
   font-weight: 700;
-  background: linear-gradient(135deg, rgba(16, 185, 129, .88), rgba(245, 158, 11, .92));
+  background: linear-gradient(135deg,
+    color-mix(in oklab, var(--accent) 88%, transparent),
+    color-mix(in oklab, var(--accent-3) 92%, transparent));
   color: #04110e;
 }
 .lb-preview__main { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
@@ -378,7 +409,9 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   font-size: var(--fs-1);
   padding: 4px 12px;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(16, 185, 129, .92), rgba(245, 158, 11, .9));
+  background: linear-gradient(135deg,
+    color-mix(in oklab, var(--accent) 92%, transparent),
+    color-mix(in oklab, var(--accent-3) 88%, transparent));
   color: #04110e;
 }
 .participant__company { font-size: var(--fs-1); }
@@ -410,7 +443,7 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
 
 @media (max-width: 600px) {
   .hero { padding: 24px; }
-  .hero__brand img { width: 64px; }
+  .hero__brand .logo-badge { --logo-badge-size: 64px; }
   .hero__cta { justify-content: flex-start; }
 }
 
@@ -453,17 +486,11 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   text-decoration: none;
 }
 .brand__mark {
-  width: clamp(38px, 2.8vw, 44px);
-  height: clamp(38px, 2.8vw, 44px);
   display: inline-flex;
   align-items: center;
   justify-content: center;
 }
-.brand__mark img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
+.brand__mark.logo-badge { --logo-badge-size: clamp(36px, 2.6vw, 44px); }
 .brand__text {
   font-size: clamp(1.05rem, 0.95rem + .4vw, 1.35rem);
   letter-spacing: .04em;
@@ -781,11 +808,12 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   font-weight: 700;
   color: color-mix(in oklab, var(--muted) 95%, white 18%);
 }
-.site-footer__brand img {
-  width: 28px;
-  height: 28px;
-  display: block;
+.site-footer__brand .logo-badge {
+  --logo-badge-size: 34px;
+  padding: 4px;
+  box-shadow: 0 12px 26px rgba(4, 12, 24, .32);
 }
+.site-footer__brand .logo-badge img { width: 68%; }
 .site-footer__nav {
   display: inline-flex;
   align-items: center;
@@ -924,7 +952,7 @@ svg text { fill: color-mix(in oklab, var(--muted) 82%, transparent); font-family
   border: 1px solid rgba(20, 184, 166, .24);
   background:
     radial-gradient(140% 160% at 95% 0%, rgba(20, 184, 166, .18), transparent 64%),
-    radial-gradient(120% 150% at 8% 0%, rgba(245, 158, 11, .16), transparent 70%),
+    radial-gradient(120% 150% at 8% 0%, color-mix(in oklab, var(--accent-3) 20%, transparent), transparent 70%),
     linear-gradient(180deg, rgba(12, 20, 32, .96), rgba(7, 11, 20, .94));
   box-shadow: 0 38px 74px rgba(4, 12, 24, .56);
   backdrop-filter: blur(8px);
@@ -986,7 +1014,9 @@ svg text { fill: color-mix(in oklab, var(--muted) 82%, transparent); font-family
   background: rgba(16, 26, 38, .66);
 }
 .lb-table tbody tr:hover {
-  background: linear-gradient(90deg, rgba(20, 184, 166, .24), rgba(245, 158, 11, .2));
+  background: linear-gradient(90deg,
+    color-mix(in oklab, var(--accent) 26%, transparent),
+    color-mix(in oklab, var(--accent-3) 24%, transparent));
 }
 .lb-table .num {
   text-align: right;
@@ -1598,8 +1628,8 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
   border-radius: 30px;
   border: 1px solid rgba(20, 184, 166, .24);
   background:
-    radial-gradient(140% 150% at 88% 0%, rgba(245, 158, 11, .2), transparent 70%),
-    radial-gradient(160% 140% at 10% 0%, rgba(20, 184, 166, .2), transparent 72%),
+    radial-gradient(140% 150% at 88% 0%, color-mix(in oklab, var(--accent-3) 26%, transparent), transparent 70%),
+    radial-gradient(160% 140% at 10% 0%, color-mix(in oklab, var(--accent) 24%, transparent), transparent 72%),
     linear-gradient(180deg, rgba(12, 18, 34, .96), rgba(6, 10, 20, .94));
   box-shadow: 0 44px 82px rgba(4, 12, 24, .6);
   overflow: hidden;
@@ -1632,21 +1662,7 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
   flex-wrap: wrap;
 }
 .elo-card__logo {
-  width: 58px;
-  height: 58px;
-  border-radius: 20px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: linear-gradient(135deg, rgba(20, 184, 166, .25), rgba(245, 158, 11, .18));
-  border: 1px solid rgba(20, 184, 166, .32);
-  box-shadow: 0 18px 34px rgba(4, 12, 24, .45);
-  backdrop-filter: blur(6px);
-}
-.elo-card__logo img {
-  width: 38px;
-  height: auto;
-  filter: drop-shadow(0 8px 16px rgba(0,0,0,.4));
+  --logo-badge-size: 58px;
 }
 .elo-card__heading {
   display: flex;
@@ -1710,7 +1726,9 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
   width: 12px;
   height: 12px;
   border-radius: 999px;
-  background: linear-gradient(135deg, rgba(20, 184, 166, .85), rgba(245, 158, 11, .78));
+  background: linear-gradient(135deg,
+    color-mix(in oklab, var(--accent) 86%, transparent),
+    color-mix(in oklab, var(--accent-3) 82%, transparent));
   box-shadow: 0 0 0 2px rgba(0, 0, 0, .28);
 }
 .filter-chip:hover {
@@ -1721,7 +1739,9 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
 }
 .filter-chip.active {
   color: #041110;
-  background: linear-gradient(90deg, rgba(20, 184, 166, .95), rgba(245, 158, 11, .88));
+  background: linear-gradient(90deg,
+    color-mix(in oklab, var(--accent) 96%, transparent),
+    color-mix(in oklab, var(--accent-3) 92%, transparent));
   border-color: transparent;
   box-shadow: 0 20px 40px rgba(16, 185, 129, .32);
 }
@@ -1737,7 +1757,7 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
   border-radius: 26px;
   background:
     radial-gradient(140% 180% at 6% 0%, rgba(14, 184, 166, .18), transparent 70%),
-    radial-gradient(160% 180% at 96% 18%, rgba(245, 158, 11, .2), transparent 68%),
+    radial-gradient(160% 180% at 96% 18%, color-mix(in oklab, var(--accent-3) 24%, transparent), transparent 68%),
     linear-gradient(180deg, rgba(8, 18, 32, .95), rgba(8, 14, 26, .92));
   border: 1px solid rgba(20, 184, 166, .3);
   padding: 32px;

--- a/server/web/bot.html
+++ b/server/web/bot.html
@@ -225,7 +225,7 @@
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -288,7 +288,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -26,37 +26,118 @@
     const shortDate = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
     const $ = (sel) => document.querySelector(sel);
 
-    function canonicalCompany(company) {
-      const trimmed = (company || 'OpenAI').trim();
-      return trimmed ? trimmed : 'OpenAI';
+    const COMPANY_ICON_DATA = {
+      openai:      { path: '/web/img/openai.svg', alt: 'OpenAI' },
+      deepseek:    { path: '/web/img/deepseek-color.svg', alt: 'DeepSeek' },
+      xai:         { path: '/web/img/xai.svg', alt: 'xAI' },
+      anthropic:   { path: '/web/img/anthropic.svg', alt: 'Anthropic' },
+      meta:        { path: '/web/img/meta.svg', alt: 'Meta' },
+      google:      { path: '/web/img/google.svg', alt: 'Google' },
+      mistral:     { path: '/web/img/mistral.svg', alt: 'Mistral' },
+      groq:        { path: '/web/img/groq.svg', alt: 'Groq' },
+      together:    { path: '/web/img/together.svg', alt: 'Together' },
+      perplexity:  { path: '/web/img/perplexity.svg', alt: 'Perplexity' },
+      azure:       { path: '/web/img/azure.svg', alt: 'Azure' },
+      openrouter:  { path: '/web/img/openrouter.svg', alt: 'OpenRouter' },
+      cohere:      { path: '/web/img/cohere.svg', alt: 'Cohere' },
+      fireworks:   { path: '/web/img/fireworks.svg', alt: 'Fireworks' },
+      qwen:        { path: '/web/img/qwen.svg', alt: 'Qwen' },
+    };
+
+    const COMPANY_ALIAS = {
+      llama: 'meta',
+      llamaii: 'meta',
+      grok: 'xai',
+      'xai': 'xai',
+      'x.ai': 'xai',
+      gemini: 'google',
+    };
+
+    const COMPANY_LABELS = {
+      openai: 'OpenAI',
+      deepseek: 'DeepSeek',
+      xai: 'xAI',
+      anthropic: 'Anthropic',
+      meta: 'Meta',
+      google: 'Google',
+      mistral: 'Mistral',
+      groq: 'Groq',
+      together: 'Together',
+      perplexity: 'Perplexity',
+      azure: 'Azure',
+      openrouter: 'OpenRouter',
+      cohere: 'Cohere',
+      fireworks: 'Fireworks',
+      qwen: 'Qwen',
+    };
+
+    function slugifyCompany(value) {
+      return String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
     }
 
-    function companyKey(company) {
-      return canonicalCompany(company).toLowerCase();
+    function prettyCompanyName(value) {
+      const slug = slugifyCompany(value);
+      if (COMPANY_LABELS[slug]) return COMPANY_LABELS[slug];
+      if (!value) return '';
+      return String(value)
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/\b\w/g, ch => ch.toUpperCase());
     }
 
-    function openaiIconMarkup() {
-      return '<img class="org-icon" src="/web/img/openai.svg" alt="OpenAI"/>';
+    function extractOpenRouterVendor(model) {
+      if (!model) return '';
+      const match = String(model).match(/openrouter[\\/:|-]+([A-Za-z0-9_.-]+)/i);
+      if (match && match[1]) return match[1];
+      const parts = String(model)
+        .split(/[\\/:]/)
+        .map(part => part.trim())
+        .filter(Boolean);
+      if (!parts.length) return '';
+      const idx = parts.findIndex(part => part.toLowerCase() === 'openrouter');
+      if (idx >= 0) {
+        if (parts[idx + 1]) return parts[idx + 1];
+        if (idx > 0) return parts[idx - 1];
+      }
+      return '';
+    }
+
+    function resolveCompanyMeta(company, model) {
+      const rawCompany = String(company || '').trim();
+      const lowerCompany = rawCompany.toLowerCase();
+      const modelStr = String(model || '').trim();
+      const lowerModel = modelStr.toLowerCase();
+      let vendor = '';
+      if (!rawCompany || lowerCompany === 'openrouter') {
+        vendor = extractOpenRouterVendor(modelStr);
+      }
+      const fallback = lowerModel.includes('openrouter') ? 'OpenRouter' : 'OpenAI';
+      const primary = vendor || rawCompany || fallback;
+      let slug = slugifyCompany(primary);
+      if (slug === 'openrouter' && vendor) {
+        slug = slugifyCompany(vendor);
+      }
+      if (COMPANY_ALIAS[slug]) slug = COMPANY_ALIAS[slug];
+      if (!slug) slug = 'openai';
+      const labelSource = vendor || rawCompany || primary;
+      const label = COMPANY_LABELS[slug] || prettyCompanyName(labelSource) || 'OpenAI';
+      return { slug, label };
+    }
+
+    function canonicalCompany(company, model) {
+      return resolveCompanyMeta(company, model).label;
     }
 
     function companyIconMarkup(company, model) {
-      const c = (company || '').trim().toLowerCase();
-      const m = (model || '').trim().toLowerCase();
-      if (!c || c === 'openai') return openaiIconMarkup();
-      const inc = (s) => c.includes(s) || m.startsWith(`${s}/`) || m.includes(`/${s}`);
-      if (inc('deepseek')) return '<img class="org-icon" src="/web/img/deepseek-color.svg" alt="DeepSeek"/>';
-      if (inc('xai') || inc('grok')) return '<img class="org-icon" src="/web/img/xai.svg" alt="xAI"/>';
-      if (inc('anthropic')) return '<img class="org-icon" src="/web/img/anthropic.svg" alt="Anthropic"/>';
-      if (inc('meta') || inc('llama')) return '<img class="org-icon" src="/web/img/meta.svg" alt="Meta"/>';
-      if (inc('google') || inc('gemini')) return '<img class="org-icon" src="/web/img/google.svg" alt="Google"/>';
-      if (inc('mistral')) return '<img class="org-icon" src="/web/img/mistral.svg" alt="Mistral"/>';
-      if (inc('groq')) return '<img class="org-icon" src="/web/img/groq.svg" alt="Groq"/>';
-      if (inc('together')) return '<img class="org-icon" src="/web/img/together.svg" alt="Together"/>';
-      if (inc('perplexity')) return '<img class="org-icon" src="/web/img/perplexity.svg" alt="Perplexity"/>';
-      if (inc('azure')) return '<img class="org-icon" src="/web/img/azure.svg" alt="Azure"/>';
-      if (inc('openrouter')) return '<img class="org-icon" src="/web/img/openrouter.svg" alt="OpenRouter"/>';
-      if (inc('cohere')) return '<img class="org-icon" src="/web/img/cohere.svg" alt="Cohere"/>';
-      if (inc('fireworks')) return '<img class="org-icon" src="/web/img/fireworks.svg" alt="Fireworks"/>';
+      const meta = resolveCompanyMeta(company, model);
+      const icon = COMPANY_ICON_DATA[meta.slug];
+      if (icon) {
+        return `<img class="org-icon" src="${icon.path}" alt="${icon.alt}"/>`;
+      }
       return '<span class="org-icon org-icon--dot" aria-hidden="true"></span>';
     }
 
@@ -116,8 +197,10 @@
       const trimmedModel = trimModelName(meta.model || '');
       const pieces = [];
       if (trimmedModel) pieces.push(trimmedModel);
-      const canonical = (meta.company || '').trim() ? canonicalCompany(meta.company) : '';
-      const company = canonical;
+      let company = '';
+      if ((meta.company || '').trim() || (meta.model || '').trim()) {
+        company = canonicalCompany(meta.company, meta.model);
+      }
       const lowerModel = trimmedModel.toLowerCase();
       const lowerCompany = company.toLowerCase();
       const includeCompany = Boolean(company) && !lowerModel.includes(lowerCompany);
@@ -185,25 +268,27 @@
       rows.forEach(r => {
         if (r.bot_id == null) return;
         const model = (r.model || '').trim();
-        const company = canonicalCompany(r.company);
+        const metaInfo = resolveCompanyMeta(r.company, model);
+        const companyLabel = metaInfo.label;
+        const companySlug = metaInfo.slug || 'openai';
         let entry = map.get(r.bot_id);
         if (!entry) {
           entry = {
             botId: r.bot_id,
             meta: {
               model,
-              company,
-              companyKey: companyKey(company),
-              iconMarkup: companyIconMarkup(company, model)
+              company: companyLabel,
+              companyKey: companySlug,
+              iconMarkup: companyIconMarkup(r.company, model)
             },
             pts: []
           };
           map.set(r.bot_id, entry);
         } else {
           entry.meta.model = model || entry.meta.model;
-          entry.meta.company = company;
-          entry.meta.companyKey = companyKey(company);
-          entry.meta.iconMarkup = companyIconMarkup(company, model || entry.meta.model);
+          entry.meta.company = companyLabel;
+          entry.meta.companyKey = companySlug;
+          entry.meta.iconMarkup = companyIconMarkup(r.company, model || entry.meta.model);
         }
         const when = new Date(r.when);
         if (Number.isNaN(when.getTime())) return;
@@ -220,7 +305,7 @@
         if (!map.has(key)) {
           map.set(key, {
             key,
-            label: canonicalCompany(entry.meta.company),
+            label: entry.meta.company,
             iconMarkup: entry.meta.iconMarkup
           });
         }
@@ -521,7 +606,7 @@
         modelEl.textContent = plot.meta.model || 'Unknown';
         const companyEl = document.createElement('span');
         companyEl.className = 'chart-legend__company';
-        companyEl.textContent = canonicalCompany(plot.meta.company);
+        companyEl.textContent = plot.meta.company || 'Unknown';
         textWrap.appendChild(modelEl);
         textWrap.appendChild(companyEl);
 
@@ -800,7 +885,7 @@
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -822,7 +907,7 @@
       <div class="elo-card__header">
         <div class="elo-card__intro">
           <div class="elo-card__brand">
-            <span class="elo-card__logo">
+            <span class="elo-card__logo logo-badge logo-badge--md">
               <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
             </span>
             <div class="elo-card__heading">
@@ -853,7 +938,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -43,7 +43,7 @@
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -91,7 +91,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -17,7 +17,7 @@
     <div class="topnav">
       <div class="topnav__cluster">
         <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-          <span class="brand__mark">
+          <span class="brand__mark logo-badge logo-badge--sm">
             <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
           </span>
           <span class="brand__text">PokerBench</span>
@@ -40,7 +40,9 @@
         <div class="hero__grid">
           <div class="hero__intro">
             <div class="hero__brand">
-              <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo">
+              <span class="logo-badge logo-badge--lg">
+                <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+              </span>
               <div>
                 <div class="hero__eyebrow">AI Poker Benchmark</div>
                 <h1 class="hero__title">PokerBench</h1>
@@ -121,7 +123,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">
@@ -162,30 +166,116 @@
       return s;
     }
 
-    function canonicalCompany(company = 'OpenAI') {
-      const trimmed = String(company ?? '').trim();
-      return trimmed ? trimmed : 'OpenAI';
+    const COMPANY_ICON_DATA = {
+      openai:      { path: '/web/img/openai.svg', alt: 'OpenAI' },
+      deepseek:    { path: '/web/img/deepseek-color.svg', alt: 'DeepSeek' },
+      xai:         { path: '/web/img/xai.svg', alt: 'xAI' },
+      anthropic:   { path: '/web/img/anthropic.svg', alt: 'Anthropic' },
+      meta:        { path: '/web/img/meta.svg', alt: 'Meta' },
+      google:      { path: '/web/img/google.svg', alt: 'Google' },
+      mistral:     { path: '/web/img/mistral.svg', alt: 'Mistral' },
+      groq:        { path: '/web/img/groq.svg', alt: 'Groq' },
+      together:    { path: '/web/img/together.svg', alt: 'Together' },
+      perplexity:  { path: '/web/img/perplexity.svg', alt: 'Perplexity' },
+      azure:       { path: '/web/img/azure.svg', alt: 'Azure' },
+      openrouter:  { path: '/web/img/openrouter.svg', alt: 'OpenRouter' },
+      cohere:      { path: '/web/img/cohere.svg', alt: 'Cohere' },
+      fireworks:   { path: '/web/img/fireworks.svg', alt: 'Fireworks' },
+      qwen:        { path: '/web/img/qwen.svg', alt: 'Qwen' },
+    };
+
+    const COMPANY_ALIAS = {
+      llama: 'meta',
+      llamaii: 'meta',
+      grok: 'xai',
+      'xai': 'xai',
+      'x.ai': 'xai',
+      gemini: 'google',
+    };
+
+    const COMPANY_LABELS = {
+      openai: 'OpenAI',
+      deepseek: 'DeepSeek',
+      xai: 'xAI',
+      anthropic: 'Anthropic',
+      meta: 'Meta',
+      google: 'Google',
+      mistral: 'Mistral',
+      groq: 'Groq',
+      together: 'Together',
+      perplexity: 'Perplexity',
+      azure: 'Azure',
+      openrouter: 'OpenRouter',
+      cohere: 'Cohere',
+      fireworks: 'Fireworks',
+      qwen: 'Qwen',
+    };
+
+    function slugifyCompany(value) {
+      return String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+    }
+
+    function prettyCompanyName(value) {
+      const slug = slugifyCompany(value);
+      if (COMPANY_LABELS[slug]) return COMPANY_LABELS[slug];
+      if (!value) return '';
+      return String(value)
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/\b\w/g, ch => ch.toUpperCase());
+    }
+
+    function extractOpenRouterVendor(model) {
+      if (!model) return '';
+      const match = String(model).match(/openrouter[\\/:|-]+([A-Za-z0-9_.-]+)/i);
+      if (match && match[1]) return match[1];
+      const parts = String(model)
+        .split(/[\\/:]/)
+        .map(part => part.trim())
+        .filter(Boolean);
+      if (!parts.length) return '';
+      const idx = parts.findIndex(part => part.toLowerCase() === 'openrouter');
+      if (idx >= 0) {
+        if (parts[idx + 1]) return parts[idx + 1];
+        if (idx > 0) return parts[idx - 1];
+      }
+      return '';
+    }
+
+    function resolveCompanyMeta(company, model) {
+      const rawCompany = String(company || '').trim();
+      const lowerCompany = rawCompany.toLowerCase();
+      const modelStr = String(model || '').trim();
+      const lowerModel = modelStr.toLowerCase();
+      let vendor = '';
+      if (!rawCompany || lowerCompany === 'openrouter') {
+        vendor = extractOpenRouterVendor(modelStr);
+      }
+      const fallback = lowerModel.includes('openrouter') ? 'OpenRouter' : 'OpenAI';
+      const primary = vendor || rawCompany || fallback;
+      let slug = slugifyCompany(primary);
+      if (slug === 'openrouter' && vendor) {
+        slug = slugifyCompany(vendor);
+      }
+      if (COMPANY_ALIAS[slug]) slug = COMPANY_ALIAS[slug];
+      if (!slug) slug = 'openai';
+      const labelSource = vendor || rawCompany || primary;
+      const label = COMPANY_LABELS[slug] || prettyCompanyName(labelSource) || 'OpenAI';
+      return { slug, label };
+    }
+
+    function canonicalCompany(company, model) {
+      return resolveCompanyMeta(company, model).label;
     }
 
     function companyIconPath(company, model) {
-      const c = (company || '').trim().toLowerCase();
-      const m = (model || '').trim().toLowerCase();
-      const matches = (needle) => c.includes(needle) || m.startsWith(`${needle}/`) || m.includes(`/${needle}`);
-      if (!c || c === 'openai') return '/web/img/openai.svg';
-      if (matches('deepseek')) return '/web/img/deepseek-color.svg';
-      if (matches('xai') || matches('grok')) return '/web/img/xai.svg';
-      if (matches('anthropic')) return '/web/img/anthropic.svg';
-      if (matches('meta') || matches('llama')) return '/web/img/meta.svg';
-      if (matches('google') || matches('gemini')) return '/web/img/google.svg';
-      if (matches('mistral')) return '/web/img/mistral.svg';
-      if (matches('groq')) return '/web/img/groq.svg';
-      if (matches('together')) return '/web/img/together.svg';
-      if (matches('perplexity')) return '/web/img/perplexity.svg';
-      if (matches('azure')) return '/web/img/azure.svg';
-      if (matches('openrouter')) return '/web/img/openrouter.svg';
-      if (matches('cohere')) return '/web/img/cohere.svg';
-      if (matches('fireworks')) return '/web/img/fireworks.svg';
-      return null;
+      const meta = resolveCompanyMeta(company, model);
+      const icon = COMPANY_ICON_DATA[meta.slug];
+      return icon ? icon.path : null;
     }
 
     function iconTitle(meta) {
@@ -448,7 +538,7 @@
         const participantMeta = {};
         const participants = (d.participants || []).map(p => {
           const label = String(p.label ?? '').trim();
-          const company = canonicalCompany(p.company);
+          const company = canonicalCompany(p.company, p.model);
           if (label) {
             participantMeta[label] = {
               label,
@@ -493,7 +583,7 @@
           metaMap.A = {
             label: 'A',
             model: A.model || '',
-            company: '',
+            company: canonicalCompany('', A.model),
             icon: companyIconPath('', A.model),
           };
         }
@@ -501,7 +591,7 @@
           metaMap.B = {
             label: 'B',
             model: B.model || '',
-            company: '',
+            company: canonicalCompany('', B.model),
             icon: companyIconPath('', B.model),
           };
         }

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -19,10 +19,110 @@
     const $   = s => document.querySelector(s);
     const fmt = n => Number(n||0).toLocaleString();
     const escapeHtml = (s = '') => s.replace(/[&<>"']/g, ch => ({ '&':'&amp;', '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;' }[ch]));
-    const canonicalCompany = (company) => {
-      const trimmed = (company || 'OpenAI').trim();
-      return trimmed || 'OpenAI';
+
+    const COMPANY_ICON_DATA = {
+      openai:      { path: '/web/img/openai.svg', alt: 'OpenAI' },
+      deepseek:    { path: '/web/img/deepseek-color.svg', alt: 'DeepSeek' },
+      xai:         { path: '/web/img/xai.svg', alt: 'xAI' },
+      anthropic:   { path: '/web/img/anthropic.svg', alt: 'Anthropic' },
+      meta:        { path: '/web/img/meta.svg', alt: 'Meta' },
+      google:      { path: '/web/img/google.svg', alt: 'Google' },
+      mistral:     { path: '/web/img/mistral.svg', alt: 'Mistral' },
+      groq:        { path: '/web/img/groq.svg', alt: 'Groq' },
+      together:    { path: '/web/img/together.svg', alt: 'Together' },
+      perplexity:  { path: '/web/img/perplexity.svg', alt: 'Perplexity' },
+      azure:       { path: '/web/img/azure.svg', alt: 'Azure' },
+      openrouter:  { path: '/web/img/openrouter.svg', alt: 'OpenRouter' },
+      cohere:      { path: '/web/img/cohere.svg', alt: 'Cohere' },
+      fireworks:   { path: '/web/img/fireworks.svg', alt: 'Fireworks' },
+      qwen:        { path: '/web/img/qwen.svg', alt: 'Qwen' },
     };
+
+    const COMPANY_ALIAS = {
+      llama: 'meta',
+      llamaii: 'meta',
+      grok: 'xai',
+      'xai': 'xai',
+      'x.ai': 'xai',
+      gemini: 'google',
+    };
+
+    const COMPANY_LABELS = {
+      openai: 'OpenAI',
+      deepseek: 'DeepSeek',
+      xai: 'xAI',
+      anthropic: 'Anthropic',
+      meta: 'Meta',
+      google: 'Google',
+      mistral: 'Mistral',
+      groq: 'Groq',
+      together: 'Together',
+      perplexity: 'Perplexity',
+      azure: 'Azure',
+      openrouter: 'OpenRouter',
+      cohere: 'Cohere',
+      fireworks: 'Fireworks',
+      qwen: 'Qwen',
+    };
+
+    function slugifyCompany(value) {
+      return String(value || '')
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '');
+    }
+
+    function prettyCompanyName(value) {
+      const slug = slugifyCompany(value);
+      if (COMPANY_LABELS[slug]) return COMPANY_LABELS[slug];
+      if (!value) return '';
+      return String(value)
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .replace(/\b\w/g, ch => ch.toUpperCase());
+    }
+
+    function extractOpenRouterVendor(model) {
+      if (!model) return '';
+      const match = String(model).match(/openrouter[\\/:|-]+([A-Za-z0-9_.-]+)/i);
+      if (match && match[1]) return match[1];
+      const parts = String(model)
+        .split(/[\\/:]/)
+        .map(part => part.trim())
+        .filter(Boolean);
+      if (!parts.length) return '';
+      const idx = parts.findIndex(part => part.toLowerCase() === 'openrouter');
+      if (idx >= 0) {
+        if (parts[idx + 1]) return parts[idx + 1];
+        if (idx > 0) return parts[idx - 1];
+      }
+      return '';
+    }
+
+    function resolveCompanyMeta(company, model) {
+      const rawCompany = String(company || '').trim();
+      const lowerCompany = rawCompany.toLowerCase();
+      const modelStr = String(model || '').trim();
+      const lowerModel = modelStr.toLowerCase();
+      let vendor = '';
+      if (!rawCompany || lowerCompany === 'openrouter') {
+        vendor = extractOpenRouterVendor(modelStr);
+      }
+      const fallback = lowerModel.includes('openrouter') ? 'OpenRouter' : 'OpenAI';
+      const primary = vendor || rawCompany || fallback;
+      let slug = slugifyCompany(primary);
+      if (slug === 'openrouter' && vendor) {
+        slug = slugifyCompany(vendor);
+      }
+      if (COMPANY_ALIAS[slug]) slug = COMPANY_ALIAS[slug];
+      if (!slug) slug = 'openai';
+      const labelSource = vendor || rawCompany || primary;
+      const label = COMPANY_LABELS[slug] || prettyCompanyName(labelSource) || 'OpenAI';
+      return { slug, label };
+    }
+
+    const canonicalCompany = (company, model) => resolveCompanyMeta(company, model).label;
     const dateFmt = (iso) => {
       const d = new Date(iso);
       return d.toLocaleString([], { year:'numeric', month:'short', day:'2-digit', hour:'2-digit', minute:'2-digit' });
@@ -74,7 +174,7 @@
       }
       const total = Number(stats.total);
       if (!Number.isFinite(total) || total <= 0) {
-        return { hasData: false, display: 'n/a', ratio: 0, good: Number(stats.good || 0), total: 0 };
+        return { hasData: false, display: '—', ratio: 0, good: Number(stats.good || 0), total: 0 };
       }
       const good = Number(stats.good || 0);
       const ratioRaw = Number.isFinite(stats.acc) ? stats.acc : (total > 0 ? good / total : 0);
@@ -83,33 +183,17 @@
       return { hasData: true, display: `${pct}% (${good}/${total})`, ratio, good, total };
     }
 
-        function openaiIcon(){
-          return '<img class="org-icon" src="/web/img/openai.svg" alt="OpenAI"/>';
-    }
-
     function companyIconMarkup(company, model){
-      const c = (company||'').trim().toLowerCase();
-      const m = (model||'').trim().toLowerCase();
-      if (!c || c === 'openai') return openaiIcon();
-      const inc = (s)=> c.includes(s) || m.startsWith(s+'/') || m.includes('/'+s);
-      if (inc('deepseek')) return '<img class="org-icon" src="/web/img/deepseek-color.svg" alt="DeepSeek"/>';
-      if (inc('xai') || inc('grok')) return '<img class="org-icon" src="/web/img/xai.svg" alt="xAI"/>';
-      if (inc('anthropic')) return '<img class="org-icon" src="/web/img/anthropic.svg" alt="Anthropic"/>';
-      if (inc('meta') || inc('llama')) return '<img class="org-icon" src="/web/img/meta.svg" alt="Meta"/>';
-      if (inc('google') || inc('gemini')) return '<img class="org-icon" src="/web/img/google.svg" alt="Google"/>';
-      if (inc('mistral')) return '<img class="org-icon" src="/web/img/mistral.svg" alt="Mistral"/>';
-      if (inc('groq')) return '<img class="org-icon" src="/web/img/groq.svg" alt="Groq"/>';
-      if (inc('together')) return '<img class="org-icon" src="/web/img/together.svg" alt="Together"/>';
-      if (inc('perplexity')) return '<img class="org-icon" src="/web/img/perplexity.svg" alt="Perplexity"/>';
-      if (inc('azure')) return '<img class="org-icon" src="/web/img/azure.svg" alt="Azure"/>';
-      if (inc('openrouter')) return '<img class="org-icon" src="/web/img/openrouter.svg" alt="OpenRouter"/>';
-      if (inc('cohere')) return '<img class="org-icon" src="/web/img/cohere.svg" alt="Cohere"/>';
-      if (inc('fireworks')) return '<img class="org-icon" src="/web/img/fireworks.svg" alt="Fireworks"/>';
+      const meta = resolveCompanyMeta(company, model);
+      const icon = COMPANY_ICON_DATA[meta.slug];
+      if (icon) {
+        return `<img class="org-icon" src="${icon.path}" alt="${icon.alt}"/>`;
+      }
       return '<span class="org-icon org-icon--dot" aria-hidden="true"></span>';
     }
 
     function orgCell(company, model){
-      const label = escapeHtml(canonicalCompany(company));
+      const label = escapeHtml(canonicalCompany(company, model));
       const icon = companyIconMarkup(company, model);
       return `<span class="lb-org">${icon}<span class="txt">${label}</span></span>`;
     }
@@ -139,7 +223,7 @@ function rowHTML(i, r){
         <td>${orgCell(r.company, r.model)}</td>
         <td class="num">${fmt(hands)}</td>
         <td class="num">${Math.max(0,Math.min(100, Number(r.win_rate_pct||0)))}%<span class="sub">${ciTxt}</span></td>
-        <td class="num">${judge.hasData ? judge.display : 'n/a'}</td>
+        <td class="num">${judge.hasData ? judge.display : '—'}</td>
         <td class="num">${fmt(r.net_chips)}</td>
         <td class="sub">${r.updated_at ? dateFmt(r.updated_at) : 'n/a'}</td>
       </tr>`;
@@ -237,19 +321,24 @@ function rowHTML(i, r){
             const stats = judgeStatsFor(botId, row);
             const host = tr.querySelector('.lb-model');
             if (host){
-              let pill = host.querySelector('.pill.ghost');
-              if (!pill){
-                pill = document.createElement('span');
-                pill.className='pill ghost';
-                pill.style.marginLeft='6px';
-                host.appendChild(pill);
+              const existing = host.querySelector('.pill.ghost');
+              if (stats.hasData) {
+                let pill = existing;
+                if (!pill){
+                  pill = document.createElement('span');
+                  pill.className='pill ghost';
+                  pill.style.marginLeft='6px';
+                  host.appendChild(pill);
+                }
+                pill.title = `EV judge accuracy (${stats.good}/${stats.total})`;
+                pill.textContent = stats.display;
+              } else if (existing) {
+                existing.remove();
               }
-              pill.title = stats.hasData ? `EV judge accuracy (${stats.good}/${stats.total})` : 'EV judge accuracy (no data yet)';
-              pill.textContent = stats.hasData ? stats.display : 'n/a';
             }
             const tds = tr.querySelectorAll('td');
             if (tds.length >= 7){
-              tds[6].innerHTML = stats.hasData ? stats.display : 'n/a';
+              tds[6].textContent = stats.hasData ? stats.display : '—';
             }
           });
         }catch{}
@@ -282,7 +371,7 @@ function rowHTML(i, r){
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -345,7 +434,9 @@ function rowHTML(i, r){
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">

--- a/server/web/live.html
+++ b/server/web/live.html
@@ -35,7 +35,7 @@
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -69,7 +69,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -70,7 +70,7 @@
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -100,7 +100,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -293,7 +293,7 @@
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">
-        <span class="brand__mark">
+        <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
@@ -376,7 +376,9 @@
   <footer class="site-footer">
     <div class="site-footer__inner">
       <a class="site-footer__brand" href="/web/index.html">
-        <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        <span class="logo-badge logo-badge--sm">
+          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
+        </span>
         <span>PokerBench</span>
       </a>
       <nav class="site-footer__nav" aria-label="Footer">


### PR DESCRIPTION
## Summary
- retune the site palette to remove orange accents, introduce a reusable logo badge treatment, and freshen gradients across components
- derive vendor metadata for OpenRouter-backed bots so leaderboards, the homepage, and the Elo view show the source organization icon and label
- streamline leaderboard judge accuracy rendering by skipping empty pills and displaying an em dash instead of the glitchy hidden "n/a"

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cc9ddc3e30832d93e900b36f7f1986