### PR TITLE
Add seedpack scheduling, paired bootstrap CIs, and stability tracking

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -1269,8 +1269,13 @@ func playHandMatch(
 				if len(h.BB.Hole) == 2 {
 					bbHole = []string{h.BB.Hole[0].String(), h.BB.Hole[1].String()}
 				}
+				potOdds := 0.0
+				denom := h.Pot + toCall
+				if toCall > 0 && denom > 0 {
+					potOdds = float64(toCall) / float64(denom)
+				}
 				_ = db.InsertActionLog(context.Background(), matchID, pairIndex, h.ID, s, curLabel, action, amount,
-					h.Pot, h.CurBet, toCall, minTo, maxTo, sbStack, bbStack, sbCom, bbCom, boardNow, sbHole, bbHole)
+					h.Pot, h.CurBet, toCall, minTo, maxTo, sbStack, bbStack, sbCom, bbCom, boardNow, sbHole, bbHole, potOdds, potOdds)
 			}
 
 			// logging adornments
@@ -1842,6 +1847,22 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 	if seeds <= 0 {
 		seeds = (atoiDef(os.Getenv("DUEL_HANDS"), 10) + 1) / 2
 	}
+	seedPackPath := strings.TrimSpace(os.Getenv("SEEDPACK_PATH"))
+	if seedPackPath == "" {
+		seedPackPath = strings.TrimSpace(os.Getenv("SEEDPACK"))
+	}
+	var seedPack *SeedPack
+	if seedPackPath != "" {
+		sp, err := LoadSeedPack(seedPackPath)
+		if err != nil {
+			log.Fatalf("load seedpack: %v", err)
+		}
+		seedPack = sp
+		seeds = len(sp.Seeds)
+		if seeds <= 0 {
+			log.Fatalf("seedpack %s has no seeds", seedPackPath)
+		}
+	}
 
 	// players
 	a, b := loadPlayers(startStack)
@@ -1867,12 +1888,30 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 	var pairWinsA, pairTies, pairTotal int
 	var margins []float64
 
-	// seed stream
-	base := deckSeedFromEnvOrCrypto()
-	sm := newSeedStream(base)
-
-	log.Printf("Match seed base: %d (mirrored pairs=%d)", base, seeds)
+	// seed stream or seedpack override
+	var base uint64
+	var sm seedStream
+	if seedPack != nil {
+		base = seedPack.Seeds[0]
+		meta := seedPack.Metadata()
+		log.Printf("Seedpack: %s v%s (pairs=%d sha256=%s)", meta.Name, meta.Version, meta.Count, meta.SHA256)
+	} else {
+		base = deckSeedFromEnvOrCrypto()
+		sm = newSeedStream(base)
+		log.Printf("Match seed base: %d (mirrored pairs=%d)", base, seeds)
+	}
 	fmt.Println(dim("Ctrl+C → graceful stop by default. Set STOP_IMMEDIATE=1 for hard stop."))
+
+	var seedpackMeta *store.SeedpackMeta
+	if seedPack != nil {
+		meta := seedPack.Metadata()
+		seedpackMeta = &store.SeedpackMeta{
+			Name:    meta.Name,
+			Version: meta.Version,
+			Count:   meta.Count,
+			SHA256:  meta.SHA256,
+		}
+	}
 
 	boardStr := func(bd []engine.Card) string {
 		if len(bd) < 5 {
@@ -1885,6 +1924,26 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 	var matchID int64
 	var botAID, botBID int64
 	accA, accB := 0.5, 0.5
+	persistCheckpoint := func(stage string, pairIndex *int) {
+		if db == nil || matchID == 0 {
+			return
+		}
+		overrides := make(map[int64]float64, 2)
+		if botAID != 0 {
+			overrides[botAID] = gA.Rating
+		}
+		if botBID != 0 {
+			overrides[botBID] = gB.Rating
+		}
+		ranking, err := db.RankingOrder(context.Background(), overrides)
+		if err != nil {
+			log.Printf("RankingOrder failed: %v", err)
+			return
+		}
+		if err := db.InsertRatingCheckpoint(context.Background(), matchID, stage, pairIndex, ranking); err != nil {
+			log.Printf("InsertRatingCheckpoint(%s) failed: %v", stage, err)
+		}
+	}
 	if db != nil {
 		companyA, companyB := companyForModel(a.Model), companyForModel(b.Model)
 		rePtr := strptr(os.Getenv("OPENAI_REASONING_EFFORT"))
@@ -1937,7 +1996,7 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 
 		// create match + start rating point
 		if db != nil {
-			id, err := db.CreateMatch(context.Background(), sb, bb, startStack, seeds, int64(base), eloStart, eloK, eloPerHand, eloWeightPot)
+			id, err := db.CreateMatch(context.Background(), sb, bb, startStack, seeds, int64(base), eloStart, eloK, eloPerHand, eloWeightPot, seedpackMeta)
 			if err != nil {
 				log.Printf("CreateMatch failed: %v (disabling DB this run)", err)
 				db = nil
@@ -1950,6 +2009,7 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 				); err != nil {
 					log.Printf("InsertRatingPoint(start) failed: %v", err)
 				}
+				persistCheckpoint("start", nil)
 			}
 		}
 	}
@@ -1963,7 +2023,18 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 			break
 		}
 
-		seed := int64(sm.next())
+		var seedVal uint64
+		if seedPack != nil {
+			v, err := seedPack.SeedAt(i)
+			if err != nil {
+				log.Printf("seedpack lookup failed at pair %d: %v", i+1, err)
+				break
+			}
+			seedVal = v
+		} else {
+			seedVal = sm.next()
+		}
+		seed := int64(seedVal)
 		fmt.Printf("%s starting pair %d/%d (seed=%d)\n", dim("▶"), i+1, seeds, seed)
 
 		// Hand 1: A=SB, B=BB
@@ -2041,6 +2112,17 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 			mag("Glicko2 (pair)"), bold(fmt.Sprintf("seed %d", i+1)),
 			gA.Rating, gA.RD, gA.Volatility, gB.Rating, gB.RD, gB.Volatility)
 
+		bbPer100 := 0.0
+		if bb > 0 {
+			bbPer100 = 50.0 * float64(chipsA) / float64(bb)
+		}
+		if db != nil && matchID != 0 && botAID != 0 && botBID != 0 {
+			idx := i + 1
+			if err := db.InsertPairDelta(context.Background(), matchID, idx, botAID, botBID, bbPer100); err != nil {
+				log.Printf("InsertPairDelta(pair %d) failed: %v", idx, err)
+			}
+		}
+
 		// CI bookkeeping
 		pairTotal++
 		switch {
@@ -2062,6 +2144,7 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 			); err != nil {
 				log.Printf("InsertRatingPoint(pair %d) failed: %v", idx, err)
 			}
+			persistCheckpoint("after_pair", &idx)
 		}
 
 		// conservation + bust
@@ -2119,6 +2202,7 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 		); err != nil {
 			log.Printf("InsertRatingPoint(end) failed: %v", err)
 		}
+		persistCheckpoint("end", nil)
 
 		rePtr := strptr(os.Getenv("OPENAI_REASONING_EFFORT"))
 		aChk, aCall, aRaise, aFold := tallyCounts(tallies[a.Label])

--- a/server/router.go
+++ b/server/router.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -40,17 +41,21 @@ func Router(db *store.DB) http.Handler {
 		ctx := r.Context()
 
 		type Match struct {
-			ID             int64      `json:"id"`
-			CreatedAt      time.Time  `json:"created_at"`
-			EndedAt        *time.Time `json:"ended_at"`
-			SB             int        `json:"sb"`
-			BB             int        `json:"bb"`
-			StartStack     int        `json:"start_stack"`
-			DuelSeeds      int        `json:"duel_seeds"`
-			EloStart       float64    `json:"elo_start"`
-			EloK           float64    `json:"elo_k"`
-			EloPerHand     bool       `json:"elo_per_hand"`
-			EloWeightByPot bool       `json:"elo_weight_by_pot"`
+			ID              int64      `json:"id"`
+			CreatedAt       time.Time  `json:"created_at"`
+			EndedAt         *time.Time `json:"ended_at"`
+			SB              int        `json:"sb"`
+			BB              int        `json:"bb"`
+			StartStack      int        `json:"start_stack"`
+			DuelSeeds       int        `json:"duel_seeds"`
+			EloStart        float64    `json:"elo_start"`
+			EloK            float64    `json:"elo_k"`
+			EloPerHand      bool       `json:"elo_per_hand"`
+			EloWeightByPot  bool       `json:"elo_weight_by_pot"`
+			SeedpackName    *string    `json:"seedpack_name,omitempty"`
+			SeedpackVersion *string    `json:"seedpack_version,omitempty"`
+			SeedpackCount   *int       `json:"seedpack_count,omitempty"`
+			SeedpackSHA     *string    `json:"seedpack_sha256,omitempty"`
 		}
 		type Participant struct {
 			Label   string  `json:"label"`
@@ -95,12 +100,14 @@ func Router(db *store.DB) http.Handler {
 		var m Match
 		err := db.QueryRow(ctx, `
             SELECT id, created_at, ended_at, sb, bb, start_stack, duel_seeds,
-                   elo_start, elo_k, elo_per_hand, elo_weight_by_pot
+                   elo_start, elo_k, elo_per_hand, elo_weight_by_pot,
+                   seedpack_name, seedpack_version, seedpack_count, seedpack_sha256
               FROM matches
              ORDER BY id DESC
              LIMIT 1
         `).Scan(&m.ID, &m.CreatedAt, &m.EndedAt, &m.SB, &m.BB, &m.StartStack, &m.DuelSeeds,
-			&m.EloStart, &m.EloK, &m.EloPerHand, &m.EloWeightByPot)
+			&m.EloStart, &m.EloK, &m.EloPerHand, &m.EloWeightByPot,
+			&m.SeedpackName, &m.SeedpackVersion, &m.SeedpackCount, &m.SeedpackSHA)
 		if err != nil {
 			http.Error(w, "no matches yet", http.StatusNotFound)
 			return
@@ -190,20 +197,25 @@ func Router(db *store.DB) http.Handler {
 	mux.HandleFunc("/api/matches", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		type Row struct {
-			ID        int64      `json:"id"`
-			CreatedAt time.Time  `json:"created_at"`
-			EndedAt   *time.Time `json:"ended_at"`
-			SBA       int        `json:"sb"`
-			BBA       int        `json:"bb"`
-			Start     int        `json:"start_stack"`
-			Seeds     int        `json:"duel_seeds"`
-			ModelA    string     `json:"model_a"`
-			ModelB    string     `json:"model_b"`
+			ID              int64      `json:"id"`
+			CreatedAt       time.Time  `json:"created_at"`
+			EndedAt         *time.Time `json:"ended_at"`
+			SBA             int        `json:"sb"`
+			BBA             int        `json:"bb"`
+			Start           int        `json:"start_stack"`
+			Seeds           int        `json:"duel_seeds"`
+			ModelA          string     `json:"model_a"`
+			ModelB          string     `json:"model_b"`
+			SeedpackName    *string    `json:"seedpack_name,omitempty"`
+			SeedpackVersion *string    `json:"seedpack_version,omitempty"`
+			SeedpackCount   *int       `json:"seedpack_count,omitempty"`
+			SeedpackSHA     *string    `json:"seedpack_sha256,omitempty"`
 		}
 		rows, err := db.Query(ctx, `
             SELECT m.id, m.created_at, m.ended_at, m.sb, m.bb, m.start_stack, m.duel_seeds,
                    MAX(CASE WHEN p.label='A' THEN p.name_snapshot END) AS model_a,
-                   MAX(CASE WHEN p.label='B' THEN p.name_snapshot END) AS model_b
+                   MAX(CASE WHEN p.label='B' THEN p.name_snapshot END) AS model_b,
+                   m.seedpack_name, m.seedpack_version, m.seedpack_count, m.seedpack_sha256
               FROM matches m
               LEFT JOIN match_participants p ON p.match_id = m.id
              GROUP BY m.id
@@ -218,13 +230,42 @@ func Router(db *store.DB) http.Handler {
 		out := []Row{}
 		for rows.Next() {
 			var x Row
-			if err := rows.Scan(&x.ID, &x.CreatedAt, &x.EndedAt, &x.SBA, &x.BBA, &x.Start, &x.Seeds, &x.ModelA, &x.ModelB); err != nil {
+			if err := rows.Scan(&x.ID, &x.CreatedAt, &x.EndedAt, &x.SBA, &x.BBA, &x.Start, &x.Seeds, &x.ModelA, &x.ModelB,
+				&x.SeedpackName, &x.SeedpackVersion, &x.SeedpackCount, &x.SeedpackSHA); err != nil {
 				http.Error(w, err.Error(), 500)
 				return
 			}
 			out = append(out, x)
 		}
 		writeJSON(w, map[string]any{"rows": out})
+	})
+
+	mux.HandleFunc("/api/seedpacks", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		packs, err := db.ListSeedpacks(ctx)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		type Pack struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+			Count   int    `json:"count"`
+			SHA256  string `json:"sha256"`
+		}
+		out := make([]Pack, 0, len(packs))
+		for _, p := range packs {
+			if strings.TrimSpace(p.SHA256) == "" {
+				continue
+			}
+			out = append(out, Pack{
+				Name:    p.Name,
+				Version: p.Version,
+				Count:   p.Count,
+				SHA256:  p.SHA256,
+			})
+		}
+		writeJSON(w, map[string]any{"seedpacks": out})
 	})
 
 	// Leaderboard: top bots by Elo (career stats, org)
@@ -591,6 +632,8 @@ func Router(db *store.DB) http.Handler {
 			Board       []string  `json:"board"`
 			SBHole      []string  `json:"sb_hole"`
 			BBHole      []string  `json:"bb_hole"`
+			PotOdds     float64   `json:"pot_odds"`
+			RequiredEq  float64   `json:"required_equity"`
 			CreatedAt   time.Time `json:"created_at"`
 		}
 
@@ -617,7 +660,7 @@ func Router(db *store.DB) http.Handler {
                     SELECT id, pair_index, hand_id, street, actor_label, action, amount,
                            pot, cur_bet, to_call, min_raise_to, max_raise_to,
                            sb_stack, bb_stack, sb_committed, bb_committed,
-                           board, created_at
+                           board, pot_odds, required_equity, created_at
                       FROM action_logs
                      WHERE match_id = $1 AND id > $2
                      ORDER BY id
@@ -632,7 +675,7 @@ func Router(db *store.DB) http.Handler {
 					if err := rows.Scan(&r.ID, &r.PairIndex, &r.HandID, &r.Street, &r.ActorLabel, &r.Action, &r.Amount,
 						&r.Pot, &r.CurBet, &r.ToCall, &r.MinRaiseTo, &r.MaxRaiseTo,
 						&r.SBStack, &r.BBStack, &r.SBCommitted, &r.BBCommitted,
-						&r.Board, &r.CreatedAt); err != nil {
+						&r.Board, &r.PotOdds, &r.RequiredEq, &r.CreatedAt); err != nil {
 						rows.Close()
 						http.Error(w, err.Error(), 500)
 						return
@@ -677,11 +720,15 @@ func Router(db *store.DB) http.Handler {
 			bots = append(bots, b)
 		}
 		type Pair struct {
-			AID   int64 `json:"a_id"`
-			BID   int64 `json:"b_id"`
-			AWins int   `json:"a_wins"`
-			BWins int   `json:"b_wins"`
-			Hands int   `json:"hands"`
+			AID          int64    `json:"a_id"`
+			BID          int64    `json:"b_id"`
+			AWins        int      `json:"a_wins"`
+			BWins        int      `json:"b_wins"`
+			Hands        int      `json:"hands"`
+			BB100Samples int      `json:"bb100_samples"`
+			BB100Mean    *float64 `json:"bb100_mean,omitempty"`
+			BB100Lo      *float64 `json:"bb100_lo,omitempty"`
+			BB100Hi      *float64 `json:"bb100_hi,omitempty"`
 		}
 		pairs := []Pair{}
 		rows2, err := db.Query(ctx, `
@@ -708,7 +755,152 @@ func Router(db *store.DB) http.Handler {
 			}
 			pairs = append(pairs, p)
 		}
+		type pairKey struct{ a, b int64 }
+		deltaMap := make(map[pairKey][]float64)
+		rows3, err := db.Query(ctx, `
+            SELECT bot_a_id, bot_b_id, bb_per_100
+              FROM match_pair_deltas
+        `)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		for rows3.Next() {
+			var aID, bID int64
+			var val float64
+			if err := rows3.Scan(&aID, &bID, &val); err != nil {
+				rows3.Close()
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			key := pairKey{a: aID, b: bID}
+			delta := val
+			if aID > bID {
+				key = pairKey{a: bID, b: aID}
+				delta = -val
+			}
+			deltaMap[key] = append(deltaMap[key], delta)
+		}
+		rows3.Close()
+		for i := range pairs {
+			key := pairKey{a: pairs[i].AID, b: pairs[i].BID}
+			vals := deltaMap[key]
+			if len(vals) == 0 {
+				continue
+			}
+			mean, lo, hi := PairedBootstrapCI(vals, 2000, 0.05)
+			pairs[i].BB100Samples = len(vals)
+			m := mean
+			l := lo
+			h := hi
+			pairs[i].BB100Mean = &m
+			pairs[i].BB100Lo = &l
+			pairs[i].BB100Hi = &h
+		}
 		writeJSON(w, map[string]any{"bots": bots, "pairs": pairs})
+	})
+
+	mux.HandleFunc("/api/stability", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		finalOrder, err := db.RankingOrder(ctx, nil)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		finalStrings := make([]string, 0, len(finalOrder))
+		for _, id := range finalOrder {
+			finalStrings = append(finalStrings, strconv.FormatInt(id, 10))
+		}
+		type Row struct {
+			MatchID  int64     `json:"match_id"`
+			Stage    string    `json:"stage"`
+			PairIdx  *int      `json:"pair_index,omitempty"`
+			Rankings []int64   `json:"rankings"`
+			Created  time.Time `json:"created_at"`
+			Seedpack *struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+				Count   int    `json:"count"`
+				SHA256  string `json:"sha256"`
+			} `json:"seedpack,omitempty"`
+			Tau float64 `json:"kendall_tau"`
+		}
+		rows, err := db.Query(ctx, `
+            SELECT c.match_id, c.stage, COALESCE(c.pair_index, -1) AS pair_index,
+                   c.rankings, c.created_at,
+                   m.seedpack_name, m.seedpack_version, m.seedpack_count, m.seedpack_sha256
+              FROM rating_checkpoints c
+              JOIN matches m ON m.id = c.match_id
+             ORDER BY c.created_at
+        `)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer rows.Close()
+		out := []Row{}
+		for rows.Next() {
+			var matchID int64
+			var stage string
+			var pairIdx int
+			var rankings []int64
+			var created time.Time
+			var seedName, seedVersion, seedSHA *string
+			var seedCount *int
+			if err := rows.Scan(&matchID, &stage, &pairIdx, &rankings, &created, &seedName, &seedVersion, &seedCount, &seedSHA); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			var idxPtr *int
+			if pairIdx >= 0 {
+				idx := pairIdx
+				idxPtr = &idx
+			}
+			rankStrings := make([]string, 0, len(rankings))
+			for _, id := range rankings {
+				rankStrings = append(rankStrings, strconv.FormatInt(id, 10))
+			}
+			tau := 0.0
+			if len(rankStrings) > 1 && len(finalStrings) > 1 {
+				tau = KendallTau(rankStrings, finalStrings)
+			}
+			row := Row{
+				MatchID:  matchID,
+				Stage:    stage,
+				PairIdx:  idxPtr,
+				Rankings: rankings,
+				Created:  created,
+				Tau:      tau,
+			}
+			if seedName != nil || seedVersion != nil || seedCount != nil || seedSHA != nil {
+				var cnt int
+				if seedCount != nil {
+					cnt = *seedCount
+				}
+				sha := ""
+				if seedSHA != nil {
+					sha = *seedSHA
+				}
+				if strings.TrimSpace(sha) != "" {
+					row.Seedpack = &struct {
+						Name    string `json:"name"`
+						Version string `json:"version"`
+						Count   int    `json:"count"`
+						SHA256  string `json:"sha256"`
+					}{
+						Name:    strPtrValue(seedName),
+						Version: strPtrValue(seedVersion),
+						Count:   cnt,
+						SHA256:  sha,
+					}
+				}
+			}
+			out = append(out, row)
+		}
+		writeJSON(w, map[string]any{
+			"rows":       out,
+			"final_rank": finalOrder,
+		})
 	})
 
 	// Elo history across matches per bot (end-of-match Elo and label mapping)
@@ -781,6 +973,8 @@ func Router(db *store.DB) http.Handler {
 			Board       []string  `json:"board"`
 			SBHole      []string  `json:"sb_hole"`
 			BBHole      []string  `json:"bb_hole"`
+			PotOdds     float64   `json:"pot_odds"`
+			RequiredEq  float64   `json:"required_equity"`
 			CreatedAt   time.Time `json:"created_at"`
 			// Optional solver eval join
 			Solver          *string  `json:"solver"`
@@ -797,7 +991,7 @@ func Router(db *store.DB) http.Handler {
             SELECT a.id, a.pair_index, a.hand_id, a.street, a.actor_label, a.action, a.amount,
                    a.pot, a.cur_bet, a.to_call, a.min_raise_to, a.max_raise_to,
                    a.sb_stack, a.bb_stack, a.sb_committed, a.bb_committed,
-                   a.board, a.sb_hole, a.bb_hole, a.created_at,
+                   a.board, a.sb_hole, a.bb_hole, a.pot_odds, a.required_equity, a.created_at,
                    e.solver, e.solver_version, e.best_action, e.best_amount_to, e.ev_gap_bb, e.correctness_prob, e.is_top_action
               FROM action_logs a
               LEFT JOIN action_eval e ON e.action_log_id = a.id
@@ -815,7 +1009,7 @@ func Router(db *store.DB) http.Handler {
 			if err := rows.Scan(&r.ID, &r.PairIndex, &r.HandID, &r.Street, &r.ActorLabel, &r.Action, &r.Amount,
 				&r.Pot, &r.CurBet, &r.ToCall, &r.MinRaiseTo, &r.MaxRaiseTo,
 				&r.SBStack, &r.BBStack, &r.SBCommitted, &r.BBCommitted,
-				&r.Board, &r.SBHole, &r.BBHole, &r.CreatedAt,
+				&r.Board, &r.SBHole, &r.BBHole, &r.PotOdds, &r.RequiredEq, &r.CreatedAt,
 				&r.Solver, &r.SolverVersion, &r.EvalBestAction, &r.EvalBestTo, &r.EvalGapBB, &r.EvalCorrectProb, &r.EvalIsTop); err != nil {
 				http.Error(w, err.Error(), 500)
 				return
@@ -918,6 +1112,13 @@ func Router(db *store.DB) http.Handler {
 	})
 
 	return mux
+}
+
+func strPtrValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/server/seedpack.go
+++ b/server/seedpack.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+type SeedPack struct {
+	Name    string   `json:"name"`
+	Version string   `json:"version"`
+	Seeds   []uint64 `json:"seeds"`
+	hash    string
+}
+
+type SeedPackMeta struct {
+	Name    string
+	Version string
+	Count   int
+	SHA256  string
+}
+
+func LoadSeedPack(path string) (*SeedPack, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var sp SeedPack
+	if err := json.Unmarshal(data, &sp); err != nil {
+		return nil, err
+	}
+	if len(sp.Seeds) == 0 {
+		return nil, fmt.Errorf("seedpack has no seeds")
+	}
+	hash := sha256.Sum256(data)
+	sp.hash = hex.EncodeToString(hash[:])
+	return &sp, nil
+}
+
+func (sp *SeedPack) Metadata() SeedPackMeta {
+	if sp == nil {
+		return SeedPackMeta{}
+	}
+	return SeedPackMeta{
+		Name:    sp.Name,
+		Version: sp.Version,
+		Count:   len(sp.Seeds),
+		SHA256:  sp.hash,
+	}
+}
+
+func (sp *SeedPack) SeedAt(idx int) (uint64, error) {
+	if sp == nil {
+		return 0, fmt.Errorf("seedpack nil")
+	}
+	if idx < 0 || idx >= len(sp.Seeds) {
+		return 0, fmt.Errorf("seed index %d out of range", idx)
+	}
+	return sp.Seeds[idx], nil
+}

--- a/server/stats_extra.go
+++ b/server/stats_extra.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"math"
+	mrand "math/rand"
+	"sort"
+)
+
+func PairedBootstrapCI(deltas []float64, B int, alpha float64) (mean, lo, hi float64) {
+	n := len(deltas)
+	if n == 0 || B <= 0 {
+		return 0, 0, 0
+	}
+	if alpha <= 0 || alpha >= 1 {
+		alpha = 0.05
+	}
+	sum := 0.0
+	for _, v := range deltas {
+		sum += v
+	}
+	mean = sum / float64(n)
+	if B == 1 {
+		return mean, mean, mean
+	}
+	samples := make([]float64, B)
+	for b := 0; b < B; b++ {
+		acc := 0.0
+		for i := 0; i < n; i++ {
+			acc += deltas[mrand.Intn(n)]
+		}
+		samples[b] = acc / float64(n)
+	}
+	sort.Float64s(samples)
+	lowerIdx := int(math.Round((alpha / 2.0) * float64(B-1)))
+	upperIdx := int(math.Round((1.0 - alpha/2.0) * float64(B-1)))
+	if lowerIdx < 0 {
+		lowerIdx = 0
+	}
+	if upperIdx >= B {
+		upperIdx = B - 1
+	}
+	lo = samples[lowerIdx]
+	hi = samples[upperIdx]
+	return
+}
+
+func KendallTau(a, b []string) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	posA := make(map[string]int, len(a))
+	for i, v := range a {
+		if _, ok := posA[v]; !ok {
+			posA[v] = i
+		}
+	}
+	posB := make(map[string]int, len(b))
+	for i, v := range b {
+		if _, ok := posB[v]; !ok {
+			posB[v] = i
+		}
+	}
+	order := make([]string, 0, len(a))
+	seen := make(map[string]struct{}, len(a))
+	for _, v := range a {
+		if _, ok := posB[v]; !ok {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		order = append(order, v)
+	}
+	if len(order) < 2 {
+		return 0
+	}
+	totalPairs := float64(len(order) * (len(order) - 1) / 2)
+	if totalPairs == 0 {
+		return 0
+	}
+	concordant := 0
+	discordant := 0
+	for i := 0; i < len(order)-1; i++ {
+		for j := i + 1; j < len(order); j++ {
+			ai := posA[order[i]]
+			aj := posA[order[j]]
+			bi := posB[order[i]]
+			bj := posB[order[j]]
+			diffA := ai - aj
+			diffB := bi - bj
+			prod := diffA * diffB
+			if prod > 0 {
+				concordant++
+			} else if prod < 0 {
+				discordant++
+			}
+		}
+	}
+	return float64(concordant-discordant) / totalPairs
+}

--- a/server/stats_extra_test.go
+++ b/server/stats_extra_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"math"
+	mrand "math/rand"
+	"testing"
+)
+
+func TestPairedBootstrapCI(t *testing.T) {
+	deltas := []float64{-5, -2.5, 0, 2.5, 5}
+	mrand.Seed(123)
+	mean, lo, hi := PairedBootstrapCI(deltas, 2000, 0.05)
+	if math.Abs(mean-0) > 1e-9 {
+		t.Fatalf("expected mean 0, got %f", mean)
+	}
+	if !(lo < mean && mean < hi) {
+		t.Fatalf("expected mean inside interval, got lo=%f hi=%f mean=%f", lo, hi, mean)
+	}
+	if hi-lo <= 0 {
+		t.Fatalf("expected positive width interval")
+	}
+}
+
+func TestPairedBootstrapCIEmpty(t *testing.T) {
+	mean, lo, hi := PairedBootstrapCI(nil, 1000, 0.05)
+	if mean != 0 || lo != 0 || hi != 0 {
+		t.Fatalf("expected zeros, got %f %f %f", mean, lo, hi)
+	}
+}
+
+func TestKendallTau(t *testing.T) {
+	a := []string{"a", "b", "c", "d"}
+	b := []string{"a", "b", "c", "d"}
+	if v := KendallTau(a, b); math.Abs(v-1) > 1e-9 {
+		t.Fatalf("expected tau=1, got %f", v)
+	}
+	c := []string{"d", "c", "b", "a"}
+	if v := KendallTau(a, c); math.Abs(v+1) > 1e-9 {
+		t.Fatalf("expected tau=-1, got %f", v)
+	}
+	d := []string{"a", "c", "e", "b"}
+	if v := KendallTau(a, d); v >= 1 || v <= -1 {
+		t.Fatalf("expected tau in (-1,1), got %f", v)
+	}
+	e := []string{"z"}
+	if v := KendallTau(a, e); v != 0 {
+		t.Fatalf("expected 0 for insufficient overlap, got %f", v)
+	}
+}

--- a/server/store/schema.sql
+++ b/server/store/schema.sql
@@ -44,8 +44,18 @@ CREATE TABLE IF NOT EXISTS matches (
   elo_start        REAL NOT NULL,
   elo_k            REAL NOT NULL,
   elo_per_hand     BOOL NOT NULL,
-  elo_weight_by_pot BOOL NOT NULL
+  elo_weight_by_pot BOOL NOT NULL,
+  seedpack_name    TEXT,
+  seedpack_version TEXT,
+  seedpack_count   INT,
+  seedpack_sha256  TEXT
 );
+
+ALTER TABLE matches
+  ADD COLUMN IF NOT EXISTS seedpack_name TEXT,
+  ADD COLUMN IF NOT EXISTS seedpack_version TEXT,
+  ADD COLUMN IF NOT EXISTS seedpack_count INT,
+  ADD COLUMN IF NOT EXISTS seedpack_sha256 TEXT;
 
 -- =========================
 -- PARTICIPANTS (final snapshot per bot in a match)
@@ -195,6 +205,8 @@ CREATE TABLE IF NOT EXISTS action_logs (
   board          TEXT[] NOT NULL DEFAULT '{}',
   sb_hole        TEXT[] NOT NULL DEFAULT '{}',
   bb_hole        TEXT[] NOT NULL DEFAULT '{}',
+  pot_odds       REAL NOT NULL DEFAULT 0,
+  required_equity REAL NOT NULL DEFAULT 0,
   created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -206,6 +218,39 @@ ALTER TABLE action_logs
   ADD COLUMN IF NOT EXISTS sb_hole TEXT[] NOT NULL DEFAULT '{}';
 ALTER TABLE action_logs
   ADD COLUMN IF NOT EXISTS bb_hole TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE action_logs
+  ADD COLUMN IF NOT EXISTS pot_odds REAL NOT NULL DEFAULT 0;
+ALTER TABLE action_logs
+  ADD COLUMN IF NOT EXISTS required_equity REAL NOT NULL DEFAULT 0;
+
+-- =========================
+-- MATCH PAIR DELTAS (bb/100 per mirrored pair)
+-- =========================
+CREATE TABLE IF NOT EXISTS match_pair_deltas (
+  match_id    BIGINT NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+  pair_index  INT NOT NULL,
+  bot_a_id    BIGINT NOT NULL REFERENCES bots(id) ON DELETE CASCADE,
+  bot_b_id    BIGINT NOT NULL REFERENCES bots(id) ON DELETE CASCADE,
+  bb_per_100  REAL NOT NULL,
+  PRIMARY KEY (match_id, pair_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_match_pair_deltas_bot ON match_pair_deltas(bot_a_id, bot_b_id);
+
+-- =========================
+-- RATING CHECKPOINTS (ranking snapshots)
+-- =========================
+CREATE TABLE IF NOT EXISTS rating_checkpoints (
+  id         BIGSERIAL PRIMARY KEY,
+  match_id   BIGINT NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+  stage      TEXT NOT NULL CHECK (stage IN ('start','after_pair','end')),
+  pair_index INT,
+  rankings   BIGINT[] NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_rating_checkpoints_match_stage_pair
+  ON rating_checkpoints (match_id, stage, COALESCE(pair_index, 0));
 
 -- =========================
 -- SOLVER EVALUATION (per action, optional)

--- a/server/store/seedpack.go
+++ b/server/store/seedpack.go
@@ -1,0 +1,8 @@
+package store
+
+type SeedpackMeta struct {
+	Name    string
+	Version string
+	Count   int
+	SHA256  string
+}

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"errors"
+	"sort"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -281,16 +282,37 @@ func (db *DB) CreateMatch(
 	deckSeedBase int64,
 	eloStart, eloK float64,
 	eloPerHand, eloWeightByPot bool,
+	seedpack *SeedpackMeta,
 ) (int64, error) {
 	var id int64
+	var name any
+	var version any
+	var count any
+	var sha any
+	if seedpack != nil && seedpack.Count > 0 {
+		if seedpack.Name != "" {
+			name = seedpack.Name
+		}
+		if seedpack.Version != "" {
+			version = seedpack.Version
+		}
+		count = seedpack.Count
+		if seedpack.SHA256 != "" {
+			sha = seedpack.SHA256
+		}
+	}
 	err := db.QueryRow(ctx, `
-		INSERT INTO matches(
-			sb, bb, start_stack, duel_seeds, deck_seed_base,
-			elo_start, elo_k, elo_per_hand, elo_weight_by_pot
-		)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
-		RETURNING id
-	`, sb, bb, startStack, duelSeeds, deckSeedBase, eloStart, eloK, eloPerHand, eloWeightByPot).Scan(&id)
+                INSERT INTO matches(
+                        sb, bb, start_stack, duel_seeds, deck_seed_base,
+                        elo_start, elo_k, elo_per_hand, elo_weight_by_pot,
+                        seedpack_name, seedpack_version, seedpack_count, seedpack_sha256
+                )
+                VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+                RETURNING id
+        `, sb, bb, startStack, duelSeeds, deckSeedBase,
+		eloStart, eloK, eloPerHand, eloWeightByPot,
+		name, version, count, sha,
+	).Scan(&id)
 	return id, err
 }
 
@@ -404,6 +426,123 @@ func (db *DB) CompleteMatch(ctx context.Context, matchID int64) error {
 	return err
 }
 
+func (db *DB) InsertPairDelta(ctx context.Context, matchID int64, pairIndex int, botAID, botBID int64, bbPer100 float64) error {
+	_, err := db.Exec(ctx, `
+        INSERT INTO match_pair_deltas(match_id, pair_index, bot_a_id, bot_b_id, bb_per_100)
+        VALUES ($1,$2,$3,$4,$5)
+        ON CONFLICT (match_id, pair_index) DO UPDATE
+          SET bot_a_id = EXCLUDED.bot_a_id,
+              bot_b_id = EXCLUDED.bot_b_id,
+              bb_per_100 = EXCLUDED.bb_per_100
+    `, matchID, pairIndex, botAID, botBID, bbPer100)
+	return err
+}
+
+func (db *DB) RankingOrder(ctx context.Context, overrides map[int64]float64) ([]int64, error) {
+	rows, err := db.Query(ctx, `
+            SELECT id, COALESCE(g_rating, 1500) AS rating,
+                   COALESCE(matches, 0) AS matches,
+                   COALESCE(hands, 0) AS hands
+              FROM v_bot_career
+        `)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	type entry struct {
+		id      int64
+		rating  float64
+		matches int
+		hands   int
+	}
+	entries := []entry{}
+	seen := make(map[int64]struct{})
+	for rows.Next() {
+		var e entry
+		if err := rows.Scan(&e.id, &e.rating, &e.matches, &e.hands); err != nil {
+			return nil, err
+		}
+		if overrides != nil {
+			if v, ok := overrides[e.id]; ok {
+				e.rating = v
+			}
+		}
+		entries = append(entries, e)
+		seen[e.id] = struct{}{}
+	}
+	for id, rating := range overrides {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		entries = append(entries, entry{id: id, rating: rating})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].rating != entries[j].rating {
+			return entries[i].rating > entries[j].rating
+		}
+		if entries[i].matches != entries[j].matches {
+			return entries[i].matches > entries[j].matches
+		}
+		if entries[i].hands != entries[j].hands {
+			return entries[i].hands > entries[j].hands
+		}
+		return entries[i].id < entries[j].id
+	})
+	out := make([]int64, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.id)
+	}
+	return out, nil
+}
+
+func (db *DB) InsertRatingCheckpoint(ctx context.Context, matchID int64, stage string, pairIndex *int, ranking []int64) error {
+	if len(ranking) == 0 {
+		return nil
+	}
+	var idx any
+	if pairIndex != nil {
+		idx = *pairIndex
+	}
+	_, err := db.Exec(ctx, `
+        INSERT INTO rating_checkpoints(match_id, stage, pair_index, rankings)
+        VALUES ($1,$2,$3,$4)
+        ON CONFLICT (match_id, stage, COALESCE(pair_index,0)) DO UPDATE
+          SET rankings = EXCLUDED.rankings,
+              created_at = now()
+    `, matchID, stage, idx, ranking)
+	return err
+}
+
+func (db *DB) ListSeedpacks(ctx context.Context) ([]SeedpackMeta, error) {
+	rows, err := db.Query(ctx, `
+            SELECT DISTINCT seedpack_name, seedpack_version, seedpack_count, seedpack_sha256
+              FROM matches
+             WHERE seedpack_name IS NOT NULL
+               AND seedpack_sha256 IS NOT NULL
+             ORDER BY seedpack_name, seedpack_version
+        `)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	res := []SeedpackMeta{}
+	for rows.Next() {
+		var m SeedpackMeta
+		var count *int
+		if err := rows.Scan(&m.Name, &m.Version, &count, &m.SHA256); err != nil {
+			return nil, err
+		}
+		if count != nil {
+			m.Count = *count
+		}
+		if m.SHA256 == "" {
+			continue
+		}
+		res = append(res, m)
+	}
+	return res, nil
+}
+
 // InsertActionLog records one action step for live viewers and auditing.
 func (db *DB) InsertActionLog(
 	ctx context.Context,
@@ -419,6 +558,8 @@ func (db *DB) InsertActionLog(
 	board []string,
 	sbHole []string,
 	bbHole []string,
+	potOdds float64,
+	requiredEquity float64,
 ) error {
 	var amt any
 	if amount != nil {
@@ -430,13 +571,15 @@ func (db *DB) InsertActionLog(
             actor_label, action, amount,
             pot, cur_bet, to_call, min_raise_to, max_raise_to,
             sb_stack, bb_stack, sb_committed, bb_committed,
-            board, sb_hole, bb_hole
+            board, sb_hole, bb_hole,
+            pot_odds, required_equity
         ) VALUES (
             $1,$2,$3,$4,
             $5,$6,$7,
             $8,$9,$10,$11,$12,
             $13,$14,$15,$16,
-            $17,$18,$19
+            $17,$18,$19,
+            $20,$21
         )
     `,
 		matchID, pairIndex, handID, street,
@@ -444,6 +587,7 @@ func (db *DB) InsertActionLog(
 		pot, curBet, toCall, minTo, maxTo,
 		sbStack, bbStack, sbCommitted, bbCommitted,
 		board, sbHole, bbHole,
+		potOdds, requiredEquity,
 	)
 	return err
 }

--- a/server/web/index.html
+++ b/server/web/index.html
@@ -576,7 +576,7 @@
           }
         }
 
-        $('#meta').innerHTML = [
+        const metaRows = [
           metaRow('Match ID', match.id),
           metaRow('Created', new Date(match.created_at).toLocaleString()),
           metaRow('Ended', ended),
@@ -587,7 +587,18 @@
           metaRow('K factor', match.elo_k ?? '—'),
           metaRow('Per-hand K', match.elo_per_hand ?? '—'),
           metaRow('Weight by pot', match.elo_weight_by_pot ? 'Yes' : 'No'),
-        ].join('');
+        ];
+        if (match.seedpack_sha256) {
+          const nameBits = [];
+          if (match.seedpack_name) nameBits.push(safe(match.seedpack_name));
+          if (match.seedpack_version) nameBits.push(`v${safe(match.seedpack_version)}`);
+          const title = nameBits.join(' ').trim() || 'Seedpack';
+          const count = match.seedpack_count ? `${fmt(match.seedpack_count)} seeds` : '';
+          const body = [title, safe(count)].filter(Boolean).join(' · ');
+          const hashShort = safe(String(match.seedpack_sha256).slice(0, 12)) + '…';
+          metaRows.push(metaRow('Seedpack', `${body}<br><span class="mono muted">${hashShort}</span>`));
+        }
+        $('#meta').innerHTML = metaRows.join('');
 
         const participantMeta = {};
         const participants = (d.participants || []).map(p => {


### PR DESCRIPTION
## Summary
- add a seedpack loader to fix mirrored seeds for a duel, persist the pack metadata, and surface it via the REST APIs/UI
- record per-pair bb/100 deltas, expose 95% paired bootstrap confidence intervals on the matchup matrix, and include pot odds in action logs for instant UI rendering
- snapshot glicko ranking checkpoints, expose a Kendall tau stability feed, and cover the new stats helpers with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf43b86dc8832da3c8c8b0febed6f8