### PR TITLE
Refine navigation and replay styling

### DIFF
--- a/server/web/about.html
+++ b/server/web/about.html
@@ -9,7 +9,7 @@
   <script src="/web/app.js" defer></script>
   <script>
     document.addEventListener('DOMContentLoaded', () => {
-      document.querySelectorAll('.topnav a').forEach(a => {
+      document.querySelectorAll('.topnav__links a').forEach(a => {
         try {
           const last = a.getAttribute('href').split('/').pop();
           if (location.pathname.endsWith(last)) a.classList.add('active');
@@ -21,20 +21,96 @@
 <body>
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -187,7 +263,7 @@
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -227,6 +227,28 @@ p {
   .wrap--wide {
     width: min(100%, calc(100vw - 32px));
   }
+  .topnav {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    gap: 16px;
+  }
+  .topnav__links {
+    justify-content: center;
+  }
+  .topnav__actions {
+    justify-content: center;
+  }
+  .elo-card__filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .filter-group {
+    width: 100%;
+  }
+  .elo-card__filters .sort-control {
+    width: 100%;
+    justify-content: space-between;
+  }
 }
 
 @media (max-width: 640px) {
@@ -238,6 +260,17 @@ p {
   .row {
     grid-template-columns: 1fr;
   }
+  .topnav {
+    gap: 12px;
+  }
+  .topnav__links .pill {
+    padding: 0.5rem 0.85rem;
+    font-size: var(--fs-0);
+  }
+  .nav-link__icon {
+    width: 1rem;
+    height: 1rem;
+  }
 }
 
 .site-header {
@@ -247,7 +280,9 @@ p {
   background: rgba(255, 255, 255, 0.94);
   backdrop-filter: blur(16px);
   border-bottom: 1px solid transparent;
-  transition: transform 220ms ease, box-shadow 220ms ease, background-color 220ms ease, border-color 220ms ease;
+  opacity: 1;
+  transition: transform 220ms ease, opacity 220ms ease, box-shadow 220ms ease, background-color 220ms ease,
+    border-color 220ms ease;
 }
 
 .site-header--shadow {
@@ -257,23 +292,133 @@ p {
 }
 
 .site-header--hidden {
-  transform: translateY(-110%);
+  transform: translateY(-120%);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .topnav {
   width: min(1340px, calc(100vw - 56px));
   margin: 0 auto;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 24px;
+  gap: 20px;
   padding: 18px 0;
 }
 
-.topnav nav {
+.topnav__links {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  justify-content: center;
+}
+
+.topnav__actions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.nav-link__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  color: currentColor;
+}
+
+.nav-link__icon svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  stroke: currentColor;
+  stroke-width: 1.75;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
+}
+
+.nav-link__label {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
+.nav-settings {
+  position: relative;
+  font-weight: 600;
+  padding-inline: 1rem;
+}
+
+.nav-settings__panel {
+  position: absolute;
+  top: calc(100% + 14px);
+  right: 0;
+  width: min(320px, calc(100vw - 32px));
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 16px;
+  z-index: 25;
+  opacity: 0;
+  transform: translateY(-6px) scale(0.96);
+  transform-origin: top right;
+  pointer-events: none;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.topnav__actions.is-open .nav-settings__panel {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+
+.topnav__actions.is-open .nav-settings {
+  background: rgba(17, 17, 17, 0.08);
+  border-color: rgba(17, 17, 17, 0.18);
+}
+
+.nav-settings__section {
+  display: grid;
+  gap: 10px;
+}
+
+.nav-settings__section h3 {
+  margin: 0;
+  font-size: var(--fs-1);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.nav-settings__row {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  color: var(--muted);
+  cursor: not-allowed;
+}
+
+.nav-settings__label {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.nav-settings__hint {
+  font-size: var(--fs-0);
+  color: var(--muted);
 }
 
 .brand {
@@ -310,6 +455,15 @@ p {
 
 .brand:hover .logo-badge {
   transform: scale(1.04);
+}
+
+.topnav__links .pill {
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+}
+
+.topnav__links .pill .nav-link__label {
+  font-size: var(--fs-1);
 }
 
 .logo-badge--sm {
@@ -632,6 +786,20 @@ p {
   font-weight: 500;
   color: var(--muted);
   margin-right: 4px;
+}
+
+.sort-control select {
+  border: none;
+  background: transparent;
+  font-weight: 600;
+  font-size: var(--fs-1);
+  color: var(--accent);
+  padding: 0.25rem 0.35rem;
+  cursor: pointer;
+}
+
+.sort-control select:focus {
+  outline: none;
 }
 
 .sort-control button {
@@ -1051,13 +1219,47 @@ p {
 .elo-card__filters {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.elo-card__filters .sort-control {
+  margin-left: auto;
+}
+
+.filter-group {
+  display: grid;
   gap: 10px;
+  min-width: 240px;
+}
+
+.filter-group__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--fs-1);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.filter-group__label svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  fill: none;
 }
 
 .filter-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+  align-items: center;
 }
 
 .filter-chips .pill {
@@ -1218,23 +1420,28 @@ p {
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   align-items: center;
   gap: 14px 18px;
+  padding: 22px;
+  border-radius: 26px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(243, 244, 246, 0.9) 100%);
+  border: 1px solid var(--border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 }
 
 .replay__controls .group {
-  background: rgba(7, 29, 20, 0.35);
-  border-color: rgba(236, 252, 244, 0.2);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  background: var(--surface);
+  border-color: rgba(17, 24, 39, 0.08);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.08);
 }
 
 .replay__controls .group .pill {
-  padding: 0.35rem 0.8rem;
-  color: rgba(236, 252, 244, 0.85);
+  padding: 0.35rem 0.9rem;
+  color: var(--muted);
   border-color: transparent;
 }
 
 .replay__controls .group .pill:hover {
-  background: rgba(236, 252, 244, 0.12);
-  color: #ffffff;
+  background: rgba(17, 17, 17, 0.08);
+  color: var(--accent);
 }
 
 .replay__controls .pill,
@@ -1243,19 +1450,19 @@ p {
 }
 
 .replay__controls .select-pill {
-  background: rgba(7, 29, 20, 0.45);
-  border-color: rgba(236, 252, 244, 0.2);
-  color: rgba(236, 252, 244, 0.92);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
-  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 1.5L6 6.5L10.5 1.5' stroke='%23d1fae5' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  background: var(--surface);
+  border-color: rgba(17, 24, 39, 0.14);
+  color: var(--text);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  background-image: url("data:image/svg+xml,%3Csvg width='12' height='8' viewBox='0 0 12 8' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1.5 1.5L6 6.5L10.5 1.5' stroke='%23111827' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
 }
 
 .replay__controls .select-pill:hover {
-  border-color: rgba(236, 252, 244, 0.42);
+  border-color: rgba(17, 24, 39, 0.28);
 }
 
 .replay__controls .select-pill:focus {
-  box-shadow: 0 0 0 4px rgba(167, 243, 208, 0.25);
+  box-shadow: 0 0 0 4px rgba(17, 24, 39, 0.08);
 }
 
 .replay__status {
@@ -1267,13 +1474,13 @@ p {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: rgba(236, 252, 244, 0.85);
+  color: var(--text);
 }
 
 .replay__speed label,
 .replay__holes label {
   font-size: var(--fs-1);
-  color: rgba(236, 252, 244, 0.72);
+  color: var(--muted);
 }
 
 .replay__speed input[type='range'] {
@@ -1310,7 +1517,7 @@ turn-pill {
 
 .replay__progress .mono {
   font-size: var(--fs-1);
-  color: rgba(236, 252, 244, 0.85);
+  color: var(--muted);
 }
 
 .replay__hand {
@@ -1318,15 +1525,15 @@ turn-pill {
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-weight: 600;
-  color: rgba(236, 252, 244, 0.86);
+  color: var(--accent);
 }
 
 .replay__caption {
   text-align: center;
-  color: rgba(236, 252, 244, 0.8);
+  color: var(--muted);
   margin-bottom: 6px;
   font-size: var(--fs-1);
-  font-family: var(--font-mono);
+  font-family: var(--font-sans);
 }
 
 .replay__pot {
@@ -1358,7 +1565,7 @@ turn-pill {
   border-radius: 32px;
   background: radial-gradient(circle at 50% 20%, #2fa467 0%, #1c7d4a 55%, #0d5230 100%);
   border: 1px solid rgba(8, 53, 34, 0.55);
-  padding: 32px;
+  padding: 48px 36px 36px;
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 32px 80px rgba(9, 44, 27, 0.45);
   color: rgba(236, 252, 244, 0.92);
   overflow: hidden;
@@ -1470,6 +1677,15 @@ turn-pill {
   min-height: var(--card-h);
 }
 
+#board {
+  margin-top: 18px;
+}
+
+#sb_hole,
+#bb_hole {
+  margin-top: 16px;
+}
+
 #sb_hole {
   justify-content: flex-start;
 }
@@ -1480,8 +1696,8 @@ turn-pill {
 
 .cardx {
   --corner-pad: 10px;
-  --rank-size: 24px;
-  --glyph-size: 4.4em;
+  --rank-size: 26px;
+  --glyph-size: 4.35em;
   --tilt: 0deg;
   --card-front-bg: linear-gradient(145deg, #fdfdfd 0%, #f1f5f9 100%);
   --card-front-border: rgba(15, 23, 42, 0.12);
@@ -1494,9 +1710,9 @@ turn-pill {
   position: relative;
   display: grid;
   place-items: center;
-  font-family: 'Syne Mono', var(--font-sans);
-  font-weight: 700;
-  letter-spacing: 0.2px;
+  font-family: 'Space Grotesk', var(--font-display), var(--font-sans);
+  font-weight: 600;
+  letter-spacing: 0.04em;
   color: var(--card-front-color);
   transform-style: preserve-3d;
   transform: rotateY(var(--tilt));
@@ -1654,7 +1870,7 @@ turn-pill {
     --card-h: 138px;
   }
   body.replay-theme .felt {
-    padding: 26px;
+    padding: 32px 24px 26px;
   }
   body.replay-theme .replay__controls {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -1667,7 +1883,7 @@ turn-pill {
     --card-h: 118px;
   }
   body.replay-theme .felt {
-    padding: 20px;
+    padding: 24px 18px 22px;
   }
 }
 
@@ -2018,12 +2234,13 @@ turn-pill {
   background: var(--surface);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
-  overflow: hidden;
+  overflow: visible;
+  padding: 6px 6px 18px;
 }
 
 .page-history table thead th {
   background: var(--surface-alt);
-  border-bottom: 1px solid var(--border);
+  border-bottom: none;
 }
 
 .page-history table tbody tr {
@@ -2036,7 +2253,7 @@ turn-pill {
 }
 
 .history-table__cell {
-  padding: 20px 22px;
+  padding: 20px 25px;
 }
 
 .history-date {
@@ -2054,9 +2271,37 @@ turn-pill {
   color: var(--muted);
 }
 
+.page-history .history-table table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0 6px;
+  margin-top: 6px;
+}
+
+.page-history .history-table thead th {
+  border-radius: 12px 12px 0 0;
+}
+
+.page-history .history-table tbody tr {
+  background: var(--surface);
+  border-radius: 16px;
+}
+
+.page-history .history-table tbody tr td:first-child {
+  border-top-left-radius: 16px;
+  border-bottom-left-radius: 16px;
+}
+
+.page-history .history-table tbody tr td:last-child {
+  border-top-right-radius: 16px;
+  border-bottom-right-radius: 16px;
+}
+
 .history-models {
-  display: grid;
-  gap: 4px;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
   font-weight: 600;
 }
 
@@ -2114,11 +2359,6 @@ turn-pill {
 .page-history .pill.accent {
   box-shadow: 0 12px 28px rgba(59, 130, 246, 0.22);
 }
-.topnav__cluster {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
 
 /* ---------- Reduced motion ------------------------------------------ */
 
@@ -2131,4 +2371,7 @@ turn-pill {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+.page-history .history-table tbody tr td {
+  border-bottom: none;
 }

--- a/server/web/app.js
+++ b/server/web/app.js
@@ -40,7 +40,7 @@
       applyScrollState();
     }
 
-    const navLinks = document.querySelectorAll('.topnav nav a[href]');
+    const navLinks = document.querySelectorAll('.topnav__links a[href]');
     if (navLinks.length) {
       const pathParts = location.pathname.split('/');
       const currentSlug = (pathParts[pathParts.length - 1] || '').toLowerCase();
@@ -57,6 +57,50 @@
           link.removeAttribute('aria-current');
         }
       });
+    }
+
+    const settingsToggle = document.querySelector('.nav-settings');
+    const settingsPanel = document.getElementById('navSettingsPanel');
+    const actionsHost = settingsToggle?.closest('.topnav__actions');
+    if (settingsToggle && settingsPanel && actionsHost) {
+      const closePanel = () => {
+        actionsHost.classList.remove('is-open');
+        settingsToggle.setAttribute('aria-expanded', 'false');
+        settingsPanel.hidden = true;
+      };
+
+      const openPanel = () => {
+        actionsHost.classList.add('is-open');
+        settingsToggle.setAttribute('aria-expanded', 'true');
+        settingsPanel.hidden = false;
+      };
+
+      const togglePanel = () => {
+        const isOpen = actionsHost.classList.contains('is-open');
+        if (isOpen) {
+          closePanel();
+        } else {
+          openPanel();
+          settingsPanel.focus?.({ preventScroll: true });
+        }
+      };
+
+      settingsToggle.addEventListener('click', event => {
+        event.preventDefault();
+        togglePanel();
+      });
+
+      document.addEventListener('click', event => {
+        if (!actionsHost.contains(event.target)) {
+          closePanel();
+        }
+      });
+
+      document.addEventListener('keydown', event => {
+        if (event.key === 'Escape') closePanel();
+      });
+
+      closePanel();
     }
   };
 

--- a/server/web/bot.html
+++ b/server/web/bot.html
@@ -15,7 +15,7 @@
 
     // nav active state
     document.addEventListener('DOMContentLoaded', ()=>{
-      document.querySelectorAll('.topnav a').forEach(a=>{
+      document.querySelectorAll('.topnav__links a').forEach(a=>{
         try{
           if(location.pathname.endsWith(a.getAttribute('href').split('/').pop()))
             a.classList.add('active');
@@ -225,20 +225,96 @@
 <body>
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -288,7 +364,7 @@
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -223,7 +223,7 @@
     });
 
     function highlightNav() {
-      document.querySelectorAll('.topnav a').forEach(a => {
+      document.querySelectorAll('.topnav__links a').forEach(a => {
         try {
           const last = a.getAttribute('href').split('/').pop();
           if (location.pathname.endsWith(last)) a.classList.add('active');
@@ -921,20 +921,96 @@
 <body class="page-elo">
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -954,7 +1030,19 @@
           </div>
         </div>
         <div class="elo-card__filters">
-          <div id="companyFilters" class="filter-chips"></div>
+          <div class="filter-group" aria-label="Company filters">
+            <span class="filter-group__label">
+              <svg viewBox="0 0 24 24" role="presentation">
+                <path d="M4 21h16"></path>
+                <path d="M4 10h16"></path>
+                <path d="M9 21V10"></path>
+                <path d="M15 21V10"></path>
+                <path d="M12 3v7"></path>
+              </svg>
+              Filter by company
+            </span>
+            <div id="companyFilters" class="filter-chips"></div>
+          </div>
           <label class="sort-control" for="sortMode">
             <span class="sort-control__label">Sort by</span>
             <select id="sortMode" name="sortMode" aria-label="Sort Elo series">
@@ -979,7 +1067,7 @@
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -144,27 +144,103 @@
 <body class="page-history">
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
   <main class="page-content">
     <div class="wrap wrap--wide">
       <div class="history-hero">
-        <a class="history-hero__logo" href="/web/index.html" aria-label="PokerBench home">
+        <a class="history-hero__logo" href="/web/live.html" aria-label="PokerBench latest match">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </a>
         <div class="history-hero__body">
@@ -195,7 +271,7 @@
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -468,20 +468,96 @@ function rowHTML(i, r, metric){
 <body>
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -536,7 +612,7 @@ function rowHTML(i, r, metric){
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>

--- a/server/web/live.html
+++ b/server/web/live.html
@@ -35,20 +35,96 @@
 <body>
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -69,7 +145,7 @@
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -9,7 +9,7 @@
   <script src="/web/app.js" defer></script>
   <script>
     document.addEventListener('DOMContentLoaded', ()=>{
-      document.querySelectorAll('.topnav a').forEach(a=>{ try{ if(location.pathname.endsWith(a.getAttribute('href').split('/').pop())) a.classList.add('active'); }catch(e){} });
+      document.querySelectorAll('.topnav__links a').forEach(a=>{ try{ if(location.pathname.endsWith(a.getAttribute('href').split('/').pop())) a.classList.add('active'); }catch(e){} });
     });
     const $ = s => document.querySelector(s);
     function heat(p){
@@ -70,20 +70,96 @@
 <body>
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -100,7 +176,7 @@
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -293,20 +293,96 @@
 <body class="replay-theme">
   <header class="site-header">
     <div class="topnav">
-      <a class="brand" href="/web/index.html" aria-label="PokerBench home">
+      <a class="brand" href="/web/live.html" aria-label="PokerBench latest match">
         <span class="brand__mark logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>
         <span class="brand__text">PokerBench</span>
       </a>
-      <nav>
-        <a class="pill" href="/web/leaderboard.html">Leaderboard</a>
-        <a class="pill" href="/web/matrix.html">Matrix</a>
-        <a class="pill" href="/web/elo.html">Elo</a>
-        <a class="pill" href="/web/replay.html">Replay</a>
-        <a class="pill" href="/web/history.html">History</a>
-        <a class="pill" href="/web/about.html">About</a>
+      <nav class="topnav__links" aria-label="Primary navigation">
+        <a class="pill nav-link" href="/web/leaderboard.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M16 21H8m4-4v4m0-4a4 4 0 0 0 4-4V4H8v9a4 4 0 0 0 4 4ZM5 4H4a2 2 0 0 0-2 2v1a5 5 0 0 0 5 5h.5M19 4h1a2 2 0 0 1 2 2v1a5 5 0 0 1-5 5h-.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Leaderboard</span>
+        </a>
+        <a class="pill nav-link" href="/web/matrix.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <rect x="3" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="3" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="3" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+              <rect x="14" y="14" width="7" height="7" rx="1.5" fill="none"></rect>
+            </svg>
+          </span>
+          <span class="nav-link__label">Matrix</span>
+        </a>
+        <a class="pill nav-link" href="/web/elo.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M4 19h16"></path>
+              <path d="M4 16.5 8.5 11l4 3.5L20 6.5"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Elo</span>
+        </a>
+        <a class="pill nav-link" href="/web/replay.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M14.752 11.168 11.1 8.64A1 1 0 0 0 9.5 9.64v4.72a1 1 0 0 0 1.6.8l3.652-2.528a1 1 0 0 0 0-1.664ZM21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">Replay</span>
+        </a>
+        <a class="pill nav-link" href="/web/history.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M12 6v6h4.5"></path>
+              <path d="M21.75 12a9.75 9.75 0 1 1-19.5 0 9.75 9.75 0 0 1 19.5 0Z"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">History</span>
+        </a>
+        <a class="pill nav-link" href="/web/about.html">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle cx="12" cy="12" r="9" fill="none"></circle>
+              <path d="M12 10v6"></path>
+              <path d="M12 7h.01"></path>
+            </svg>
+          </span>
+          <span class="nav-link__label">About</span>
+        </a>
       </nav>
+      <div class="topnav__actions">
+        <button class="pill nav-link nav-settings" type="button" aria-expanded="false" aria-controls="navSettingsPanel">
+          <span class="nav-link__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" role="presentation">
+              <path d="M10.5 3.5 9.8 5.7a1 1 0 0 1-.7.7L6.9 6.9a1 1 0 0 0-.5 1.6l1.6 1.6a1 1 0 0 1 .3.9l-.4 2.3a1 1 0 0 0 1 1.2h2.2a1 1 0 0 1 .9.6l1 2.1a1 1 0 0 0 1.8 0l1-2.1a1 1 0 0 1 .9-.6h2.2a1 1 0 0 0 1-1.2l-.4-2.3a1 1 0 0 1 .3-.9l1.6-1.6a1 1 0 0 0-.5-1.6l-2.2-.5a1 1 0 0 1-.7-.7l-.7-2.2a1 1 0 0 0-1-.7h-2.4a1 1 0 0 0-1 .7Z"></path>
+              <circle cx="12" cy="12" r="2.5"></circle>
+            </svg>
+          </span>
+          <span class="nav-link__label">Settings</span>
+        </button>
+        <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
+          <div class="nav-settings__section">
+            <h3>Display</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Theme</span>
+              <span class="nav-settings__hint">Auto (coming soon)</span>
+            </button>
+          </div>
+          <div class="nav-settings__section">
+            <h3>Notifications</h3>
+            <button class="nav-settings__row" type="button" disabled>
+              <span class="nav-settings__label">Match alerts</span>
+              <span class="nav-settings__hint">Not yet available</span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -378,7 +454,7 @@
 
   <footer class="site-footer">
     <div class="site-footer__inner">
-      <a class="site-footer__brand" href="/web/index.html">
+      <a class="site-footer__brand" href="/web/live.html">
         <span class="logo-badge logo-badge--sm">
           <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
         </span>


### PR DESCRIPTION
## Summary
- refresh the global navigation with inline icons, a scroll-aware settings dropdown, and updated PokerBench links
- restyle the replay experience with lighter controls, repositioned cards, and an updated cardface font tied to suit colours
- clean up history and analytics surfaces with wider spacing, richer match tiles, and clearer company filtering cues

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf65721354832db571fab39dfa468a