### PR TITLE
Add explicit OpenRouter provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ DUEL_SEEDS=5 \
 ./ai-thunderdome --duel-matrix
 ```
 
+When routing through OpenRouter, set `LLM_PROVIDER=openrouter` and provide `OPENROUTER_MODELS` instead of `OPENAI_MODELS`.
+
 Windows-friendly PowerShell helpers live in `scripts/run-openai-pairwise.ps1` and `scripts/run-openai-matrix.ps1`.
 
 ---
@@ -170,8 +172,12 @@ Windows-friendly PowerShell helpers live in `scripts/run-openai-pairwise.ps1` an
 | `OPENROUTER_API_KEY` / `OPENROUTER_API_KEY_FILE` | Alternative secret for OpenRouter users (mirrors into `OPENAI_API_KEY`). | _(optional)_ |
 | `DATABASE_URL` | PostgreSQL DSN (`postgres://user:pass@host:port/db?sslmode=`). | `postgres://poker:poker@localhost:5432/thunderdome?sslmode=disable` |
 | `PORT` | HTTP port for the server mode. | `8080` |
+| `LLM_PROVIDER` | Force provider precedence (`openai` or `openrouter`). | derived |
 | `OPENAI_MODEL_A` / `OPENAI_MODEL_B` | Model identifiers for the A/B seats. | `OPENAI_MODEL` fallback |
 | `OPENAI_MODEL_SB` / `OPENAI_MODEL_BB` | Seat-specific overrides if you prefer SB/BB naming. | `OPENAI_MODEL` fallback |
+| `OPENROUTER_MODEL` | Shared OpenRouter identifier when routing via OpenRouter. | _(optional)_ |
+| `OPENROUTER_MODEL_A` / `OPENROUTER_MODEL_B` | Seat models for OpenRouter runs. | `OPENROUTER_MODEL` fallback |
+| `OPENROUTER_MODEL_SB` / `OPENROUTER_MODEL_BB` | SB/BB naming for OpenRouter-specific configs. | `OPENROUTER_MODEL` fallback |
 | `OPENAI_REASONING_EFFORT` | Attach provider-specific reasoning hint (e.g., `medium`, `high`). | unset |
 | `OPENAI_MAX_OUTPUT_TOKENS` | Hard cap on model responses. | provider default |
 | `LLM_COMPANY` | Label used in the UI (e.g., `OpenAI`, `Anthropic`). | derived |

--- a/compose.env.example
+++ b/compose.env.example
@@ -22,11 +22,16 @@ OPENAI_MODEL=gpt-4o-mini
 # LLM_COMPANY=OpenAI                     # label stored in DB (auto-detected from base if unset)
 
 # OpenRouter example (routes to many vendors via one key)
+# LLM_PROVIDER=openrouter
 # OPENAI_API_BASE=https://openrouter.ai/api/v1
 # LLM_COMPANY=OpenRouter
 # OPENROUTER_API_KEY=or-key-...            # or drop the key in ./secrets/openrouter_api_key.txt
 # OPENROUTER_SITE_URL=https://your-site.example.com
 # OPENROUTER_TITLE=PokerBench
+# OPENROUTER_MODEL=meta-llama/llama-3.1-70b-instruct
+# # Or specify seat assignments explicitly:
+# OPENROUTER_MODEL_A=meta-llama/llama-3.1-70b-instruct
+# OPENROUTER_MODEL_B=mistralai/mistral-nemo
 # Models will be like: anthropic/claude-3.5-sonnet, google/gemini-1.5-pro, meta-llama/llama-3.1-405b-instruct
 
 # Azure example
@@ -52,6 +57,7 @@ USE_COLOR=1
 
 # Batch duels (pairwise): used by --duel-matrix
 # OPENAI_MODELS=gpt-4o-mini,gpt-5-mini,gpt-4.1-mini-2025-04-14
+# OPENROUTER_MODELS=meta-llama/llama-3.1-70b-instruct,mistralai/mistral-nemo
 
 # Secrets
 # Place provider keys inside ./secrets (Docker Compose mounts it automatically).

--- a/server/llm/openrouter.go
+++ b/server/llm/openrouter.go
@@ -1,0 +1,143 @@
+package llm
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+type providerKind int
+
+const (
+	providerOpenAI providerKind = iota
+	providerOpenRouter
+)
+
+type apiConfig struct {
+	Kind         providerKind
+	APIKey       string
+	Model        string
+	BaseURL      string
+	HeaderName   string
+	HeaderPrefix string
+	Organization string
+	ExtraHeaders map[string]string
+}
+
+func resolveAPIConfig(model string) (apiConfig, error) {
+	cfg := apiConfig{
+		Model:        strings.TrimSpace(model),
+		ExtraHeaders: map[string]string{},
+	}
+
+	if preferOpenRouterEnv() {
+		cfg.Kind = providerOpenRouter
+	} else {
+		cfg.Kind = providerOpenAI
+	}
+
+	if override := strings.ToLower(strings.TrimSpace(os.Getenv("LLM_PROVIDER"))); override != "" {
+		switch override {
+		case "openrouter":
+			cfg.Kind = providerOpenRouter
+		case "openai":
+			cfg.Kind = providerOpenAI
+		}
+	}
+
+	base := firstNonEmpty(
+		os.Getenv("OPENAI_API_BASE"),
+		os.Getenv("OPENAI_BASE_URL"),
+		os.Getenv("OPENROUTER_API_BASE"),
+		os.Getenv("OPENROUTER_BASE_URL"),
+	)
+	base = strings.TrimSpace(base)
+	if base == "" {
+		if cfg.Kind == providerOpenRouter {
+			base = "https://openrouter.ai/api/v1"
+		} else {
+			base = "https://api.openai.com/v1"
+		}
+	}
+	cfg.BaseURL = strings.TrimRight(base, "/")
+	if strings.Contains(strings.ToLower(cfg.BaseURL), "openrouter") {
+		cfg.Kind = providerOpenRouter
+	}
+
+	openAIKey := strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	openRouterKey := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY"))
+	switch cfg.Kind {
+	case providerOpenRouter:
+		if openRouterKey != "" {
+			cfg.APIKey = openRouterKey
+		} else {
+			cfg.APIKey = openAIKey
+		}
+	default:
+		cfg.APIKey = openAIKey
+	}
+	if cfg.Kind == providerOpenRouter && openRouterKey != "" {
+		cfg.APIKey = openRouterKey
+	}
+	if cfg.APIKey == "" {
+		cfg.APIKey = openRouterKey
+	}
+	if cfg.APIKey == "" {
+		return apiConfig{}, errors.New("API key missing: set OPENAI_API_KEY or OPENROUTER_API_KEY")
+	}
+
+	headerName := strings.TrimSpace(os.Getenv("OPENAI_API_KEY_HEADER"))
+	if headerName == "" {
+		headerName = strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY_HEADER"))
+	}
+	if headerName == "" {
+		headerName = "Authorization"
+	}
+	prefix := os.Getenv("OPENAI_API_KEY_PREFIX")
+	if prefix == "" {
+		prefix = os.Getenv("OPENROUTER_API_KEY_PREFIX")
+	}
+	if headerName == "Authorization" && strings.TrimSpace(prefix) == "" {
+		prefix = "Bearer "
+	}
+	cfg.HeaderName = headerName
+	cfg.HeaderPrefix = prefix
+	cfg.Organization = strings.TrimSpace(os.Getenv("OPENAI_ORG"))
+
+	if cfg.Kind == providerOpenRouter {
+		if v := strings.TrimSpace(os.Getenv("OPENROUTER_SITE_URL")); v != "" {
+			cfg.ExtraHeaders["HTTP-Referer"] = v
+			cfg.ExtraHeaders["Referer"] = v
+		}
+		if v := strings.TrimSpace(os.Getenv("OPENROUTER_TITLE")); v != "" {
+			cfg.ExtraHeaders["X-Title"] = v
+		}
+	}
+
+	if cfg.Model == "" {
+		if cfg.Kind == providerOpenRouter {
+			cfg.Model = strings.TrimSpace(os.Getenv("OPENROUTER_MODEL"))
+		}
+		if cfg.Model == "" {
+			cfg.Model = strings.TrimSpace(os.Getenv("OPENAI_MODEL"))
+		}
+	}
+	if cfg.Model == "" {
+		return apiConfig{}, errors.New("model missing: set OPENAI_MODEL/OPENROUTER_MODEL or pass a value")
+	}
+
+	return cfg, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func PreferOpenRouter() bool {
+	return preferOpenRouterEnv()
+}


### PR DESCRIPTION
## Summary
- add a dedicated OpenRouter config path in the LLM layer and expose provider detection helpers
- update player/model loading plus duel matrix orchestration to honor OpenRouter-specific environment variables
- document the new environment knobs in the README and compose.env example

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ccab6a5a74832d831cd51b8b24fa24