### PR TITLE
Improve OpenRouter site URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ DUEL_SEEDS=5 \
 
 When routing through OpenRouter, set `LLM_PROVIDER=openrouter` and provide `OPENROUTER_MODELS` instead of `OPENAI_MODELS`.
 
+Personal OpenRouter keys also expect the caller to include the site metadata headers. Export `OPENROUTER_SITE_URL` (and optionally `OPENROUTER_TITLE`) so the client can attach them automatically:
+
+```bash
+export OPENROUTER_SITE_URL="https://your-app.example.com"
+export OPENROUTER_TITLE="PokerBench (local dev)"
+```
+
+The site URL defaults to `http://localhost`, keeping local development simple while still allowing production deployments to report their own domain.
+
 Windows-friendly PowerShell helpers live in `scripts/run-openai-pairwise.ps1` and `scripts/run-openai-matrix.ps1`.
 
 ---
@@ -170,6 +179,8 @@ Windows-friendly PowerShell helpers live in `scripts/run-openai-pairwise.ps1` an
 | --- | --- | --- |
 | `OPENAI_API_KEY` / `OPENAI_API_KEY_FILE` | Auth token for the LLM provider. | _(required)_ |
 | `OPENROUTER_API_KEY` / `OPENROUTER_API_KEY_FILE` | Alternative secret for OpenRouter users (mirrors into `OPENAI_API_KEY`). | _(optional)_ |
+| `OPENROUTER_SITE_URL` | Referer value registered with OpenRouter (falls back to `http://localhost`). | `http://localhost` |
+| `OPENROUTER_TITLE` | Optional app name advertised to OpenRouter. | `PokerBench` |
 | `DATABASE_URL` | PostgreSQL DSN (`postgres://user:pass@host:port/db?sslmode=`). | `postgres://poker:poker@localhost:5432/thunderdome?sslmode=disable` |
 | `PORT` | HTTP port for the server mode. | `8080` |
 | `LLM_PROVIDER` | Force provider precedence (`openai` or `openrouter`). | derived |

--- a/compose.env.example
+++ b/compose.env.example
@@ -26,8 +26,8 @@ OPENAI_MODEL=gpt-4o-mini
 # OPENAI_API_BASE=https://openrouter.ai/api/v1
 # LLM_COMPANY=OpenRouter
 # OPENROUTER_API_KEY=or-key-...            # or drop the key in ./secrets/openrouter_api_key.txt
-# OPENROUTER_SITE_URL=https://your-site.example.com
-# OPENROUTER_TITLE=PokerBench
+# OPENROUTER_SITE_URL=https://your-site.example.com     # required for personal keys (defaults to http://localhost)
+# OPENROUTER_TITLE=PokerBench                           # optional label shown in OpenRouter logs
 # OPENROUTER_MODEL=meta-llama/llama-3.1-70b-instruct
 # # Or specify seat assignments explicitly:
 # OPENROUTER_MODEL_A=meta-llama/llama-3.1-70b-instruct

--- a/server/llm/openrouter.go
+++ b/server/llm/openrouter.go
@@ -2,6 +2,9 @@ package llm
 
 import (
 	"errors"
+	"fmt"
+	"log"
+	"net/url"
 	"os"
 	"strings"
 )
@@ -129,12 +132,10 @@ func resolveAPIConfig(model string) (apiConfig, error) {
 	cfg.Organization = strings.TrimSpace(os.Getenv("OPENAI_ORG"))
 
 	if cfg.Kind == providerOpenRouter {
-		siteURL := strings.TrimSpace(os.Getenv("OPENROUTER_SITE_URL"))
-		if siteURL == "" {
-			siteURL = strings.TrimSpace(os.Getenv("SITE_URL"))
-		}
-		if siteURL == "" {
-			siteURL = "https://pokerbench.ai"
+		siteURL, err := resolveOpenRouterSiteURL()
+		if err != nil {
+			log.Printf("OpenRouter site URL error: %v", err)
+			return apiConfig{}, err
 		}
 		if siteURL != "" {
 			cfg.ExtraHeaders["HTTP-Referer"] = siteURL
@@ -163,6 +164,39 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func resolveOpenRouterSiteURL() (string, error) {
+	siteURL := strings.TrimSpace(os.Getenv("OPENROUTER_SITE_URL"))
+	if siteURL == "" {
+		siteURL = strings.TrimSpace(os.Getenv("SITE_URL"))
+	}
+	if siteURL == "" {
+		port := strings.TrimSpace(os.Getenv("PORT"))
+		if port != "" {
+			siteURL = fmt.Sprintf("http://localhost:%s", port)
+		} else {
+			siteURL = "http://localhost"
+		}
+	}
+	siteURL = strings.TrimRight(siteURL, "/")
+
+	if siteURL == "" {
+		return "", errors.New("missing OpenRouter site URL: set OPENROUTER_SITE_URL or SITE_URL")
+	}
+
+	parsed, err := url.Parse(siteURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid OpenRouter site URL %q: %w", siteURL, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("invalid OpenRouter site URL scheme %q: must be http or https", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("invalid OpenRouter site URL %q: host missing", siteURL)
+	}
+
+	return parsed.String(), nil
 }
 
 func PreferOpenRouter() bool {

--- a/server/llm/openrouter_test.go
+++ b/server/llm/openrouter_test.go
@@ -12,10 +12,10 @@ func TestResolveAPIConfigOpenRouterDefaults(t *testing.T) {
 	if cfg.Kind != providerOpenRouter {
 		t.Fatalf("expected providerOpenRouter, got %v", cfg.Kind)
 	}
-	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != "https://pokerbench.ai" {
+	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != "http://localhost" {
 		t.Fatalf("unexpected HTTP-Referer: %q", got)
 	}
-	if got := cfg.ExtraHeaders["Referer"]; got != "https://pokerbench.ai" {
+	if got := cfg.ExtraHeaders["Referer"]; got != "http://localhost" {
 		t.Fatalf("unexpected Referer: %q", got)
 	}
 	if got := cfg.ExtraHeaders["X-Title"]; got != "PokerBench" {
@@ -43,5 +43,14 @@ func TestResolveAPIConfigOpenRouterOverrides(t *testing.T) {
 	}
 	if got := cfg.ExtraHeaders["X-Title"]; got != "Custom Title" {
 		t.Fatalf("unexpected X-Title: %q", got)
+	}
+}
+
+func TestResolveAPIConfigOpenRouterInvalidSiteURL(t *testing.T) {
+	t.Setenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1")
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_SITE_URL", "ftp://example.com/bad")
+	if _, err := resolveAPIConfig("meta-llama/llama-3.1-70b-instruct"); err == nil {
+		t.Fatalf("expected error for invalid site URL, got nil")
 	}
 }


### PR DESCRIPTION
## Summary
- validate and normalize the OpenRouter site URL before attaching Referer headers, with logging on misconfiguration
- default OpenRouter runs to a localhost Referer while surfacing errors for invalid values and refresh the unit tests
- document the OPENROUTER_SITE_URL/OPENROUTER_TITLE setup in the README and compose.env example

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf702cb0c0832d82b44e17756f7702