### PR TITLE
Default OpenRouter headers for compatibility

### DIFF
--- a/server/llm/openai_test.go
+++ b/server/llm/openai_test.go
@@ -1,0 +1,32 @@
+package llm
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSetHeaderPreserveCase(t *testing.T) {
+	hdr := http.Header{}
+	setHeaderPreserveCase(hdr, "HTTP-Referer", "https://example.com/app")
+	if vals := hdr["HTTP-Referer"]; len(vals) != 1 || vals[0] != "https://example.com/app" {
+		t.Fatalf("expected HTTP-Referer slice to be preserved, got %+v", vals)
+	}
+	if _, exists := hdr["Http-Referer"]; exists {
+		t.Fatalf("unexpected canonical header variant present: %+v", hdr)
+	}
+
+	setHeaderPreserveCase(hdr, "Referer", "https://example.com/app")
+	if got := hdr.Get("Referer"); got != "https://example.com/app" {
+		t.Fatalf("expected Referer to be set via canonical path, got %q", got)
+	}
+
+	// Blank values should be ignored.
+	setHeaderPreserveCase(hdr, "  ", "value")
+	setHeaderPreserveCase(hdr, "X-Test", "   ")
+	if _, exists := hdr[" "]; exists {
+		t.Fatalf("expected blank header keys to be ignored")
+	}
+	if got := hdr.Get("X-Test"); got != "" {
+		t.Fatalf("expected blank header values to be skipped, got %q", got)
+	}
+}

--- a/server/llm/openrouter.go
+++ b/server/llm/openrouter.go
@@ -129,12 +129,27 @@ func resolveAPIConfig(model string) (apiConfig, error) {
 	cfg.Organization = strings.TrimSpace(os.Getenv("OPENAI_ORG"))
 
 	if cfg.Kind == providerOpenRouter {
-		if v := strings.TrimSpace(os.Getenv("OPENROUTER_SITE_URL")); v != "" {
-			cfg.ExtraHeaders["HTTP-Referer"] = v
-			cfg.ExtraHeaders["Referer"] = v
+		siteURL := strings.TrimSpace(os.Getenv("OPENROUTER_SITE_URL"))
+		if siteURL == "" {
+			siteURL = strings.TrimSpace(os.Getenv("SITE_URL"))
 		}
-		if v := strings.TrimSpace(os.Getenv("OPENROUTER_TITLE")); v != "" {
-			cfg.ExtraHeaders["X-Title"] = v
+		if siteURL == "" {
+			siteURL = "https://pokerbench.ai"
+		}
+		if siteURL != "" {
+			cfg.ExtraHeaders["HTTP-Referer"] = siteURL
+			cfg.ExtraHeaders["Referer"] = siteURL
+		}
+
+		title := strings.TrimSpace(os.Getenv("OPENROUTER_TITLE"))
+		if title == "" {
+			title = strings.TrimSpace(os.Getenv("APP_NAME"))
+		}
+		if title == "" {
+			title = "PokerBench"
+		}
+		if title != "" {
+			cfg.ExtraHeaders["X-Title"] = title
 		}
 	}
 

--- a/server/llm/openrouter_test.go
+++ b/server/llm/openrouter_test.go
@@ -1,0 +1,47 @@
+package llm
+
+import "testing"
+
+func TestResolveAPIConfigOpenRouterDefaults(t *testing.T) {
+	t.Setenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1")
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	cfg, err := resolveAPIConfig("meta-llama/llama-3.1-70b-instruct")
+	if err != nil {
+		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	if cfg.Kind != providerOpenRouter {
+		t.Fatalf("expected providerOpenRouter, got %v", cfg.Kind)
+	}
+	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != "https://pokerbench.ai" {
+		t.Fatalf("unexpected HTTP-Referer: %q", got)
+	}
+	if got := cfg.ExtraHeaders["Referer"]; got != "https://pokerbench.ai" {
+		t.Fatalf("unexpected Referer: %q", got)
+	}
+	if got := cfg.ExtraHeaders["X-Title"]; got != "PokerBench" {
+		t.Fatalf("unexpected X-Title: %q", got)
+	}
+}
+
+func TestResolveAPIConfigOpenRouterOverrides(t *testing.T) {
+	t.Setenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1")
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_SITE_URL", "https://example.com/app")
+	t.Setenv("OPENROUTER_TITLE", "Custom Title")
+	cfg, err := resolveAPIConfig("meta-llama/llama-3.1-70b-instruct")
+	if err != nil {
+		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	if cfg.Kind != providerOpenRouter {
+		t.Fatalf("expected providerOpenRouter, got %v", cfg.Kind)
+	}
+	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != "https://example.com/app" {
+		t.Fatalf("unexpected HTTP-Referer: %q", got)
+	}
+	if got := cfg.ExtraHeaders["Referer"]; got != "https://example.com/app" {
+		t.Fatalf("unexpected Referer: %q", got)
+	}
+	if got := cfg.ExtraHeaders["X-Title"]; got != "Custom Title" {
+		t.Fatalf("unexpected X-Title: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- default the required Referer and X-Title headers when talking to OpenRouter
- allow overriding the defaults via env vars and add regression tests around the resolver

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd63a6770c832db0c48661289c564f