### PR TITLE
Handle OpenRouter parameter incompatibilities

### DIFF
--- a/server/llm/openai.go
+++ b/server/llm/openai.go
@@ -66,7 +66,20 @@ func PingTextWithOpts(ctx context.Context, model, system, user string, opts Ping
 	url := cfg.BaseURL + "/chat/completions"
 	removed := map[string]bool{}
 
-	for attempts := 0; attempts < 3; attempts++ {
+	maxAttempts := 3
+	if cfg.Kind == providerOpenRouter {
+		removalCandidates := 0
+		for _, key := range []string{"response_format", "reasoning", "max_tokens"} {
+			if _, exists := payload[key]; exists {
+				removalCandidates++
+			}
+		}
+		if attemptBudget := 1 + removalCandidates; attemptBudget > maxAttempts {
+			maxAttempts = attemptBudget
+		}
+	}
+
+	for attempts := 0; attempts < maxAttempts; attempts++ {
 		b, _ := json.Marshal(payload)
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
 		if err != nil {

--- a/server/llm/openai.go
+++ b/server/llm/openai.go
@@ -62,50 +62,61 @@ func PingTextWithOpts(ctx context.Context, model, system, user string, opts Ping
 	}
 	applyTuningFromEnv(payload, cfg.Kind == providerOpenRouter)
 
-	b, _ := json.Marshal(payload)
-	url := cfg.BaseURL + "/chat/completions"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set(cfg.HeaderName, cfg.HeaderPrefix+cfg.APIKey)
-	if cfg.Organization != "" {
-		req.Header.Set("OpenAI-Organization", cfg.Organization)
-	}
-	for k, v := range cfg.ExtraHeaders {
-		setHeaderPreserveCase(req.Header, k, v)
-	}
-
 	client := &http.Client{Timeout: 45 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
+	url := cfg.BaseURL + "/chat/completions"
+	removed := map[string]bool{}
 
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(resp.Body)
-	body := buf.Bytes()
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+	for attempts := 0; attempts < 3; attempts++ {
+		b, _ := json.Marshal(payload)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set(cfg.HeaderName, cfg.HeaderPrefix+cfg.APIKey)
+		if cfg.Organization != "" {
+			req.Header.Set("OpenAI-Organization", cfg.Organization)
+		}
+		for k, v := range cfg.ExtraHeaders {
+			setHeaderPreserveCase(req.Header, k, v)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return "", err
+		}
+
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(resp.Body)
+		body := buf.Bytes()
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			var cc struct {
+				Choices []struct {
+					Message struct {
+						Content string `json:"content"`
+					} `json:"message"`
+				} `json:"choices"`
+			}
+			if err := json.Unmarshal(body, &cc); err != nil {
+				return "", err
+			}
+			if len(cc.Choices) == 0 {
+				return "", errors.New("no choices returned")
+			}
+			return cc.Choices[0].Message.Content, nil
+		}
+
+		if (resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusUnprocessableEntity) && adjustOpenRouterPayloadForRetry(payload, cfg.Kind, body, removed) {
+			continue
+		}
+
 		return "", fmt.Errorf("openai http %d: %s", resp.StatusCode, truncate(string(body), 800))
 	}
 
-	var cc struct {
-		Choices []struct {
-			Message struct {
-				Content string `json:"content"`
-			} `json:"message"`
-		} `json:"choices"`
-	}
-	if err := json.Unmarshal(body, &cc); err != nil {
-		return "", err
-	}
-	if len(cc.Choices) == 0 {
-		return "", errors.New("no choices returned")
-	}
-	return cc.Choices[0].Message.Content, nil
+	return "", errors.New("exhausted chat completion retries")
 }
 
 // PingChooseAction requests a structured JSON action from the model.
@@ -269,6 +280,66 @@ func envPingOptions() PingOptions {
 		}
 	}
 	return opts
+}
+
+func adjustOpenRouterPayloadForRetry(payload map[string]any, kind providerKind, body []byte, removed map[string]bool) bool {
+	if kind != providerOpenRouter {
+		return false
+	}
+
+	lowerMsg := strings.ToLower(string(body))
+	lowerParam := ""
+	var errBody struct {
+		Error struct {
+			Message string `json:"message"`
+			Param   string `json:"param"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &errBody); err == nil {
+		if strings.TrimSpace(errBody.Error.Message) != "" {
+			lowerMsg = strings.ToLower(errBody.Error.Message)
+		}
+		lowerParam = strings.ToLower(errBody.Error.Param)
+	}
+
+	match := func(field string, aliases ...string) bool {
+		if removed[field] {
+			return false
+		}
+		if _, exists := payload[field]; !exists {
+			return false
+		}
+		if lowerParam != "" && (lowerParam == field || strings.Contains(lowerParam, field)) {
+			return true
+		}
+		if strings.Contains(lowerMsg, field) {
+			return true
+		}
+		for _, alias := range aliases {
+			if strings.Contains(lowerMsg, alias) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if match("response_format", "json_schema", "structured outputs", "structured_output") {
+		delete(payload, "response_format")
+		removed["response_format"] = true
+		return true
+	}
+	if match("reasoning", "internal reasoning", "reasoning_effort") {
+		delete(payload, "reasoning")
+		removed["reasoning"] = true
+		return true
+	}
+	if match("max_tokens", "max_output_tokens") {
+		delete(payload, "max_tokens")
+		removed["max_tokens"] = true
+		return true
+	}
+
+	return false
 }
 
 func envWithFallback(preferOpenRouter bool, openAIKey, openRouterKey string) string {

--- a/server/llm/openai_test.go
+++ b/server/llm/openai_test.go
@@ -30,3 +30,37 @@ func TestSetHeaderPreserveCase(t *testing.T) {
 		t.Fatalf("expected blank header values to be skipped, got %q", got)
 	}
 }
+
+func TestAdjustOpenRouterPayloadForRetryResponseFormat(t *testing.T) {
+	payload := map[string]any{
+		"response_format": map[string]any{"type": "json_schema"},
+	}
+	body := []byte(`{"error":{"message":"model does not support response_format","param":"response_format"}}`)
+	removed := map[string]bool{}
+	if !adjustOpenRouterPayloadForRetry(payload, providerOpenRouter, body, removed) {
+		t.Fatalf("expected response_format adjustment to trigger retry")
+	}
+	if _, ok := payload["response_format"]; ok {
+		t.Fatalf("response_format should have been removed from payload")
+	}
+	if adjustOpenRouterPayloadForRetry(payload, providerOpenRouter, body, removed) {
+		t.Fatalf("second adjustment attempt should not trigger once removed")
+	}
+}
+
+func TestAdjustOpenRouterPayloadForRetryReasoning(t *testing.T) {
+	payload := map[string]any{
+		"reasoning": map[string]any{"effort": "high"},
+	}
+	body := []byte(`{"error":{"message":"reasoning parameter unsupported"}}`)
+	removed := map[string]bool{}
+	if !adjustOpenRouterPayloadForRetry(payload, providerOpenRouter, body, removed) {
+		t.Fatalf("expected reasoning adjustment to trigger retry")
+	}
+	if _, ok := payload["reasoning"]; ok {
+		t.Fatalf("reasoning should have been removed from payload")
+	}
+	if adjustOpenRouterPayloadForRetry(payload, providerOpenRouter, body, removed) {
+		t.Fatalf("second adjustment attempt should not trigger once removed")
+	}
+}


### PR DESCRIPTION
## Summary
- add retry logic to `PingTextWithOpts` so OpenRouter requests automatically retry without unsupported parameters
- remove unsupported `response_format`, `reasoning`, or `max_tokens` payload fields when the provider rejects them
- cover the new adjustment helper with unit tests for both response_format and reasoning cases

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf43ce21b4832d84e20f21cb5e2f66