### PR TITLE
Fix OpenRouter detection and key mirroring

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -210,7 +210,7 @@ func loadAPIKeyFromSecret() {
 		}
 	}
 
-	if key := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")); key != "" {
+	if key := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")); key != "" && strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
 		os.Setenv("OPENAI_API_KEY", key)
 	}
 }


### PR DESCRIPTION
## Summary
- restore automatic OpenRouter routing by detecting provider from model prefixes before and after env fallbacks
- ensure manual provider overrides persist while recomputing base URLs, API keys, and headers
- only mirror the OpenRouter API key into OPENAI_API_KEY when the OpenAI key is unset

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ccb97838a8832d898eb68f4f875e4e