### PR TITLE
Add guided tooltips with persistent preference

### DIFF
--- a/server/web/about.html
+++ b/server/web/about.html
@@ -101,6 +101,10 @@
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -408,7 +408,28 @@ p {
   background: var(--surface-alt);
   border: 1px solid var(--border);
   color: var(--muted);
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.nav-settings__row:not([disabled]):hover,
+.nav-settings__row:not([disabled]):focus-visible {
+  background: var(--surface);
+  border-color: var(--border-strong);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+}
+
+.nav-settings__row[disabled] {
   cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.nav-settings__row.is-off .nav-settings__label {
+  color: var(--muted);
+}
+
+.nav-settings__row.is-off .nav-settings__hint {
+  color: var(--muted-soft);
 }
 
 .nav-settings__label {
@@ -2500,6 +2521,96 @@ turn-pill {
 .bb-zone .muted,
 .sb-zone .muted {
   color: var(--muted);
+}
+
+.inline-tip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+  width: 22px;
+  height: 22px;
+  margin-left: 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+  transition: background var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.inline-tip:hover,
+.inline-tip:focus-visible {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-contrast);
+  box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.1);
+}
+
+.inline-tip::after {
+  content: attr(data-tip);
+  position: absolute;
+  bottom: calc(100% + 14px);
+  left: 50%;
+  transform: translate(-50%, 6px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  color: var(--text);
+  font-size: var(--fs-1);
+  line-height: 1.45;
+  box-shadow: var(--shadow-sm);
+  opacity: 0;
+  pointer-events: none;
+  width: max-content;
+  max-width: 280px;
+  text-align: left;
+  transition: opacity var(--transition), transform var(--transition);
+  z-index: 40;
+  background-clip: padding-box;
+}
+
+.inline-tip::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 4px);
+  left: 50%;
+  width: 14px;
+  height: 14px;
+  transform: translate(-50%, 10px) rotate(45deg);
+  background: var(--surface);
+  border-left: 1px solid var(--border);
+  border-top: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition), transform var(--transition);
+  z-index: 39;
+}
+
+.inline-tip:hover::after,
+.inline-tip:hover::before,
+.inline-tip:focus-visible::after,
+.inline-tip:focus-visible::before {
+  opacity: 1;
+}
+
+.inline-tip:hover::after,
+.inline-tip:focus-visible::after {
+  transform: translate(-50%, 0);
+}
+
+.inline-tip:hover::before,
+.inline-tip:focus-visible::before {
+  transform: translate(-50%, 2px) rotate(45deg);
+}
+
+body.tooltips-disabled .inline-tip {
+  display: none;
 }
 
 .tooltip-pop {

--- a/server/web/app.js
+++ b/server/web/app.js
@@ -59,6 +59,52 @@
       });
     }
 
+    const TOOLTIP_COOKIE = 'pb_tooltips';
+    const TOOLTIP_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+    const getCookie = name => {
+      if (!name || !document.cookie) return '';
+      const prefix = `${name}=`;
+      const parts = document.cookie.split(';');
+      for (const part of parts) {
+        const trimmed = part.trim();
+        if (trimmed && trimmed.startsWith(prefix)) {
+          return decodeURIComponent(trimmed.slice(prefix.length));
+        }
+      }
+      return '';
+    };
+
+    const setCookie = (name, value, maxAge) => {
+      if (!name) return;
+      const safeValue = encodeURIComponent(value ?? '');
+      const age = Number.isFinite(maxAge) ? `; max-age=${Math.max(0, Math.trunc(maxAge))}` : '';
+      document.cookie = `${name}=${safeValue}${age}; path=/; SameSite=Lax`;
+    };
+
+    let tooltipToggle = null;
+    let tooltipHint = null;
+    let tooltipsEnabled = getCookie(TOOLTIP_COOKIE) !== 'off';
+
+    const syncTooltipsPreference = () => {
+      if (document.body) {
+        document.body.classList.toggle('tooltips-disabled', !tooltipsEnabled);
+      }
+      if (tooltipToggle) {
+        tooltipToggle.setAttribute('aria-checked', tooltipsEnabled ? 'true' : 'false');
+        tooltipToggle.classList.toggle('is-off', !tooltipsEnabled);
+        tooltipToggle.setAttribute('title', tooltipsEnabled ? 'Disable guided tips' : 'Enable guided tips');
+      }
+      if (tooltipHint) {
+        tooltipHint.textContent = tooltipsEnabled ? 'On' : 'Off';
+      }
+      if (!tooltipsEnabled && document.activeElement?.classList?.contains('inline-tip')) {
+        document.activeElement.blur();
+      }
+    };
+
+    syncTooltipsPreference();
+
     const settingsToggle = document.querySelector('.nav-settings');
     const settingsPanel = document.getElementById('navSettingsPanel');
     const actionsHost = settingsToggle?.closest('.topnav__actions');
@@ -99,6 +145,18 @@
       document.addEventListener('keydown', event => {
         if (event.key === 'Escape') closePanel();
       });
+
+      tooltipToggle = settingsPanel.querySelector('[data-setting="tooltips"]');
+      tooltipHint = settingsPanel.querySelector('[data-setting-state="tooltips"]');
+      syncTooltipsPreference();
+
+      if (tooltipToggle) {
+        tooltipToggle.addEventListener('click', () => {
+          tooltipsEnabled = !tooltipsEnabled;
+          syncTooltipsPreference();
+          setCookie(TOOLTIP_COOKIE, tooltipsEnabled ? 'on' : 'off', TOOLTIP_COOKIE_MAX_AGE);
+        });
+      }
 
       closePanel();
     }

--- a/server/web/bot.html
+++ b/server/web/bot.html
@@ -344,6 +344,10 @@
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -1017,6 +1017,10 @@
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -224,6 +224,10 @@
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -548,6 +548,10 @@ function rowHTML(i, r, metric){
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>
@@ -570,8 +574,12 @@ function rowHTML(i, r, metric){
       <div class="card lb-card">
         <div class="lb-card__header">
           <div>
-            <h1>Leaderboard</h1>
-            <div class="muted">Compare bots by rating, volume, win rate, and judge accuracy.</div>
+            <h1>Leaderboard
+              <button class="inline-tip" type="button" data-tip="Click any model name to open its PokerBench profile with full stats and recent matches." aria-label="Tip: click models for more information">i</button>
+            </h1>
+            <div class="muted">Compare bots by rating, volume, win rate, and judge accuracy.
+              <button class="inline-tip" type="button" data-tip="PokerBench runs continuous heads-up poker matches between bots, tracks every hand, and updates ratings as results arrive." aria-label="Tip: how PokerBench runs matches">i</button>
+            </div>
           </div>
           <div class="sort-control" role="group" aria-label="Rating metric">
             <span class="sort-control__label">Rating</span>

--- a/server/web/live.html
+++ b/server/web/live.html
@@ -115,6 +115,10 @@
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -168,6 +168,10 @@
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -373,6 +373,10 @@
         <div class="nav-settings__panel" id="navSettingsPanel" hidden tabindex="-1">
           <div class="nav-settings__section">
             <h3>Display</h3>
+            <button class="nav-settings__row" type="button" data-setting="tooltips" role="switch" aria-checked="true">
+              <span class="nav-settings__label">Guided tips</span>
+              <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
+            </button>
             <button class="nav-settings__row" type="button" disabled>
               <span class="nav-settings__label">Theme</span>
               <span class="nav-settings__hint">Auto (coming soon)</span>


### PR DESCRIPTION
## Summary
- add inline guided tooltips that explain how to use the leaderboard
- introduce a settings toggle backed by cookies to persist tooltip preference across pages
- refresh navigation settings styling to support interactive controls on every page

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf86658570832db9ecd3bde6b7220a