### PR TITLE
Align secrets workflow for OpenRouter support

### DIFF
--- a/compose.env.example
+++ b/compose.env.example
@@ -24,8 +24,7 @@ OPENAI_MODEL=gpt-4o-mini
 # OpenRouter example (routes to many vendors via one key)
 # OPENAI_API_BASE=https://openrouter.ai/api/v1
 # LLM_COMPANY=OpenRouter
-# OPENROUTER_API_KEY=or-key-...
-# OPENROUTER_API_KEY_FILE=./secrets/openrouter_api_key.txt
+# OPENROUTER_API_KEY=or-key-...            # or drop the key in ./secrets/openrouter_api_key.txt
 # OPENROUTER_SITE_URL=https://your-site.example.com
 # OPENROUTER_TITLE=PokerBench
 # Models will be like: anthropic/claude-3.5-sonnet, google/gemini-1.5-pro, meta-llama/llama-3.1-405b-instruct
@@ -55,11 +54,9 @@ USE_COLOR=1
 # OPENAI_MODELS=gpt-4o-mini,gpt-5-mini,gpt-4.1-mini-2025-04-14
 
 # Secrets
-# To mount a key via Docker secrets, set OPENAI_API_SECRET_FILE to the path on your host
-# (defaults to ./secrets/openai_api_key.txt), and place your key on a single line in that file.
-# The container will read it from /run/secrets/openai_api_key automatically.
-# OPENAI_API_SECRET_FILE=./secrets/openai_api_key.txt
-# OPENROUTER_API_SECRET_FILE=./secrets/openrouter_api_key.txt
+# Place provider keys inside ./secrets (Docker Compose mounts it automatically).
+# printf 'sk-...' > ./secrets/openai_api_key.txt
+# printf 'or-key-...' > ./secrets/openrouter_api_key.txt
 # Or, for local runs without Docker, export directly:
 # OPENAI_API_KEY=sk-...
 # OPENROUTER_API_KEY=or-key-...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,3 @@
-secrets:
-  openai_api_key:
-    file: ${OPENAI_API_SECRET_FILE:-./secrets/openai_api_key.txt}   # one line: your API key (not committed)
-
 services:
   db:
     image: postgres:16-alpine
@@ -18,21 +14,20 @@ services:
       retries: 10
     volumes:
       - pgdata:/var/lib/postgresql/data
+      - ./secrets:/app/secrets:ro
 
   app:
     build:
       context: .
       dockerfile: Dockerfile
-    secrets:
-      - openai_api_key
     env_file:
       - ${ENV_FILE:-compose.env}        # set ENV_FILE to choose a different env
-    environment:
-      OPENAI_API_KEY_FILE: /run/secrets/openai_api_key
     depends_on:
       db:
         condition: service_healthy
     ports: ["8080:8080"]
+    volumes:
+      - ./secrets:/app/secrets:ro
     command: ["/app/ai-thunderdome"]    # server mode
     restart: unless-stopped
 
@@ -40,30 +35,26 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    secrets:
-      - openai_api_key
     env_file:
       - ${ENV_FILE:-compose.env}
-    environment:
-      OPENAI_API_KEY_FILE: /run/secrets/openai_api_key
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - ./secrets:/app/secrets:ro
     command: ["/app/ai-thunderdome", "--duel"]
 
   migrate:
     build:
       context: .
       dockerfile: Dockerfile
-    secrets:
-      - openai_api_key
     env_file:
       - ${ENV_FILE:-compose.env}
-    environment:
-      OPENAI_API_KEY_FILE: /run/secrets/openai_api_key
     depends_on:
       db:
         condition: service_healthy
+    volumes:
+      - ./secrets:/app/secrets:ro
     command: ["/app/ai-thunderdome", "--migrate"]
     restart: "no"
 


### PR DESCRIPTION
## Summary
- make the API key bootstrap prefer OpenRouter hints when the base URL targets OpenRouter while still mirroring into OPENAI_API_KEY
- mount the local ./secrets directory into every Compose service and remove the Docker secret indirection
- document the co-located OpenAI/OpenRouter secret workflow in the README and sample compose environment

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cca54b57ac832dbb3a896268b134a5