### PR TITLE
Fix Elo chart color alignment and company sorting

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -943,8 +943,6 @@ table.leaderboard th.updated { white-space: nowrap; }
   border: 1px solid var(--border); border-radius: 10px;
 }
 #chart path { stroke-linecap: round; stroke-linejoin: round; filter: drop-shadow(0 0 1px rgba(0,0,0,.35)); }
-#chart path:nth-of-type(1){ stroke: var(--accent); }
-#chart path:nth-of-type(2){ stroke: var(--accent-2); }
 #chart circle { fill: color-mix(in oklab, var(--text) 88%, transparent); stroke: rgba(0,0,0,.35); stroke-width: .5; }
 #legend { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
 #legend .pill { border-color: rgba(20, 184, 166, .32); background: var(--surface-2); }
@@ -1844,7 +1842,6 @@ kbd { background: var(--slate-5); border:1px solid var(--border); border-bottom-
 .chart-marker {
   fill: rgba(255,255,255,.95);
   stroke-width: 3;
-  stroke: currentColor;
   filter: drop-shadow(0 0 8px rgba(0,0,0,.35));
   pointer-events: none;
 }

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -18,7 +18,6 @@
       currentSeries: [],
       companies: [],
       selectedCompany: 'all',
-      sortMode: 'latest',
       colorAssignments: new Map(),
       nextColorIndex: 0,
       resizeTimer: null,
@@ -161,6 +160,11 @@
       const vendor = lowerModel.includes('openrouter') ? extractOpenRouterVendor(modelStr) : '';
 
       const candidateStrings = [rawCompany, vendor];
+      if (modelStr) {
+        modelStr.split(/[^A-Za-z0-9]+/).forEach(part => {
+          if (part) candidateStrings.push(part);
+        });
+      }
       if (vendor) {
         vendor.split(/[^A-Za-z0-9]+/).forEach(part => {
           if (part) candidateStrings.push(part);
@@ -837,48 +841,26 @@
 
     function sortSeries(list) {
       const items = Array.isArray(list) ? list.slice() : [];
-      if (state.sortMode === 'company') {
-        return items.sort((a, b) => {
-          const aCompany = compareStrings(a.meta.company, b.meta.company);
-          if (aCompany !== 0) return aCompany;
-          const aModel = compareStrings(a.meta.model, b.meta.model);
-          if (aModel !== 0) return aModel;
-          return (a.botId || 0) - (b.botId || 0);
-        });
-      }
-      if (state.sortMode === 'model') {
-        return items.sort((a, b) => {
-          const aModel = compareStrings(a.meta.model, b.meta.model);
-          if (aModel !== 0) return aModel;
-          const aCompany = compareStrings(a.meta.company, b.meta.company);
-          if (aCompany !== 0) return aCompany;
-          return (a.botId || 0) - (b.botId || 0);
-        });
-      }
       return items.sort((a, b) => {
-        const aLast = a.pts.length ? a.pts[a.pts.length - 1].elo : -Infinity;
-        const bLast = b.pts.length ? b.pts[b.pts.length - 1].elo : -Infinity;
-        if (bLast !== aLast) return bLast - aLast;
-        return compareStrings(a.meta.model, b.meta.model);
+        const aCompany = compareStrings(a.meta.company, b.meta.company);
+        if (aCompany !== 0) return aCompany;
+        const aModel = compareStrings(a.meta.model, b.meta.model);
+        if (aModel !== 0) return aModel;
+        return (a.botId || 0) - (b.botId || 0);
       });
     }
 
     function bindSortControl() {
       const select = document.getElementById('sortMode');
       if (!select || select.dataset.bound === 'true') return;
-      select.addEventListener('change', () => {
-        const value = select.value || 'latest';
-        if (value === state.sortMode) return;
-        state.sortMode = value;
-        applyFilters();
-      });
+      select.value = 'company';
       select.dataset.bound = 'true';
     }
 
     function updateSortControl() {
       const select = document.getElementById('sortMode');
       if (!select) return;
-      if (select.value !== state.sortMode) select.value = state.sortMode;
+      if (select.value !== 'company') select.value = 'company';
     }
 
     function handleResize() {
@@ -975,9 +957,7 @@
           <label class="sort-control" for="sortMode">
             <span class="sort-control__label">Sort by</span>
             <select id="sortMode" name="sortMode" aria-label="Sort Elo series">
-              <option value="latest">Latest Elo</option>
               <option value="company">Company (A → Z)</option>
-              <option value="model">Model (A → Z)</option>
             </select>
           </label>
         </div>

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -152,6 +152,11 @@
       const vendor = lowerModel.includes('openrouter') ? extractOpenRouterVendor(modelStr) : '';
 
       const candidateStrings = [rawCompany, vendor];
+      if (modelStr) {
+        modelStr.split(/[^A-Za-z0-9]+/).forEach(part => {
+          if (part) candidateStrings.push(part);
+        });
+      }
       if (vendor) {
         vendor.split(/[^A-Za-z0-9]+/).forEach(part => {
           if (part) candidateStrings.push(part);


### PR DESCRIPTION
## Summary
- let Elo series use their assigned palette colors instead of CSS overrides
- simplify the Elo sort control to company-only ordering and keep the dropdown in sync
- extend company resolution to inspect model names so DeepSeek and other vendors map correctly on both Elo and leaderboard pages

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ccb399c064832db2db3bdc5ee04ea8