### PR TITLE
Enhance matrix legend and tooltips

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -1164,6 +1164,64 @@ p {
   overflow-x: auto;
 }
 
+.matrix-card {
+  position: relative;
+  padding-top: 72px;
+}
+
+.matrix-card__body {
+  margin-top: 12px;
+}
+
+.matrix-card__legend {
+  position: absolute;
+  top: 24px;
+  right: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.matrix-card__legend-gradient {
+  display: inline-block;
+  width: 140px;
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, hsl(240 70% 42%) 0%, hsl(0 70% 42%) 100%);
+}
+
+.matrix-card__legend-label {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.matrix-table .matrix-sticky {
+  position: sticky;
+  left: 0;
+  z-index: 3;
+  background: var(--surface);
+}
+
+.matrix-table thead th.matrix-sticky {
+  z-index: 4;
+}
+
+.matrix-table tbody tr:hover th.matrix-sticky {
+  background: var(--surface-alt);
+}
+
+.matrix-table th.matrix-sticky {
+  min-width: 200px;
+  box-shadow: 4px 0 12px rgba(15, 23, 42, 0.08);
+}
+
 .matrix-table th.rot {
   writing-mode: vertical-rl;
   transform: rotate(180deg);
@@ -1174,6 +1232,7 @@ p {
 .matrix-diag {
   text-align: center;
   color: var(--muted);
+  background: transparent !important;
 }
 
 .table-compact {

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -54,27 +54,34 @@
         const pa = total>0 ? p.a_wins/total : 0.5;
         wins[i][j] = pa; wins[j][i] = 1-pa;
       }
-      let html = '<div class="table-wrap"><table class="matrix-table"><thead><tr><th>Model</th>' + bots.map(b=>`<th class=\"rot\" title=\"${b.name}\">${shortName(b.name)}</th>`).join('') + '</tr></thead><tbody>';
+      let html = '<div class="table-wrap"><table class="matrix-table"><thead><tr><th class=\"matrix-sticky\">Model</th>' + bots.map(b=>`<th class=\"rot\" title=\"${b.name}\">${shortName(b.name)}</th>`).join('') + '</tr></thead><tbody>';
       bots.forEach((b, i)=>{
-        html += `<tr><th scope="row"><div>${shortName(b.name)}</div><div class=\"sub\">${b.company}</div></th>`;
+        html += `<tr><th scope="row" class="matrix-sticky"><div>${shortName(b.name)}</div><div class=\"sub\">${b.company}</div></th>`;
         for(let j=0;j<N;j++){
-          if(i===j){ html += '<td class="matrix-diag">-</td>'; continue; }
+          if(i===j){
+            const name = bots[i]?.name || '—';
+            const diagTitle = `${name} self-play intentionally left blank`;
+            const diagAria = `Self matchup for ${name} — intentionally blank`;
+            html += `<td class="matrix-diag" title="${escapeAttr(diagTitle)}" aria-label="${escapeAttr(diagAria)}"></td>`;
+            continue;
+          }
           const p = wins[i][j];
-          const pct = p==null? '-' : Math.round(100*p)+'%';
+          const pct = p==null? '—' : Math.round(100*p)+'%';
+          const q = wins[j][i];
+          const oppPct = q==null? '—' : Math.round(100*q)+'%';
           const exp = Math.round(100*eloProb(elo[i], elo[j]))+'%';
           const aName = bots[i]?.name || '—';
           const bName = bots[j]?.name || '—';
           const pairLabel = `${aName} vs ${bName}`;
-          const tipParts = [pairLabel];
-          if (hands[i][j]) {
-            tipParts.push(`${pct} actual of ${hands[i][j]} hands`);
-          } else {
-            tipParts.push(`${pct} actual`);
-          }
-          tipParts.push(`${exp} expected (Elo)`);
+          const handCount = hands[i][j] || 0;
+          const sample = handCount > 0 ? ` (n=${handCount})` : '';
+          const duelLine = `${aName} vs ${bName}: ${pct}${sample} • ${bName} vs ${aName}: ${oppPct}${sample}`;
+          const tipParts = [duelLine, `Expected (Elo): ${exp}`];
           const tip = tipParts.join('\n');
           const style = heat(p==null?0.5:p);
-          const aria = pct === '-' ? `${pairLabel}` : `${pct} win rate — ${pairLabel}`;
+          const aria = p==null
+            ? `${pairLabel} — no completed hands yet`
+            : `${pairLabel}: ${pct} over ${handCount} hands. Reverse: ${bName} vs ${aName} ${oppPct}. Expected (Elo) ${exp}.`;
           html += `<td class="num" style="${style}" title="${escapeAttr(tip)}" aria-label="${escapeAttr(aria)}">${pct}</td>`;
         }
         html += '</tr>';
@@ -193,10 +200,17 @@
     <div class="wrap wrap--wide">
       <div class="card card--compact">
         <h1>Win Percentage Matrix <button class="inline-tip" type="button" data-tip="Each cell shows A's win rate versus B based on completed hands. Hover a result to see the sample size and Elo expectation." aria-label="Tip: how to read the win matrix">i</button></h1>
-        <div class="muted">Cell shows A’s win rate vs B (hand-level). Heat indicates stronger advantage.</div>
+        <div class="muted">Cell = A’s win rate vs B; diagonal blank by design.</div>
       </div>
 
-      <div class="card" id="matrix">Loading…</div>
+      <div class="card matrix-card">
+        <div class="matrix-card__legend" aria-hidden="true">
+          <span class="matrix-card__legend-label">0%</span>
+          <span class="matrix-card__legend-gradient"></span>
+          <span class="matrix-card__legend-label">100%</span>
+        </div>
+        <div class="matrix-card__body" id="matrix">Loading…</div>
+      </div>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- add a pinned gradient legend and refreshed explainer copy on the win matrix
- render matrix cells with bidirectional hover details while leaving the diagonal intentionally blank
- style the matrix for sticky row headers and the new legend presentation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf976cf0d0832db0232c63fc9422ae