### PR TITLE
Handle scheme-less OpenRouter site URLs

### DIFF
--- a/server/llm/openrouter.go
+++ b/server/llm/openrouter.go
@@ -179,13 +179,35 @@ func resolveOpenRouterSiteURL() (string, error) {
 			siteURL = "http://localhost"
 		}
 	}
-	siteURL = strings.TrimRight(siteURL, "/")
 
-	if siteURL == "" {
+	normalized, err := normalizeOpenRouterSiteURL(siteURL)
+	if err != nil {
+		return "", err
+	}
+	return normalized, nil
+}
+
+func normalizeOpenRouterSiteURL(siteURL string) (string, error) {
+	trimmed := strings.TrimSpace(siteURL)
+	if trimmed == "" {
 		return "", errors.New("missing OpenRouter site URL: set OPENROUTER_SITE_URL or SITE_URL")
 	}
+	trimmed = strings.TrimRight(trimmed, "/")
 
-	parsed, err := url.Parse(siteURL)
+	if !strings.Contains(trimmed, "://") {
+		lower := strings.ToLower(trimmed)
+		switch {
+		case strings.HasPrefix(lower, "localhost"),
+			strings.HasPrefix(lower, "127."),
+			strings.HasPrefix(lower, "[::1]"),
+			strings.HasPrefix(lower, "[0:0:0:0:0:0:0:1]"):
+			trimmed = "http://" + trimmed
+		default:
+			trimmed = "https://" + trimmed
+		}
+	}
+
+	parsed, err := url.Parse(trimmed)
 	if err != nil {
 		return "", fmt.Errorf("invalid OpenRouter site URL %q: %w", siteURL, err)
 	}
@@ -196,7 +218,10 @@ func resolveOpenRouterSiteURL() (string, error) {
 		return "", fmt.Errorf("invalid OpenRouter site URL %q: host missing", siteURL)
 	}
 
-	return parsed.String(), nil
+	parsed.Fragment = ""
+	normalized := parsed.String()
+	normalized = strings.TrimRight(normalized, "/")
+	return normalized, nil
 }
 
 func PreferOpenRouter() bool {

--- a/server/llm/openrouter_test.go
+++ b/server/llm/openrouter_test.go
@@ -54,3 +54,36 @@ func TestResolveAPIConfigOpenRouterInvalidSiteURL(t *testing.T) {
 		t.Fatalf("expected error for invalid site URL, got nil")
 	}
 }
+
+func TestResolveAPIConfigOpenRouterSiteURLNormalization(t *testing.T) {
+	t.Setenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1")
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_SITE_URL", "app.example.com/bench/")
+	cfg, err := resolveAPIConfig("meta-llama/llama-3.1-70b-instruct")
+	if err != nil {
+		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != "https://app.example.com/bench" {
+		t.Fatalf("unexpected HTTP-Referer: %q", got)
+	}
+	if got := cfg.ExtraHeaders["Referer"]; got != "https://app.example.com/bench" {
+		t.Fatalf("unexpected Referer: %q", got)
+	}
+}
+
+func TestResolveAPIConfigOpenRouterSiteURLLocalhost(t *testing.T) {
+	t.Setenv("OPENAI_API_BASE", "https://openrouter.ai/api/v1")
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_SITE_URL", "localhost:3000/ui")
+	cfg, err := resolveAPIConfig("meta-llama/llama-3.1-70b-instruct")
+	if err != nil {
+		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	want := "http://localhost:3000/ui"
+	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != want {
+		t.Fatalf("unexpected HTTP-Referer: %q", got)
+	}
+	if got := cfg.ExtraHeaders["Referer"]; got != want {
+		t.Fatalf("unexpected Referer: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- normalize OpenRouter site URL inputs by auto-prepending a scheme when missing
- ensure localhost-style values default to http while remote domains use https
- extend OpenRouter configuration tests to cover scheme normalization cases

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf868bfe9c832daee9778f1abbcf2c