### PR TITLE
Refine leaderboard snapshot and update card styling

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -491,6 +491,13 @@ pre { background: var(--slate-3); border: 1px solid var(--border); border-radius
   justify-content: center;
 }
 .brand__mark.logo-badge { --logo-badge-size: clamp(36px, 2.6vw, 44px); }
+.page-elo .topnav .logo-badge img,
+.page-elo .site-footer__brand .logo-badge img {
+  width: 88%;
+}
+.page-elo .site-footer__brand .logo-badge img {
+  width: 92%;
+}
 .brand__text {
   font-size: clamp(1.05rem, 0.95rem + .4vw, 1.35rem);
   letter-spacing: .04em;
@@ -1209,11 +1216,13 @@ svg text { fill: color-mix(in oklab, var(--muted) 82%, transparent); font-family
 .cardx .back{
   border:6px solid #fff;   /* standard frame */
   transform: rotateY(0deg);
-  background: conic-gradient(
-    var(--card-darkBg) 25%, var(--card-lightBg) 25%,
-    var(--card-lightBg) 50%, var(--card-darkBg) 50%,
-    var(--card-darkBg) 75%, var(--card-lightBg) 75%);
-  background-size:20px 20px; border-radius:10px;
+  background-color:#0f5e2a;
+  background-image:
+    linear-gradient(45deg, rgba(255,255,255,.92) 25%, transparent 25%, transparent 75%, rgba(255,255,255,.92) 75%, rgba(255,255,255,.92)),
+    linear-gradient(45deg, rgba(255,255,255,.92) 25%, transparent 25%, transparent 75%, rgba(255,255,255,.92) 75%, rgba(255,255,255,.92));
+  background-position: 0 0, 12px 12px;
+  background-size:24px 24px;
+  border-radius:10px;
 }
 
 /* JS toggles .flip to reveal */
@@ -1230,14 +1239,15 @@ svg text { fill: color-mix(in oklab, var(--muted) 82%, transparent); font-family
 .suit.main::after{ content:""; color:transparent; -webkit-background-clip:text; background-clip:text; }
 
 /* Suit colors + glyphs */
-.spade,.club{ color: var(--card-darkBlk); }
+.spade{ color:#111d2f; }
+.club{ color:#0f6b3d; }
 .heart,.diamond{ color: var(--card-darkRed); }
 .spade .suit::after{ content:'\2660'; } .heart .suit::after{ content:'\2665'; }
 .diamond .suit::after{ content:'\2666'; } .club .suit::after{ content:'\2663'; }
 
 /* Center suit gradients */
-.spade .suit.main::after{   background-image: linear-gradient(135deg, var(--card-darkBlk) 50%, var(--card-lightBlk) 50%); }
-.club  .suit.main::after{   background-image: linear-gradient(135deg, var(--card-darkBlk) 50%, var(--card-lightBlk) 50%); }
+.spade .suit.main::after{   background-image: linear-gradient(135deg, #0b1220 50%, #1f3148 50%); }
+.club  .suit.main::after{   background-image: linear-gradient(135deg, #10a95c 50%, #0b5033 50%); }
 .heart .suit.main::after{   background-image: linear-gradient(135deg, var(--card-darkRed) 50%, var(--card-lightRed) 50%); }
 .diamond .suit.main::after{ background-image: linear-gradient(135deg, var(--card-darkRed) 50%, var(--card-lightRed) 50%); }
 

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="/web/favicon.svg" type="image/svg+xml"/>
     <script>
     const palette = ['#4df6b4', '#76b0ff', '#ffd166', '#f08cf0', '#ff6d6d', '#9de7ff', '#c4f98b', '#b59bff'];
+    const MATCH_LEGEND_COLORS = ['#39d98a', '#d6c29b', '#76b0ff', '#f08cf0'];
     const state = {
       dims: { width: 1100, height: 440 },
       pad: { top: 48, right: 70, bottom: 64, left: 78 },
@@ -164,24 +165,19 @@
       return { label, model, company };
     }
 
-    function buildLegendEntry(slot, meta) {
+    function buildLegendEntry(meta, color) {
       const host = document.createElement('div');
       host.className = 'match-legend__item';
-      const color = slot === 'A' ? '#39d98a' : '#d6c29b';
-      host.style.setProperty('--legend-color', color);
+      const resolvedColor = color || MATCH_LEGEND_COLORS[0];
+      host.style.setProperty('--legend-color', resolvedColor);
 
       const swatch = document.createElement('span');
       swatch.className = 'match-legend__swatch';
-      swatch.style.background = color;
+      swatch.style.background = resolvedColor;
       host.appendChild(swatch);
 
       const details = document.createElement('div');
       details.className = 'match-legend__details';
-
-      const slotEl = document.createElement('span');
-      slotEl.className = 'match-legend__slot';
-      slotEl.textContent = slot;
-      details.appendChild(slotEl);
 
       const infoWrap = document.createElement('div');
       infoWrap.className = 'match-legend__info';
@@ -225,14 +221,20 @@
         const res = await fetch('/api/last-match');
         if (!res.ok) return;
         const data = await res.json();
-        const participants = Array.isArray(data?.participants) ? data.participants : [];
-        const map = new Map();
-        participants.forEach(p => {
-          const { label, model, company } = normalizeLegendMeta(p);
-          if (label) map.set(label, { label, model, company });
+        const participants = data && Array.isArray(data.participants) ? data.participants : [];
+        const built = [];
+        const seen = new Set();
+        participants.forEach(participant => {
+          const meta = normalizeLegendMeta(participant);
+          const hasDetails = (meta.model || '').trim() || (meta.company || '').trim();
+          if (!hasDetails) return;
+          const key = `${meta.model}::${meta.company}`;
+          if (seen.has(key)) return;
+          seen.add(key);
+          const color = MATCH_LEGEND_COLORS[built.length % MATCH_LEGEND_COLORS.length];
+          built.push(buildLegendEntry(meta, color));
         });
-        const slots = ['A', 'B'];
-        const entries = slots.map(slot => buildLegendEntry(slot, map.get(slot) || { label: slot, model: '', company: '' }));
+        const entries = built;
         const hasLegend = entries.some(entry => entry.hasInfo);
         if (!hasLegend) return;
         entries.forEach(entry => host.appendChild(entry.element));
@@ -881,7 +883,7 @@
     }
   </script>
 </head>
-<body>
+<body class="page-elo">
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/index.html" aria-label="PokerBench home">

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -143,6 +143,7 @@
     const $ = sel => document.querySelector(sel);
     const fmt = n => n.toLocaleString();
     const pct = n => `${Math.max(0, Math.round(n))}%`;
+    const MAX_LEADERBOARD_PREVIEW = 5;
     const safe = s => String(s ?? '').replace(/[&<>"']/g, ch => ({
       "&": "&amp;",
       "<": "&lt;",
@@ -657,7 +658,8 @@
         const res = await fetch('/api/leaderboard');
         if (!res.ok) throw new Error('bad status');
         const data = await res.json();
-        const rows = ((data && data.rows) || data || []).slice(0, 5);
+        const rawRows = Array.isArray(data && data.rows) ? data.rows : Array.isArray(data) ? data : [];
+        const rows = rawRows.slice(0, MAX_LEADERBOARD_PREVIEW);
         if (!rows.length) {
           empty.hidden = false;
           return;


### PR DESCRIPTION
## Summary
- ensure the leaderboard snapshot preview only renders the first five rows returned by the API
- remove the slot A/B badges from the Elo page legend while enlarging the on-page brand marks
- refresh card visuals with distinct club/spade colors and a green-and-white checkerboard card back

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68cca5ddd984832d9c21ab51da9a608e