### PR TITLE
Revamp replay experience

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -1685,430 +1685,6 @@ ion);
   color: var(--muted);
 }
 
-/* ---------- Replay page -------------------------------------------- */
-
-.replay-theme {
-  background: var(--surface);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-}
-
-.replay-theme .card {
-  box-shadow: none;
-  border: none;
-  padding: 0;
-}
-
-.replay {
-  display: grid;
-  gap: 28px;
-}
-
-.replay__intro {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  align-items: center;
-  margin-top: 12px;
-}
-
-.replay__map {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-  margin-left: auto;
-}
-
-.replay__map .pill {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.1);
-  font-size: var(--fs-1);
-  color: var(--text);
-}
-
-.replay__controls {
-  grid-column: 1 / -1;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  align-items: center;
-  gap: 18px 24px;
-  padding: 26px;
-  border-radius: 28px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.97) 0%, rgba(240, 244, 255, 0.9) 100%);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.78), 0 24px 48px rgba(15, 23, 42, 0.12);
-}
-
-.replay__btn-group {
-  display: inline-flex;
-  align-items: stretch;
-  gap: 0;
-  padding: 0;
-  border-radius: 999px;
-  border: 1px solid rgba(17, 24, 39, 0.16);
-  background: var(--surface);
-  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.1);
-  overflow: hidden;
-}
-
-.replay__btn-group .pill {
-  border-radius: 0;
-  border: none;
-  padding: 0.45rem 1.1rem;
-  color: var(--muted);
-  background: transparent;
-  transition: background var(--transition), color var(--transition);
-}
-
-.replay__btn-group .pill + .pill {
-  border-left: 1px solid var(--border);
-}
-
-.replay__btn-group .pill:first-child {
-  border-radius: 999px 0 0 999px;
-}
-
-.replay__btn-group .pill:last-child {
-  border-radius: 0 999px 999px 0;
-}
-
-.replay__btn-group .pill:hover {
-  background: rgba(17, 24, 39, 0.08);
-  color: var(--accent);
-}
-
-.replay__controls .pill,
-.replay__controls .select-pill {
-  font-size: var(--fs-1);
-}
-
-.replay__controls .select-pill {
-  background: var(--surface);
-  border-color: rgba(17, 24, 39, 0.14);
-  color: var(--text);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
-}
-
-.replay__controls .select-pill:hover {
-  border-color: rgba(17, 24, 39, 0.28);
-}
-
-.replay__controls .select-pill:focus {
-  box-shadow: 0 0 0 4px rgba(17, 24, 39, 0.08);
-}
-
-.replay__speed,
-.replay__holes {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text);
-}
-
-.replay__speed label,
-.replay__holes label {
-  font-size: var(--fs-1);
-  color: var(--muted);
-  font-weight: 600;
-}
-
-.replay__speed input[type='range'] {
-  width: 180px;
-}
-
-.replay__holes .select-pill {
-  min-width: 150px;
-}
-
-turn-pill {
-  background: linear-gradient(90deg, #16a34a 0%, #4ade80 100%);
-  color: #f0fdf4;
-  font-weight: 700;
-  border-color: transparent;
-  box-shadow: 0 10px 24px rgba(74, 222, 128, 0.25);
-}
-
-.replay__range {
-  flex: 1 1 240px;
-}
-
-.replay__progress {
-  display: grid;
-  gap: 10px;
-  grid-column: 1 / -1;
-}
-
-.replay__progress label {
-  font-size: var(--fs-1);
-  color: var(--muted);
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.replay__progress-track {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.replay__progress input[type='range'] {
-  flex: 1 1 auto;
-  accent-color: #22c55e;
-}
-
-.replay__count {
-  font-size: var(--fs-1);
-  color: var(--muted);
-}
-
-.replay__statusbar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  align-items: center;
-}
-
-.replay__statusbar .pill {
-  font-size: var(--fs-1);
-}
-
-.replay__summary {
-  display: grid;
-  gap: 18px;
-  padding: 20px 24px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border);
-  background: var(--surface-alt);
-}
-
-.replay__banner {
-  margin-top: 4px;
-  padding: 14px 16px;
-  border-radius: var(--radius-sm);
-  border: 1px dashed var(--border);
-  background: var(--surface);
-  color: var(--muted);
-  font-weight: 600;
-  font-size: var(--fs-1);
-  text-align: center;
-}
-
-.replay__summary-main {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.replay__summary-block {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
-}
-
-.replay__summary-block--action {
-  min-width: min(360px, 100%);
-}
-
-.replay__summary-label {
-  font-size: var(--fs-0);
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 600;
-}
-
-
-.replay__hand {
-  margin: 0;
-  font-family: var(--font-mono);
-  font-weight: 600;
-  font-size: 1.1rem;
-  color: var(--accent);
-}
-
-.replay__caption {
-  font-weight: 600;
-  color: var(--text);
-  font-size: var(--fs-1);
-}
-
-.replay__log {
-  font-size: var(--fs-1);
-  color: var(--muted);
-}
-
-.replay__pot {
-  display: grid;
-  gap: 6px;
-  align-items: center;
-  justify-items: center;
-  padding: 16px 20px;
-  border-radius: 999px;
-  border: 1px solid rgba(236, 252, 244, 0.28);
-  background: rgba(6, 95, 70, 0.52);
-  box-shadow: inset 0 0 0 1px rgba(236, 252, 244, 0.08), 0 14px 30px rgba(6, 95, 70, 0.35);
-  color: rgba(236, 252, 244, 0.96);
-  min-width: 160px;
-}
-
-.replay__pot-label {
-  font-size: var(--fs-0);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  opacity: 0.75;
-}
-
-.replay__pot-value {
-  font-family: var(--font-mono);
-  font-size: var(--fs-3);
-  font-weight: 600;
-}
-.felt {
-  grid-column: 1 / -1;
-  position: relative;
-  width: 100%;
-  border-radius: 32px;
-  background: radial-gradient(circle at 30% 20%, rgba(16, 185, 129, 0.55) 0%, rgba(12, 74, 110, 0.92) 100%);
-  border: 1px solid rgba(12, 74, 110, 0.5);
-  padding: 42px 36px;
-  box-shadow: 0 36px 100px rgba(6, 64, 58, 0.5);
-  color: rgba(236, 252, 244, 0.96);
-  overflow: hidden;
-  --card-front-color: #111827;
-}
-
-.felt::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.16), transparent 62%);
-  pointer-events: none;
-}
-
-.felt__header {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-}
-
-.felt__board {
-  position: relative;
-  z-index: 1;
-  justify-content: center;
-}
-
-.felt__seats {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 24px;
-}
-
-.felt .stack-tag,
-.felt .muted,
-.felt .mono {
-  color: inherit;
-  font-weight: 600;
-}
-
-.felt .stack-tag {
-  background: rgba(7, 29, 20, 0.65);
-  border-color: rgba(236, 252, 244, 0.22);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.stack-tag {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  font-size: var(--fs-1);
-}
-
-.replay .stack-tag {
-  background: rgba(6, 95, 70, 0.52);
-  border-color: rgba(236, 252, 244, 0.32);
-  color: rgba(236, 252, 244, 0.96);
-  box-shadow: inset 0 0 0 1px rgba(236, 252, 244, 0.08);
-}
-
-.sb-zone,
-.bb-zone {
-  position: relative;
-  background: rgba(4, 47, 35, 0.58);
-  border: 1px solid rgba(236, 252, 244, 0.32);
-  border-radius: 26px;
-  padding: 36px 24px 24px;
-  display: grid;
-  gap: 18px;
-  transition: border-color var(--transition), background var(--transition), transform var(--transition), box-shadow var(--transition), opacity var(--transition);
-  box-shadow: inset 0 0 0 1px rgba(236, 252, 244, 0.08), 0 24px 54px rgba(6, 95, 70, 0.38);
-}
-
-#sbZone {
-  justify-items: start;
-}
-
-#bbZone {
-  justify-items: end;
-}
-
-.sb-zone .muted,
-.bb-zone .muted {
-  color: rgba(236, 252, 244, 0.92);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 600;
-}
-
-.bb-zone .muted {
-  text-align: right;
-}
-
-.seat-card__header {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-}
-
-.card.replay.focus-sb #sbZone {
-  background: rgba(56, 189, 248, 0.22);
-  border-color: rgba(56, 189, 248, 0.5);
-  box-shadow: 0 28px 60px rgba(56, 189, 248, 0.3);
-}
-
-.card.replay.focus-bb #bbZone {
-  background: rgba(34, 197, 94, 0.24);
-  border-color: rgba(34, 197, 94, 0.5);
-  box-shadow: 0 28px 60px rgba(34, 197, 94, 0.3);
-}
-
-.card.replay.focus-sb #bbZone,
-.card.replay.focus-bb #sbZone {
-  opacity: 0.72;
-}
-
-.card.replay .win-glow {
-  border-color: rgba(250, 204, 21, 0.65) !important;
-  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.45), 0 0 30px rgba(250, 204, 21, 0.55);
-}
-
 .cards {
   display: flex;
   gap: 18px;
@@ -3113,4 +2689,572 @@ body.tooltips-disabled .inline-tip {
 }
 .page-history .history-table tbody tr td {
   border-bottom: none;
+}
+
+/* ---------- Replay 2.0 layout ------------------------------------- */
+.replay-page {
+  background: var(--page-bg);
+}
+
+.replay-page .page-content {
+  padding-top: 72px;
+}
+
+.replay-intro-card {
+  display: grid;
+  gap: 20px;
+}
+
+.replay-intro {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 18px;
+}
+
+.replay-intro__field {
+  display: grid;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.replay-intro__players {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  margin-left: auto;
+}
+
+.replay-intro__meta {
+  font-size: var(--fs-1);
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.replay-grid {
+  display: grid;
+  gap: var(--gutter);
+}
+
+@media (min-width: 1120px) {
+  .replay-grid {
+    grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
+    align-items: start;
+  }
+}
+
+.card--table {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(242, 246, 255, 0.9) 100%);
+  position: relative;
+  overflow: hidden;
+}
+
+.card--table::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 18% 12%, rgba(37, 99, 235, 0.12), transparent 55%),
+              radial-gradient(circle at 85% 24%, rgba(20, 184, 166, 0.12), transparent 60%);
+  z-index: 0;
+}
+
+.card--table > * {
+  position: relative;
+  z-index: 1;
+}
+
+.card--controls,
+.card--log {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.replay-table__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.replay-table__handwrap {
+  display: grid;
+  gap: 6px;
+}
+
+.replay-table__hand {
+  font-family: var(--font-display);
+  font-size: var(--fs-4);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.replay-table__status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 20px;
+}
+
+.replay-table__pot {
+  display: grid;
+  justify-items: end;
+  gap: 6px;
+}
+
+.replay-table__pot-value {
+  font-size: var(--fs-3);
+  font-family: var(--font-mono);
+  font-weight: 600;
+}
+
+.replay-table__pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.pill.warn {
+  border-color: rgba(37, 99, 235, 0.25);
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.pill.ok {
+  border-color: rgba(16, 185, 129, 0.28);
+  background: rgba(16, 185, 129, 0.14);
+  color: #047857;
+}
+
+.replay-table__action {
+  display: grid;
+  gap: 8px;
+  padding: 18px 22px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.replay-table__action-main {
+  font-family: var(--font-display);
+  font-size: var(--fs-3);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.replay-table__action-sub {
+  font-size: var(--fs-1);
+}
+
+.replay-table__board {
+  display: grid;
+  justify-items: center;
+  gap: 12px;
+}
+
+.replay-table__board-text {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.replay-table__seats {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 680px) {
+  .replay-table__seats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.seat-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 22px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.seat-card--active {
+  transform: translateY(-4px);
+  border-color: rgba(37, 99, 235, 0.38);
+  box-shadow: 0 22px 48px rgba(37, 99, 235, 0.16);
+}
+
+.seat-card--winner {
+  border-color: rgba(250, 204, 21, 0.65);
+  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.35), 0 26px 50px rgba(250, 204, 21, 0.22);
+}
+
+.seat-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.seat-card__identity {
+  display: grid;
+  gap: 6px;
+}
+
+.seat-card__role {
+  font-size: var(--fs-0);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.seat-card__name {
+  font-family: var(--font-display);
+  font-size: var(--fs-3);
+  color: var(--accent);
+}
+
+.seat-card__dealer {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: var(--fs-1);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.2);
+}
+
+.seat-card__stacks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: baseline;
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.seat-card__stack {
+  font-size: var(--fs-2);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.seat-card__delta {
+  font-size: var(--fs-1);
+}
+
+.seat-card__delta.positive,
+.seat-card__ev-delta.positive {
+  color: #047857;
+}
+
+.seat-card__delta.negative,
+.seat-card__ev-delta.negative {
+  color: #b91c1c;
+}
+
+.seat-card__ev {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.seat-card__ev-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.seat-card__ev-title {
+  display: grid;
+  gap: 6px;
+}
+
+.seat-card__ev-title > span:first-child {
+  font-size: var(--fs-0);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.seat-card__ev-amount {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.ev-meter {
+  --ev-pct: 50%;
+  position: relative;
+  width: 100%;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.ev-meter__fill {
+  position: absolute;
+  inset: 0;
+  width: var(--ev-pct);
+  border-radius: inherit;
+  background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%);
+  transition: width 200ms ease;
+}
+
+.seat-card[data-seat="bb"] .ev-meter__fill {
+  background: linear-gradient(135deg, #14b8a6 0%, #0f766e 100%);
+}
+
+.seat-card__ev-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.seat-card__cards {
+  display: grid;
+  gap: 10px;
+}
+
+.seat-card__cards-text {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--muted);
+  text-align: center;
+}
+
+.replay-table__insights {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.insight {
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: rgba(255, 255, 255, 0.86);
+  min-height: 88px;
+}
+
+.insight.is-empty {
+  opacity: 0.7;
+}
+
+.insight__label {
+  font-size: var(--fs-0);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+.insight__value {
+  font-family: var(--font-mono);
+  font-size: var(--fs-2);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.insight--solver {
+  grid-column: 1 / -1;
+}
+
+.insight--solver .insight__value {
+  font-family: var(--font-sans);
+  font-size: var(--fs-1);
+  font-weight: 500;
+  line-height: 1.45;
+  color: var(--muted);
+}
+
+.replay-table__banner {
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: var(--fs-2);
+  color: var(--muted);
+  min-height: 1.6em;
+}
+
+.replay-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.replay-controls__buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.replay-controls__buttons .pill {
+  min-width: 96px;
+  justify-content: center;
+}
+
+.replay-controls__row {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 720px) {
+  .replay-controls__row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.replay-control {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(248, 250, 255, 0.86);
+}
+
+.replay-control__label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--fs-1);
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.replay-control__range {
+  width: 100%;
+  accent-color: #2563eb;
+}
+
+.replay-control__hint {
+  align-self: flex-end;
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.replay-control--timeline {
+  gap: 14px;
+}
+
+.replay-control__timeline-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.action-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 540px;
+  overflow: auto;
+}
+
+.action-list__item {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto auto auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(248, 250, 255, 0.9);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.action-list__item:hover,
+.action-list__item:focus-visible {
+  border-color: rgba(37, 99, 235, 0.4);
+  background: rgba(37, 99, 235, 0.12);
+  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.12);
+  transform: translateY(-2px);
+}
+
+.action-list__item.is-active {
+  border-color: rgba(79, 70, 229, 0.5);
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.22) 0%, rgba(37, 99, 235, 0.18) 100%);
+  box-shadow: 0 24px 40px rgba(79, 70, 229, 0.22);
+  color: var(--accent);
+}
+
+.action-list__item.is-hand-start::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px dashed rgba(148, 163, 184, 0.32);
+  pointer-events: none;
+}
+
+.action-list__step,
+.action-list__hand,
+.action-list__pot {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.action-list__street {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.action-list__text {
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.action-list__item.is-active .action-list__text {
+  color: var(--accent);
+}
+
+.action-list__empty {
+  padding: 36px 24px;
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border);
+  text-align: center;
+  color: var(--muted);
+  font-size: var(--fs-1);
+}
+
+@media (max-width: 720px) {
+  .replay-page .page-content {
+    padding-top: 56px;
+  }
 }

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -4,431 +4,12 @@
   <meta charset="utf-8"/>
   <title>AI Poker Lab - Replay</title>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <link rel="stylesheet" href="/web/app.css?v=8"/>
+  <link rel="stylesheet" href="/web/app.css?v=9"/>
   <link rel="icon" href="/web/favicon.svg" type="image/svg+xml"/>
   <script src="/web/app.js" defer></script>
-  <script>
-    // ------- helpers
-    const $ = (s) => document.querySelector(s);
-    const q = new URLSearchParams(location.search);
-    const fmtChips = (n) => (n == null ? '0' : Number(n).toLocaleString());
-
-    // ------- state
-    let matchId = q.get('match_id');
-    let modelA = 'A', modelB = 'B';
-    let rows = [];
-    let i = 0;
-    let timer = null;
-    let playing = false;
-    const introHoldFactor = 1.8; // extra delay between first and second action
-    const speedBase = 1500; // ms for v=1
-    let speed = speedBase;
-    let prevHandId = null;
-    let prevBoardKey = '';
-    let dealerOnSB = true;
-    let dealerEl = null;
-    let winnerSeat = null; // 'SB' | 'BB' | null
-
-    const SUIT_INFO = {
-      club: { name: 'club', glyph: '♣', aria: 'clubs' },
-      diamond: { name: 'diamond', glyph: '♦', aria: 'diamonds' },
-      heart: { name: 'heart', glyph: '♥', aria: 'hearts' },
-      spade: { name: 'spade', glyph: '♠', aria: 'spades' }
-    };
-    const SUIT_ALIASES = new Map([
-      ['c', 'club'], ['club', 'club'], ['clubs', 'club'], ['♣', 'club'], ['♣️', 'club'], ['♧', 'club'],
-      ['d', 'diamond'], ['diamond', 'diamond'], ['diamonds', 'diamond'], ['♦', 'diamond'], ['♦️', 'diamond'], ['♢', 'diamond'],
-      ['h', 'heart'], ['heart', 'heart'], ['hearts', 'heart'], ['♥', 'heart'], ['♥️', 'heart'], ['♡', 'heart'],
-      ['s', 'spade'], ['spade', 'spade'], ['spades', 'spade'], ['♠', 'spade'], ['♠️', 'spade'], ['♤', 'spade']
-    ]);
-    const NUMBER_WORDS = {
-      2: 'two',
-      3: 'three',
-      4: 'four',
-      5: 'five',
-      6: 'six',
-      7: 'seven',
-      8: 'eight',
-      9: 'nine',
-      10: 'ten'
-    };
-    const rankLookup = new Map();
-    const registerRank = (text, aria, ...keys) => {
-      const info = { text, aria };
-      keys.forEach(key => {
-        if (key != null) rankLookup.set(String(key).toUpperCase(), info);
-      });
-    };
-    registerRank('A', 'ace', 'A', 'ACE', '1', '14');
-    registerRank('K', 'king', 'K', 'KING', '13');
-    registerRank('Q', 'queen', 'Q', 'QUEEN', '12');
-    registerRank('J', 'jack', 'J', 'JACK', '11');
-    registerRank('10', 'ten', 'T', '10', 'TEN', '0');
-    for (let n = 2; n <= 9; n++) {
-      registerRank(String(n), NUMBER_WORDS[n], String(n));
-    }
-
-    function normalizeRank(value) {
-      if (value == null) return { text: '', aria: '' };
-      if (typeof value === 'number' && Number.isFinite(value)) {
-        const info = rankLookup.get(String(Math.trunc(value)));
-        if (info) return { ...info };
-      }
-      const raw = String(value).trim();
-      if (!raw) return { text: '', aria: '' };
-      const direct = rankLookup.get(raw.toUpperCase());
-      if (direct) return { ...direct };
-      return { text: raw.toUpperCase(), aria: raw.toLowerCase() };
-    }
-
-    function normalizeSuit(value) {
-      if (value == null) return { name: '', glyph: '', aria: '' };
-      const raw = String(value).trim();
-      if (!raw) return { name: '', glyph: '', aria: '' };
-      const lowered = raw.toLowerCase().replace(/\ufe0f/g, '');
-      const direct = SUIT_ALIASES.get(lowered)
-        || SUIT_ALIASES.get(lowered.slice(-1))
-        || SUIT_ALIASES.get(lowered.charAt(0));
-      const info = direct ? SUIT_INFO[direct] : null;
-      return info ? { ...info } : { name: '', glyph: '', aria: '' };
-    }
-
-    function cardParts(card) {
-      if (card == null) {
-        return { rank: '', suitName: '', suitGlyph: '', label: '', aria: '' };
-      }
-      let raw = '';
-      if (typeof card === 'string' || typeof card === 'number') {
-        raw = String(card).trim();
-      } else if (typeof card === 'object') {
-        const rawFields = ['raw', 'code', 'card'];
-        for (const key of rawFields) {
-          if (typeof card[key] === 'string') {
-            raw = card[key].trim();
-            break;
-          }
-        }
-      }
-
-      let rankSrc = '';
-      let suitSrc = '';
-      if (typeof card === 'object' && card) {
-        rankSrc = card.rank ?? card.r ?? card.value ?? card.face ?? '';
-        suitSrc = card.suit ?? card.s ?? card.suit_key ?? card.suitName ?? '';
-      }
-
-      if (!rankSrc || !suitSrc) {
-        const candidate = (raw || '').replace(/\s+/g, '');
-        const match = candidate.match(/^(.+?)([cdhsCDHS♣♦♥♠])$/);
-        if (match) {
-          if (!rankSrc) rankSrc = match[1];
-          if (!suitSrc) suitSrc = match[2];
-        } else if (!rankSrc && candidate.length >= 2) {
-          rankSrc = candidate.slice(0, -1);
-          suitSrc = suitSrc || candidate.slice(-1);
-        }
-      }
-
-      const fallbackRaw = raw ? raw.replace(/[^A-Za-z0-9]/g, '').toUpperCase() : '';
-      const rankInfo = normalizeRank(rankSrc || fallbackRaw);
-      const suitInfo = normalizeSuit(suitSrc);
-      const rankText = rankInfo.text || (fallbackRaw ? fallbackRaw.slice(0, 2) : '');
-      const glyph = suitInfo.glyph;
-      const label = rankText ? (glyph ? `${rankText}${glyph}` : rankText) : (raw || fallbackRaw);
-      const ariaParts = [];
-      if (rankInfo.aria) {
-        ariaParts.push(rankInfo.aria.charAt(0).toUpperCase() + rankInfo.aria.slice(1));
-      }
-      if (suitInfo.aria) {
-        ariaParts.push(`of ${suitInfo.aria}`);
-      }
-      const aria = ariaParts.join(' ').trim();
-      return {
-        rank: rankText,
-        suitName: suitInfo.name,
-        suitGlyph: glyph,
-        label: label || '',
-        aria: aria || (label ? `Card ${label}` : '')
-      };
-    }
-
-    // Render cards into a slot; reveal by toggling .flip post-insert
-    function setCards(el, arr, reveal) {
-      if (!el) return;
-      el.innerHTML = '';
-      const list = Array.isArray(arr) ? arr : (arr != null ? [arr] : []);
-      list.forEach((entry, idx) => {
-        const { rank, suitName, suitGlyph, label, aria } = cardParts(entry);
-        const card = document.createElement('div');
-        card.className = 'cardx deal';
-        if (suitName) card.classList.add(suitName);
-        if (label) card.setAttribute('title', label);
-        if (aria) {
-          card.setAttribute('role', 'img');
-          card.setAttribute('aria-label', aria);
-        }
-        card.style.animationDelay = `${idx * 100}ms`;
-        if (suitGlyph) {
-          card.style.setProperty('--card-glyph', "'" + suitGlyph + "'");
-        } else {
-          card.style.removeProperty('--card-glyph');
-          if (!suitName && label) {
-            card.style.setProperty('--card-glyph', "'?'");
-          }
-        }
-
-        const back = document.createElement('div');
-        back.className = 'face back';
-        const front = document.createElement('div');
-        front.className = 'face front';
-
-        const top = document.createElement('div');
-        top.className = 'num-box top suit';
-        top.textContent = (rank || label || '').slice(0, 3);
-        const bottom = document.createElement('div');
-        bottom.className = 'num-box bottom suit';
-        bottom.textContent = (rank || label || '').slice(0, 3);
-        const center = document.createElement('div');
-        center.className = 'suit main';
-
-        front.appendChild(top);
-        front.appendChild(bottom);
-        front.appendChild(center);
-        card.appendChild(back);
-        card.appendChild(front);
-        el.appendChild(card);
-        if (reveal && (rank || label)) card.classList.add('flip');
-      });
-    }
-
-    function dateShort(iso) {
-      const d = new Date(iso);
-      return d.toLocaleString([], { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
-    }
-
-    function draw() {
-      if (!rows.length) return;
-      const r = rows[i];
-
-      // Hand header "<hand> — <street>"
-      const handEl = $('#hand');
-      if (handEl) handEl.textContent = `${r.hand_id} \u2014 ${r.street}`;
-      const potEl = $('#pot');
-      if (potEl) potEl.textContent = fmtChips(r.pot);
-
-      // Board: reflip when composition changes
-      const boardArr = r.board || [];
-      const key = boardArr.join(',');
-      if (key !== prevBoardKey) {
-        prevBoardKey = key;
-        setCards($('#board'), boardArr, false);
-        setTimeout(() => { $('#board')?.querySelectorAll('.cardx').forEach((c) => c.classList.add('flip')); }, 140);
-      }
-
-      // Holes: reveal based on selector
-      const sel = $('#holesSel');
-      const mode = sel ? sel.value : 'both';
-      const showSB = mode === 'both' || mode === 'sb';
-      const showBB = mode === 'both' || mode === 'bb';
-      setCards($('#sb_hole'), r.sb_hole || [], false);
-      setCards($('#bb_hole'), r.bb_hole || [], false);
-      $('#sb_hole')?.querySelectorAll('.cardx').forEach((c) => c.classList.toggle('flip', showSB));
-      $('#bb_hole')?.querySelectorAll('.cardx').forEach((c) => c.classList.toggle('flip', showBB));
-
-      // Seat headers per hand: map A/B to SB/BB using hand suffix
-      const aIsSB = /A$/i.test((r.hand_id||''));
-      const sbName = aIsSB ? modelA : modelB;
-      const bbName = aIsSB ? modelB : modelA;
-      const sbHdr = document.querySelector('#sbZone .muted');
-      const bbHdr = document.querySelector('#bbZone .muted');
-      if (sbHdr) sbHdr.textContent = `SB \u2014 ${sbName}`;
-      if (bbHdr) bbHdr.textContent = `BB \u2014 ${bbName}`;
-
-      // Stacks
-      const sbTag = $('#sb_stack_tag');
-      const bbTag = $('#bb_stack_tag');
-      if (sbTag) sbTag.textContent = `Stack: ${fmtChips(r.sb_stack)}`;
-      if (bbTag) bbTag.textContent = `Stack: ${fmtChips(r.bb_stack)}`;
-
-      // Caption + turn indicator
-      const who = (r.actor_label === 'A' ? modelA : modelB) || r.actor_label;
-      const actionText = `${who} ${r.action}` + (r.amount != null ? ` ${r.action === 'call' ? 'for' : 'to'} ${r.amount}` : '');
-      const log = $('#log'); if (log) log.textContent = actionText;
-      const caption = $('#caption'); if (caption) caption.textContent = actionText;
-
-      const turn = $('#turn');
-      if (turn) {
-        const abbrev = r.actor_label;
-        turn.textContent = `Turn: ${abbrev}`;
-      }
-
-      const replayCard = document.querySelector('.card.replay');
-      if (replayCard) {
-        replayCard.classList.remove('focus-sb', 'focus-bb');
-        replayCard.classList.add(r.actor_label === 'A' ? 'focus-sb' : 'focus-bb');
-      }
-
-      // Dealer hop on hand boundary
-      if (prevHandId !== r.hand_id) {
-        prevHandId = r.hand_id;
-        winnerSeat = null; // reset for new hand
-        const sbZ = $('#sbZone'), bbZ = $('#bbZone');
-        sbZ?.classList.remove('win-glow');
-        bbZ?.classList.remove('win-glow');
-        const hb0 = $('#handBanner'); if (hb0) hb0.textContent = '';
-        dealerOnSB = !dealerOnSB;
-        const target = dealerOnSB ? sbZ : bbZ;
-        if (target) {
-          if (!dealerEl) { dealerEl = document.createElement('div'); dealerEl.className = 'dealer dealer-move'; dealerEl.textContent = 'D'; }
-          target.prepend(dealerEl);
-          dealerEl.classList.remove('dealer-move'); void dealerEl.offsetWidth; dealerEl.classList.add('dealer-move');
-        }
-      }
-
-      // End-of-hand banner + winner glow
-      const sbZ = $('#sbZone'), bbZ = $('#bbZone');
-      const hb = $('#handBanner');
-      const endOfHand = i === rows.length - 1 || (rows[i + 1]?.hand_id !== r.hand_id);
-      if (endOfHand) {
-        if (!winnerSeat && r.winner_seat) {
-          winnerSeat = r.winner_seat; // showdown from server
-        }
-        if (!winnerSeat && (r.action || '').toLowerCase() === 'fold') {
-          const wl = r.actor_label === 'A' ? 'B' : 'A';
-          const aIsSB2 = ((r.hand_id || '').slice(-1).toUpperCase() === 'A');
-          winnerSeat = wl === 'A' ? (aIsSB2 ? 'SB' : 'BB') : (aIsSB2 ? 'BB' : 'SB');
-        }
-        if (winnerSeat === 'SB') sbZ?.classList.add('win-glow');
-        if (winnerSeat === 'BB') bbZ?.classList.add('win-glow');
-        if (hb) {
-          let msg = 'Hand complete.';
-          if (winnerSeat === 'SB' || winnerSeat === 'BB') {
-            const aIsSB3 = ((r.hand_id || '').slice(-1).toUpperCase() === 'A');
-            const winModel = (winnerSeat === 'SB') ? (aIsSB3 ? modelA : modelB) : (aIsSB3 ? modelB : modelA);
-            msg = `${winModel} wins \u2014 ${winnerSeat}`;
-          }
-          hb.textContent = msg;
-        }
-      }
-
-      // Progress UI
-      const prog = $('#prog');
-      const count = $('#count');
-      if (prog) prog.value = i;
-      if (count) count.textContent = `${i + 1}/${rows.length}`;
-
-      if (i === rows.length - 1) {
-        const banner = $('#handBanner');
-        if (banner) banner.textContent = 'Match over.';
-        pause();
-        i = 0; // rewind for next play
-      }
-    }
-
-    function step(delta = 1) {
-      if (!rows.length) return;
-      i = Math.max(0, Math.min(i + delta, rows.length - 1));
-      draw();
-    }
-
-    function isHandStart(idx){
-      if (!rows.length) return false;
-      if (idx <= 0) return true;
-      return rows[idx-1]?.hand_id !== rows[idx]?.hand_id;
-    }
-
-    function scheduleNext(){
-      if (!playing) return;
-      const delay = Math.round(speed * (isHandStart(i) ? introHoldFactor : 1));
-      timer = setTimeout(() => { step(+1); scheduleNext(); }, delay);
-    }
-
-    function play() {
-      if (playing) return;
-      playing = true;
-      const st = $('#status'); if (st) { st.textContent = 'Playing'; st.className = 'pill ok'; }
-      scheduleNext();
-    }
-
-    function pause() {
-      playing = false;
-      if (timer) { clearTimeout(timer); timer = null; }
-      const st = $('#status'); if (st) { st.textContent = 'Paused'; st.className = 'pill ghost'; }
-    }
-
-    async function getJSON(url, fallback) {
-      try { const r = await fetch(url, { cache: 'no-store' }); if (r.ok) return await r.json(); } catch {}
-      if (fallback) { try { const r2 = await fetch(fallback, { cache: 'no-store' }); if (r2.ok) return await r2.json(); } catch {} }
-      return null;
-    }
-
-    async function populateModels() {
-      try {
-        const data = await getJSON('/api/matches', '/web/data/matches.json');
-        if (!data) return;
-        const list = data.rows || [];
-
-        // Populate selector
-        const sel = $('#matchSel');
-        if (sel) {
-          sel.innerHTML = list.slice(0, 30).map(m => `<option value="${m.id}">#${m.id} &bull; ${dateShort(m.created_at)}</option>`).join('');
-          if (matchId) sel.value = String(matchId);
-          else if (list[0]) { matchId = list[0].id; sel.value = String(matchId); }
-          sel.onchange = () => { matchId = sel.value; history.replaceState(null, '', `?match_id=${matchId}`); load(); };
-        }
-
-        // Current match row for names
-        const row = list.find(m => String(m.id) === String(matchId)) || list[0];
-        if (row) {
-          modelA = row.model_a || 'A';
-          modelB = row.model_b || 'B';
-          const map = $('#map');
-          if (map) { map.innerHTML = `<span class="pill">A &bull; ${modelA}</span> <span class="pill">B &bull; ${modelB}</span>`; }
-          try { localStorage.setItem(`replay_models_${matchId}`, JSON.stringify({A:modelA,B:modelB})); } catch {}
-        } else {
-          // fallback to cached names for this match
-          try { const cached = localStorage.getItem(`replay_models_${matchId}`); if (cached){ const o = JSON.parse(cached); if (o?.A && o?.B){ modelA = o.A; modelB = o.B; const map = $('#map'); if (map){ map.innerHTML = `<span class="pill">A &bull; ${modelA}</span> <span class="pill">B &bull; ${modelB}</span>`; } } } } catch {}
-        }
-      } catch {}
-    }
-
-    async function load() {
-      if (!matchId) await populateModels();
-      await populateModels(); // refresh labels
-
-      if (!matchId) { const log = $('#log'); if (log) log.textContent = 'No match selected.'; return; }
-      const data = await getJSON(`/api/match-logs?match_id=${encodeURIComponent(matchId)}`, `/web/data/match-logs-${encodeURIComponent(matchId)}.json`);
-      rows = (data && data.rows) ? data.rows : [];
-
-      // reset state
-      i = 0; prevHandId = null; prevBoardKey = ''; winnerSeat = null;
-      const prog = $('#prog'); if (prog) { prog.max = Math.max(0, rows.length - 1); prog.value = 0; }
-      draw();
-    }
-
-    document.addEventListener('DOMContentLoaded', () => {
-      // Nav active state
-      document.querySelectorAll('.topnav a').forEach((a) => {
-        try { const target = a.getAttribute('href').split('/').pop(); if (location.pathname.endsWith(target)) a.classList.add('active'); } catch {}
-      });
-
-      // initial load
-      populateModels().then(load);
-
-      // Controls
-      $('#play')?.addEventListener('click', play);
-      $('#pause')?.addEventListener('click', pause);
-      $('#next')?.addEventListener('click', () => step(+1));
-      $('#sl')?.addEventListener('input', (e) => { const v = Math.max(1, parseInt(e.target.value || '1', 10) || 1); speed = Math.round(speedBase / v); if (playing) { pause(); play(); } });
-      $('#prog')?.addEventListener('input', (e) => { i = parseInt(e.target.value || '0', 10) || 0; draw(); });
-      const hs = $('#holesSel'); if (hs) hs.onchange = () => draw();
-
-      // Keyboard
-      addEventListener('keydown', (ev) => { if (ev.key === 'ArrowRight') step(+1); else if (ev.key === 'ArrowLeft') step(-1); });
-    });
-  </script>
+  <script type="module" src="/web/replay.js" defer></script>
 </head>
-<body class="replay-theme">
+<body class="replay-theme replay-page">
   <header class="site-header">
     <div class="topnav">
       <a class="brand" href="/web/replay.html" aria-label="PokerBench latest match">
@@ -515,114 +96,231 @@
               <span class="nav-settings__label">Guided tips</span>
               <span class="nav-settings__hint" data-setting-state="tooltips">On</span>
             </button>
-            <button class="nav-settings__row" type="button" disabled>
-              <span class="nav-settings__label">Theme</span>
-              <span class="nav-settings__hint">Auto (coming soon)</span>
-            </button>
           </div>
           <div class="nav-settings__section">
-            <h3>Notifications</h3>
-            <button class="nav-settings__row" type="button" disabled>
-              <span class="nav-settings__label">Match alerts</span>
-              <span class="nav-settings__hint">Not yet available</span>
-            </button>
+            <h3>Shortcuts</h3>
+            <dl class="nav-settings__shortcuts">
+              <div>
+                <dt>← / →</dt>
+                <dd>Step through actions</dd>
+              </div>
+              <div>
+                <dt>Space</dt>
+                <dd>Play / pause</dd>
+              </div>
+            </dl>
           </div>
         </div>
       </div>
     </div>
   </header>
 
-  <main class="page-content">
+  <main class="page-content page-content--replay">
     <div class="wrap wrap--wide">
-      <div class="card">
-        <h1>Replay</h1>
-        <div class="muted">Latest match loads automatically. Switch below.</div>
-        <div class="replay__intro">
-          <label class="muted" for="matchSel">Match</label>
-          <div class="select-pill__wrap">
-            <select id="matchSel" class="select-pill"></select>
-          </div>
-          <div id="map" class="replay__map"></div>
+      <section class="card card--compact replay-intro-card">
+        <div class="card__header">
+          <h1>Replay</h1>
+          <p class="muted">Study every action from recent duels with live chips, board texture, and solver context.</p>
         </div>
-      </div>
-
-      <div class="card replay">
-        <div class="replay__controls">
-          <div class="replay__btn-group">
-            <button class="pill" id="play" type="button">Play</button>
-            <button class="pill" id="pause" type="button">Pause</button>
-            <button class="pill" id="next" type="button">Next</button>
-          </div>
-          <div class="replay__speed">
-            <label class="muted" for="sl">Speed</label>
-            <button class="inline-tip" type="button" data-tip="Slide right to shorten the delay between actions. Playback automatically pauses once the match completes." aria-label="Tip: adjust playback speed">i</button>
-            <input id="sl" type="range" min="1" max="5" value="1"/>
-          </div>
-          <div class="replay__holes">
-            <label class="muted" for="holesSel">Holes</label>
-            <button class="inline-tip" type="button" data-tip="Reveal one or both players' hole cards. Hidden keeps them face down until showdown." aria-label="Tip: toggle hole card visibility">i</button>
+        <div class="replay-intro">
+          <div class="replay-intro__field">
+            <label class="muted" for="matchSel">Match</label>
             <div class="select-pill__wrap">
-              <select id="holesSel" class="select-pill select-pill--condensed">
-                <option value="both">Both</option>
-                <option value="sb">SB Only</option>
-                <option value="bb">BB Only</option>
-                <option value="none">Hidden</option>
-              </select>
+              <select id="matchSel" class="select-pill"></select>
             </div>
           </div>
-          <div class="replay__progress">
-            <label class="muted" for="prog">Timeline</label>
-            <div class="replay__progress-track">
-              <input id="prog" type="range" min="0" value="0"/>
-              <span class="replay__count mono" id="count">0/0</span>
-            </div>
-          </div>
-          <div class="replay__statusbar">
-            <span id="status" class="pill ghost" aria-live="polite">Paused</span>
-            <span id="turn" class="pill turn-pill" aria-live="polite">Turn: &mdash;</span>
-          </div>
+          <div class="replay-intro__players" id="map" aria-live="polite"></div>
+          <div class="replay-intro__meta" id="matchMeta" aria-live="polite">Loading latest match…</div>
         </div>
+      </section>
 
-        <div class="replay__summary">
-          <div class="replay__summary-main">
-            <div class="replay__summary-block">
-              <span class="replay__summary-label">Hand</span>
-              <span id="hand" class="replay__hand">&mdash;</span>
+      <div class="replay-grid">
+        <section class="card card--table" id="tableCard">
+          <header class="replay-table__header">
+            <div class="replay-table__handwrap">
+              <span class="muted">Hand</span>
+              <div id="hand" class="replay-table__hand">—</div>
             </div>
-            <div class="replay__summary-block replay__summary-block--action">
-              <span class="replay__summary-label">Action</span>
-              <div id="caption" class="replay__caption">Waiting for first hand…</div>
-              <div id="log" class="replay__log muted">—</div>
+            <div class="replay-table__status">
+              <div class="replay-table__pot">
+                <span class="muted">Pot</span>
+                <span class="replay-table__pot-value mono" id="pot">0</span>
+              </div>
+              <div class="replay-table__pills">
+                <span id="status" class="pill ghost" aria-live="polite">Paused</span>
+                <span id="turn" class="pill ghost" aria-live="polite">Turn: —</span>
+              </div>
             </div>
-          </div>
-          <div class="replay__banner" id="handBanner"></div>
-        </div>
+          </header>
 
-        <div class="felt">
-          <div class="felt__header">
-            <div class="replay__pot">
-              <span class="replay__pot-label">Pot</span>
-              <span class="replay__pot-value" id="pot">0</span>
+          <div class="replay-table__action">
+            <div id="caption" class="replay-table__action-main">Waiting for first hand…</div>
+            <div id="log" class="replay-table__action-sub muted">—</div>
+          </div>
+
+          <div class="replay-table__board">
+            <div class="cards felt__board" id="board" aria-label="Community cards"></div>
+            <div class="replay-table__board-text" id="boardText">Board: —</div>
+          </div>
+
+          <div class="replay-table__seats">
+            <article class="seat-card" id="sbZone" data-seat="sb">
+              <header class="seat-card__header">
+                <div class="seat-card__identity">
+                  <span class="seat-card__role">Small blind</span>
+                  <span class="seat-card__name" id="sbName">SB</span>
+                </div>
+                <span class="seat-card__dealer" id="sbDealer" aria-hidden="true" hidden>D</span>
+              </header>
+              <div class="seat-card__stacks">
+                <span class="muted">Stack</span>
+                <span id="sb_stack_tag" class="seat-card__stack mono">0</span>
+                <span id="sb_delta" class="seat-card__delta mono">±0</span>
+              </div>
+              <div class="seat-card__ev">
+                <div class="seat-card__ev-head">
+                  <div class="seat-card__ev-title">
+                    <span>Chip equity</span>
+                    <span id="sb_ev_amount" class="seat-card__ev-amount mono">0</span>
+                  </div>
+                  <button class="inline-tip" type="button" data-tip="Approximate chip equity adds half of the pot to each stack so you can track who is ahead as chips move in." aria-label="Tip: chip equity explanation">i</button>
+                </div>
+                <div class="ev-meter" id="sb_ev_meter" aria-hidden="true">
+                  <div class="ev-meter__fill"></div>
+                </div>
+                <div class="seat-card__ev-meta">
+                  <span id="sb_ev_value" class="mono">0%</span>
+                  <span id="sb_ev_delta" class="seat-card__ev-delta mono">±0</span>
+                </div>
+              </div>
+              <div class="seat-card__cards">
+                <div class="cards cards--hole" id="sb_hole" aria-label="Small blind hole cards"></div>
+                <div class="seat-card__cards-text" id="sbHoleText">Hidden</div>
+              </div>
+            </article>
+
+            <article class="seat-card" id="bbZone" data-seat="bb">
+              <header class="seat-card__header">
+                <div class="seat-card__identity">
+                  <span class="seat-card__role">Big blind</span>
+                  <span class="seat-card__name" id="bbName">BB</span>
+                </div>
+                <span class="seat-card__dealer" id="bbDealer" aria-hidden="true" hidden>D</span>
+              </header>
+              <div class="seat-card__stacks">
+                <span class="muted">Stack</span>
+                <span id="bb_stack_tag" class="seat-card__stack mono">0</span>
+                <span id="bb_delta" class="seat-card__delta mono">±0</span>
+              </div>
+              <div class="seat-card__ev">
+                <div class="seat-card__ev-head">
+                  <div class="seat-card__ev-title">
+                    <span>Chip equity</span>
+                    <span id="bb_ev_amount" class="seat-card__ev-amount mono">0</span>
+                  </div>
+                  <button class="inline-tip" type="button" data-tip="Approximate chip equity adds half of the pot to each stack so you can track who is ahead as chips move in." aria-label="Tip: chip equity explanation">i</button>
+                </div>
+                <div class="ev-meter" id="bb_ev_meter" aria-hidden="true">
+                  <div class="ev-meter__fill"></div>
+                </div>
+                <div class="seat-card__ev-meta">
+                  <span id="bb_ev_value" class="mono">0%</span>
+                  <span id="bb_ev_delta" class="seat-card__ev-delta mono">±0</span>
+                </div>
+              </div>
+              <div class="seat-card__cards">
+                <div class="cards cards--hole" id="bb_hole" aria-label="Big blind hole cards"></div>
+                <div class="seat-card__cards-text" id="bbHoleText">Hidden</div>
+              </div>
+            </article>
+          </div>
+
+          <div class="replay-table__insights" id="insightGrid">
+            <div class="insight" id="insightPotOdds">
+              <span class="insight__label">Pot odds</span>
+              <span class="insight__value" id="potOdds">—</span>
+            </div>
+            <div class="insight" id="insightRequiredEq">
+              <span class="insight__label">Required equity</span>
+              <span class="insight__value" id="requiredEq">—</span>
+            </div>
+            <div class="insight" id="insightToCall">
+              <span class="insight__label">To call</span>
+              <span class="insight__value" id="toCall">—</span>
+            </div>
+            <div class="insight" id="insightMinRaise">
+              <span class="insight__label">Min raise</span>
+              <span class="insight__value" id="minRaise">—</span>
+            </div>
+            <div class="insight" id="insightRaiseWindow">
+              <span class="insight__label">Raise window</span>
+              <span class="insight__value" id="raiseWindow">—</span>
+            </div>
+            <div class="insight insight--solver" id="insightSolver">
+              <span class="insight__label">Solver guidance</span>
+              <span class="insight__value" id="solverText">—</span>
             </div>
           </div>
-          <div class="cards felt__board" id="board"></div>
-          <div class="felt__seats">
-            <div id="sbZone" class="sb-zone">
-              <div class="seat-card__header">
-                <span class="seat-card__label muted">SB</span>
-                <span id="sb_stack_tag" class="stack-tag">Stack: 0</span>
-              </div>
-              <div class="cards cards--hole" id="sb_hole"></div>
+
+          <div class="replay-table__banner" id="handBanner" aria-live="polite"></div>
+        </section>
+
+        <section class="card card--controls" id="controlCard">
+          <header class="card__header">
+            <h2>Controls</h2>
+            <p class="muted">Scrub through the match or let it auto-play every action.</p>
+          </header>
+          <div class="replay-controls">
+            <div class="replay-controls__buttons" role="group" aria-label="Playback">
+              <button class="pill accent" id="play" type="button">Play</button>
+              <button class="pill ghost" id="pause" type="button">Pause</button>
+              <button class="pill ghost" id="next" type="button">Next</button>
             </div>
-            <div id="bbZone" class="bb-zone">
-              <div class="seat-card__header">
-                <span class="seat-card__label muted">BB</span>
-                <span id="bb_stack_tag" class="stack-tag">Stack: 0</span>
+            <div class="replay-controls__row">
+              <div class="replay-control">
+                <div class="replay-control__label">
+                  <label for="speedSlider">Speed</label>
+                  <button class="inline-tip" type="button" data-tip="Slide right to shorten the delay between actions. Playback automatically pauses once the match completes." aria-label="Tip: adjust playback speed">i</button>
+                </div>
+                <input id="speedSlider" class="replay-control__range" type="range" min="1" max="5" value="1"/>
+                <div class="replay-control__hint mono" id="speedValue">1×</div>
               </div>
-              <div class="cards cards--hole" id="bb_hole"></div>
+              <div class="replay-control">
+                <div class="replay-control__label">
+                  <label for="holesSelect">Hole cards</label>
+                  <button class="inline-tip" type="button" data-tip="Reveal one or both players' hole cards. Hidden keeps them face down until showdown." aria-label="Tip: toggle hole card visibility">i</button>
+                </div>
+                <div class="select-pill__wrap">
+                  <select id="holesSelect" class="select-pill select-pill--condensed">
+                    <option value="both">Both</option>
+                    <option value="sb">SB Only</option>
+                    <option value="bb">BB Only</option>
+                    <option value="none">Hidden</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="replay-control replay-control--timeline">
+              <div class="replay-control__label">
+                <label for="timeline">Timeline</label>
+              </div>
+              <input id="timeline" class="replay-control__range" type="range" min="0" value="0"/>
+              <div class="replay-control__timeline-meta">
+                <span class="mono" id="count">0/0</span>
+              </div>
             </div>
           </div>
-        </div>
+        </section>
+
+        <section class="card card--log" id="logCard">
+          <header class="card__header">
+            <h2>Action history</h2>
+            <p class="muted">Tap a step to jump directly to that moment.</p>
+          </header>
+          <div class="action-list" id="actionList" role="list">
+            <div class="action-list__empty">Select a match to view its action log.</div>
+          </div>
+        </section>
       </div>
     </div>
   </main>

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -936,8 +936,12 @@ const ReplayPage = (() => {
       renderEmptyActionList('Select a match to view its action log.');
       return;
     }
+    const requestedMatchId = state.matchId;
     resetStateForMatch();
-    const data = await getJSON(`/api/match-logs?match_id=${encodeURIComponent(state.matchId)}`, `/web/data/match-logs-${encodeURIComponent(state.matchId)}.json`);
+    const data = await getJSON(`/api/match-logs?match_id=${encodeURIComponent(requestedMatchId)}`, `/web/data/match-logs-${encodeURIComponent(requestedMatchId)}.json`);
+    if (state.matchId !== requestedMatchId) {
+      return;
+    }
     state.rows = Array.isArray(data?.rows) ? data.rows : [];
     if (!state.rows.length) {
       renderEmptyActionList('No actions recorded for this match yet.');

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -1,0 +1,1122 @@
+const ReplayPage = (() => {
+  const $ = (selector, root = document) => root.querySelector(selector);
+  const $$ = (selector, root = document) => Array.from(root.querySelectorAll(selector));
+  const q = new URLSearchParams(window.location.search);
+
+  const INTRO_HOLD_FACTOR = 1.8;
+  const SPEED_BASE = 1500;
+  const FLIP_DELAY = 80;
+
+  const state = {
+    matchId: q.get('match_id'),
+    matchList: [],
+    currentMatch: null,
+    rows: [],
+    index: 0,
+    playing: false,
+    timer: null,
+    speed: SPEED_BASE,
+    modelA: 'A',
+    modelB: 'B',
+    holeMode: 'both',
+    prevBoardKey: '',
+    prevHoles: { SB: '', BB: '' },
+    prevHandId: null,
+    dealerSeat: 'SB',
+    winnerSeat: null,
+    startStacks: { SB: 0, BB: 0 },
+    baseEquity: { SB: 0, BB: 0 },
+    actionButtons: [],
+  };
+
+  const els = {};
+
+  const SUIT_INFO = {
+    club: { name: 'club', glyph: '♣', aria: 'clubs' },
+    diamond: { name: 'diamond', glyph: '♦', aria: 'diamonds' },
+    heart: { name: 'heart', glyph: '♥', aria: 'hearts' },
+    spade: { name: 'spade', glyph: '♠', aria: 'spades' }
+  };
+
+  const SUIT_ALIASES = new Map([
+    ['c', 'club'], ['club', 'club'], ['clubs', 'club'], ['♣', 'club'], ['♣️', 'club'], ['♧', 'club'],
+    ['d', 'diamond'], ['diamond', 'diamond'], ['diamonds', 'diamond'], ['♦', 'diamond'], ['♦️', 'diamond'], ['♢', 'diamond'],
+    ['h', 'heart'], ['heart', 'heart'], ['hearts', 'heart'], ['♥', 'heart'], ['♥️', 'heart'], ['♡', 'heart'],
+    ['s', 'spade'], ['spade', 'spade'], ['spades', 'spade'], ['♠', 'spade'], ['♠️', 'spade'], ['♤', 'spade'],
+  ]);
+
+  const NUMBER_WORDS = { 2: 'two', 3: 'three', 4: 'four', 5: 'five', 6: 'six', 7: 'seven', 8: 'eight', 9: 'nine', 10: 'ten' };
+
+  const rankLookup = new Map();
+  const registerRank = (text, aria, ...keys) => {
+    const info = { text, aria };
+    keys.forEach(key => {
+      if (key != null) rankLookup.set(String(key).toUpperCase(), info);
+    });
+  };
+  registerRank('A', 'ace', 'A', 'ACE', '1', '14');
+  registerRank('K', 'king', 'K', 'KING', '13');
+  registerRank('Q', 'queen', 'Q', 'QUEEN', '12');
+  registerRank('J', 'jack', 'J', 'JACK', '11');
+  registerRank('10', 'ten', 'T', '10', 'TEN', '0');
+  for (let n = 2; n <= 9; n += 1) {
+    registerRank(String(n), NUMBER_WORDS[n], String(n));
+  }
+
+  function normalizeRank(value) {
+    if (value == null) return { text: '', aria: '' };
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      const info = rankLookup.get(String(Math.trunc(value)));
+      if (info) return { ...info };
+    }
+    const raw = String(value).trim();
+    if (!raw) return { text: '', aria: '' };
+    const direct = rankLookup.get(raw.toUpperCase());
+    if (direct) return { ...direct };
+    return { text: raw.toUpperCase(), aria: raw.toLowerCase() };
+  }
+
+  function normalizeSuit(value) {
+    if (value == null) return { name: '', glyph: '', aria: '' };
+    const raw = String(value).trim();
+    if (!raw) return { name: '', glyph: '', aria: '' };
+    const lowered = raw.toLowerCase().replace(/\ufe0f/g, '');
+    const direct = SUIT_ALIASES.get(lowered)
+      || SUIT_ALIASES.get(lowered.slice(-1))
+      || SUIT_ALIASES.get(lowered.charAt(0));
+    const info = direct ? SUIT_INFO[direct] : null;
+    return info ? { ...info } : { name: '', glyph: '', aria: '' };
+  }
+
+  function cardParts(card) {
+    if (card == null) {
+      return { rank: '', suitName: '', suitGlyph: '', label: '', aria: '' };
+    }
+    let raw = '';
+    if (typeof card === 'string' || typeof card === 'number') {
+      raw = String(card).trim();
+    } else if (typeof card === 'object') {
+      const rawFields = ['raw', 'code', 'card'];
+      for (const key of rawFields) {
+        if (typeof card[key] === 'string') {
+          raw = card[key].trim();
+          break;
+        }
+      }
+    }
+
+    let rankSrc = '';
+    let suitSrc = '';
+    if (typeof card === 'object' && card) {
+      rankSrc = card.rank ?? card.r ?? card.value ?? card.face ?? '';
+      suitSrc = card.suit ?? card.s ?? card.suit_key ?? card.suitName ?? '';
+    }
+
+    if (!rankSrc || !suitSrc) {
+      const candidate = (raw || '').replace(/\s+/g, '');
+      const match = candidate.match(/^(.+?)([cdhsCDHS♣♦♥♠])$/);
+      if (match) {
+        if (!rankSrc) rankSrc = match[1];
+        if (!suitSrc) suitSrc = match[2];
+      } else if (!rankSrc && candidate.length >= 2) {
+        rankSrc = candidate.slice(0, -1);
+        suitSrc = suitSrc || candidate.slice(-1);
+      }
+    }
+
+    const fallbackRaw = raw ? raw.replace(/[^A-Za-z0-9]/g, '').toUpperCase() : '';
+    const rankInfo = normalizeRank(rankSrc || fallbackRaw);
+    const suitInfo = normalizeSuit(suitSrc);
+    const rankText = rankInfo.text || (fallbackRaw ? fallbackRaw.slice(0, 2) : '');
+    const glyph = suitInfo.glyph;
+    const label = rankText ? (glyph ? `${rankText}${glyph}` : rankText) : (raw || fallbackRaw);
+    const ariaParts = [];
+    if (rankInfo.aria) {
+      ariaParts.push(rankInfo.aria.charAt(0).toUpperCase() + rankInfo.aria.slice(1));
+    }
+    if (suitInfo.aria) {
+      ariaParts.push(`of ${suitInfo.aria}`);
+    }
+    const aria = ariaParts.join(' ').trim();
+    return {
+      rank: rankText,
+      suitName: suitInfo.name,
+      suitGlyph: glyph,
+      label: label || '',
+      aria: aria || (label ? `Card ${label}` : ''),
+    };
+  }
+
+  function setCards(el, arr) {
+    if (!el) return;
+    el.innerHTML = '';
+    const list = Array.isArray(arr) ? arr : (arr != null ? [arr] : []);
+    list.forEach((entry, idx) => {
+      const { rank, suitName, suitGlyph, label, aria } = cardParts(entry);
+      const card = document.createElement('div');
+      card.className = 'cardx deal';
+      if (suitName) card.classList.add(suitName);
+      if (label) card.setAttribute('title', label);
+      if (aria) {
+        card.setAttribute('role', 'img');
+        card.setAttribute('aria-label', aria);
+      }
+      card.style.animationDelay = `${idx * 60}ms`;
+      if (suitGlyph) {
+        card.style.setProperty('--card-glyph', `\'${suitGlyph}\'`);
+      } else {
+        card.style.removeProperty('--card-glyph');
+      }
+
+      const back = document.createElement('div');
+      back.className = 'face back';
+      const front = document.createElement('div');
+      front.className = 'face front';
+
+      const top = document.createElement('div');
+      top.className = 'num-box top suit';
+      top.textContent = (rank || label || '').slice(0, 3);
+      const bottom = document.createElement('div');
+      bottom.className = 'num-box bottom suit';
+      bottom.textContent = (rank || label || '').slice(0, 3);
+      const center = document.createElement('div');
+      center.className = 'suit main';
+
+      front.appendChild(top);
+      front.appendChild(bottom);
+      front.appendChild(center);
+      card.appendChild(back);
+      card.appendChild(front);
+      el.appendChild(card);
+    });
+  }
+
+  function applyFlip(el, reveal, delayStep = FLIP_DELAY) {
+    if (!el) return;
+    const cards = $$('.cardx', el);
+    cards.forEach((card, idx) => {
+      if (card._flipTimer) {
+        window.clearTimeout(card._flipTimer);
+        card._flipTimer = null;
+      }
+      if (reveal) {
+        card.classList.remove('flip');
+        const delay = idx * delayStep;
+        card._flipTimer = window.setTimeout(() => {
+          card.classList.add('flip');
+          card._flipTimer = null;
+        }, delay);
+      } else {
+        card.classList.remove('flip');
+      }
+    });
+  }
+
+  function formatNumber(value, precision) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return '0';
+    const opts = {};
+    if (typeof precision === 'number') {
+      opts.minimumFractionDigits = precision;
+      opts.maximumFractionDigits = precision;
+    } else if (Math.abs(num % 1) > 1e-6) {
+      opts.minimumFractionDigits = 1;
+      opts.maximumFractionDigits = 1;
+    }
+    return num.toLocaleString(undefined, opts);
+  }
+
+  const fmtChips = (n) => formatNumber(n);
+
+  function fmtSigned(n, zeroLabel = '±0', precision) {
+    const num = Number(n);
+    if (!Number.isFinite(num) || Math.abs(num) < 1e-6) {
+      return zeroLabel;
+    }
+    const sign = num >= 0 ? '+' : '−';
+    const text = formatNumber(Math.abs(num), precision);
+    return `${sign}${text}`;
+  }
+
+  function formatPercent(value) {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return null;
+    return `${(num * 100).toFixed(1)}%`;
+  }
+
+  function formatCardLabels(cards) {
+    const arr = Array.isArray(cards) ? cards : [];
+    if (!arr.length) return '';
+    return arr.map((entry) => {
+      const parts = cardParts(entry);
+      if (parts.rank && parts.suitGlyph) return `${parts.rank}${parts.suitGlyph}`;
+      return parts.label || parts.rank || '??';
+    }).join(' ');
+  }
+
+  function isHandStart(idx) {
+    if (!state.rows.length) return false;
+    if (idx <= 0) return true;
+    return state.rows[idx - 1]?.hand_id !== state.rows[idx]?.hand_id;
+  }
+
+  function isAOnSB(handId) {
+    return /A$/i.test(String(handId || ''));
+  }
+
+  function seatForLabel(label, row) {
+    if (!label) return null;
+    const seatLabel = String(label).toUpperCase();
+    const aIsSB = isAOnSB(row?.hand_id);
+    if (seatLabel === 'A') return aIsSB ? 'SB' : 'BB';
+    if (seatLabel === 'B') return aIsSB ? 'BB' : 'SB';
+    if (seatLabel === 'SB' || seatLabel === 'BB') return seatLabel;
+    return null;
+  }
+
+  function labelName(label) {
+    if (!label) return '';
+    const upper = String(label).toUpperCase();
+    if (upper === 'A') return state.modelA || 'A';
+    if (upper === 'B') return state.modelB || 'B';
+    return label;
+  }
+
+  function describeActor(row) {
+    if (!row) return '';
+    const seat = seatForLabel(row.actor_label, row);
+    const name = labelName(row.actor_label);
+    if (!name) return '';
+    return seat ? `${name} (${seat})` : name;
+  }
+
+  function fmtAction(row) {
+    if (!row) return '—';
+    const parts = [];
+    const actor = describeActor(row);
+    if (actor) parts.push(actor);
+    if (row.action) parts.push(row.action);
+    if (row.amount != null && row.amount !== '') {
+      const word = row.action && row.action.toLowerCase() === 'call' ? 'for' : 'to';
+      parts.push(`${word} ${fmtChips(row.amount)}`);
+    }
+    return parts.join(' ') || '—';
+  }
+
+  function shouldShowHole(seatKey) {
+    const mode = state.holeMode;
+    if (mode === 'both') return true;
+    if (mode === 'sb') return seatKey === 'SB';
+    if (mode === 'bb') return seatKey === 'BB';
+    return false;
+  }
+
+  function computeEquity(row, seatKey) {
+    const pot = Number(row?.pot ?? 0);
+    const sbStack = Number(row?.sb_stack ?? 0);
+    const bbStack = Number(row?.bb_stack ?? 0);
+    const half = pot / 2;
+    const sbEquity = sbStack + half;
+    const bbEquity = bbStack + half;
+    const total = sbEquity + bbEquity;
+    const equity = seatKey === 'SB' ? sbEquity : bbEquity;
+    const base = state.baseEquity[seatKey] ?? equity;
+    const share = total > 0 ? Math.max(0, Math.min(1, equity / total)) : 0.5;
+    const delta = equity - base;
+    return { equity, share, delta };
+  }
+
+  function updateDeltaElement(el, value, { zeroLabel = '±0', precision } = {}) {
+    if (!el) return;
+    const num = Number(value);
+    if (!Number.isFinite(num) || Math.abs(num) < 1e-6) {
+      el.textContent = zeroLabel;
+      el.classList.remove('positive', 'negative');
+      return;
+    }
+    const positive = num >= 0;
+    el.textContent = fmtSigned(num, zeroLabel, precision);
+    el.classList.toggle('positive', positive);
+    el.classList.toggle('negative', !positive);
+  }
+
+  function updateStatus(mode) {
+    if (!els.status) return;
+    const base = ['pill'];
+    if (mode === 'playing') {
+      els.status.textContent = 'Playing';
+      els.status.className = base.concat('warn').join(' ');
+    } else if (mode === 'complete') {
+      els.status.textContent = 'Complete';
+      els.status.className = base.concat('ok').join(' ');
+    } else {
+      els.status.textContent = 'Paused';
+      els.status.className = base.concat('ghost').join(' ');
+    }
+  }
+
+  function updateDealerIndicator() {
+    const seat = state.dealerSeat;
+    if (els.sbDealer) {
+      if (seat === 'SB') {
+        els.sbDealer.hidden = false;
+      } else {
+        els.sbDealer.hidden = true;
+      }
+    }
+    if (els.bbDealer) {
+      if (seat === 'BB') {
+        els.bbDealer.hidden = false;
+      } else {
+        els.bbDealer.hidden = true;
+      }
+    }
+    if (els.sbZone) {
+      els.sbZone.classList.toggle('seat-card--dealer', seat === 'SB');
+    }
+    if (els.bbZone) {
+      els.bbZone.classList.toggle('seat-card--dealer', seat === 'BB');
+    }
+  }
+
+  function updateWinnerGlow() {
+    if (els.sbZone) {
+      els.sbZone.classList.toggle('seat-card--winner', state.winnerSeat === 'SB');
+    }
+    if (els.bbZone) {
+      els.bbZone.classList.toggle('seat-card--winner', state.winnerSeat === 'BB');
+    }
+  }
+
+  function updateSeatFocus(activeSeat) {
+    if (els.sbZone) {
+      els.sbZone.classList.toggle('seat-card--active', activeSeat === 'SB');
+    }
+    if (els.bbZone) {
+      els.bbZone.classList.toggle('seat-card--active', activeSeat === 'BB');
+    }
+  }
+
+  function updateSeat(row, seatKey) {
+    const isSB = seatKey === 'SB';
+    const zone = isSB ? els.sbZone : els.bbZone;
+    const holeEl = isSB ? els.sbHole : els.bbHole;
+    const holeTextEl = isSB ? els.sbHoleText : els.bbHoleText;
+    const stackEl = isSB ? els.sbStack : els.bbStack;
+    const deltaEl = isSB ? els.sbDelta : els.bbDelta;
+    const evAmountEl = isSB ? els.sbEvAmount : els.bbEvAmount;
+    const evShareEl = isSB ? els.sbEvValue : els.bbEvValue;
+    const evDeltaEl = isSB ? els.sbEvDelta : els.bbEvDelta;
+    const evMeter = isSB ? els.sbEvMeter : els.bbEvMeter;
+    const evFill = isSB ? els.sbEvFill : els.bbEvFill;
+
+    const cards = isSB ? row?.sb_hole : row?.bb_hole;
+    const key = (Array.isArray(cards) ? cards : []).join(',');
+    if (key !== state.prevHoles[seatKey]) {
+      setCards(holeEl, cards);
+      state.prevHoles[seatKey] = key;
+    }
+    const show = shouldShowHole(seatKey) && Array.isArray(cards) && cards.length > 0;
+    applyFlip(holeEl, show);
+    if (holeTextEl) {
+      if (Array.isArray(cards) && cards.length) {
+        holeTextEl.textContent = show ? formatCardLabels(cards) : 'Hidden';
+      } else {
+        holeTextEl.textContent = '—';
+      }
+    }
+
+    const stack = Number(isSB ? row?.sb_stack : row?.bb_stack);
+    if (stackEl) {
+      stackEl.textContent = fmtChips(Number.isFinite(stack) ? stack : 0);
+    }
+    const base = state.startStacks[seatKey] ?? stack;
+    updateDeltaElement(deltaEl, Number.isFinite(stack) ? stack - base : 0, { precision: 0 });
+
+    const eq = computeEquity(row, seatKey);
+    if (evAmountEl) {
+      evAmountEl.textContent = fmtChips(eq.equity);
+    }
+    if (evShareEl) {
+      evShareEl.textContent = `${(eq.share * 100).toFixed(1)}%`;
+    }
+    updateDeltaElement(evDeltaEl, eq.delta, { precision: 1 });
+    if (evMeter) {
+      evMeter.style.setProperty('--ev-pct', `${Math.max(0, Math.min(100, eq.share * 100))}%`);
+    }
+    if (evFill) {
+      evFill.style.width = `${Math.max(0, Math.min(100, eq.share * 100))}%`;
+    }
+    if (zone) {
+      zone.setAttribute('data-equity', eq.share.toFixed(3));
+    }
+  }
+
+  function updateInsights(row) {
+    const potOdds = formatPercent(row?.pot_odds);
+    const reqEq = formatPercent(row?.required_equity);
+    const toCall = Number(row?.to_call);
+    const minRaise = Number(row?.min_raise_to);
+    const maxRaise = Number(row?.max_raise_to);
+
+    if (els.potOdds) {
+      els.potOdds.textContent = potOdds ?? '—';
+      els.potOdds.parentElement?.classList.toggle('is-empty', !potOdds);
+    }
+    if (els.requiredEq) {
+      els.requiredEq.textContent = reqEq ?? '—';
+      els.requiredEq.parentElement?.classList.toggle('is-empty', !reqEq);
+    }
+    if (els.toCall) {
+      const text = Number.isFinite(toCall) ? fmtChips(toCall) : '—';
+      els.toCall.textContent = text;
+      els.toCall.parentElement?.classList.toggle('is-empty', !Number.isFinite(toCall));
+    }
+    if (els.minRaise) {
+      const text = Number.isFinite(minRaise) ? fmtChips(minRaise) : '—';
+      els.minRaise.textContent = text;
+      els.minRaise.parentElement?.classList.toggle('is-empty', !Number.isFinite(minRaise));
+    }
+    if (els.raiseWindow) {
+      let text = '—';
+      if (Number.isFinite(minRaise) && Number.isFinite(maxRaise)) {
+        text = `${fmtChips(minRaise)} – ${fmtChips(maxRaise)}`;
+      } else if (Number.isFinite(minRaise)) {
+        text = `≥ ${fmtChips(minRaise)}`;
+      } else if (Number.isFinite(maxRaise)) {
+        text = `≤ ${fmtChips(maxRaise)}`;
+      }
+      els.raiseWindow.textContent = text;
+      const hasValue = Number.isFinite(minRaise) || Number.isFinite(maxRaise);
+      els.raiseWindow.parentElement?.classList.toggle('is-empty', !hasValue);
+    }
+
+    if (els.solverText) {
+      const solver = row?.solver;
+      const solverVersion = row?.solver_version;
+      const bestAction = row?.eval_best_action;
+      const bestTo = row?.eval_best_to;
+      const gap = Number(row?.eval_gap_bb);
+      const prob = Number(row?.eval_correct_prob);
+      const isTop = typeof row?.eval_is_top === 'boolean' ? row.eval_is_top : null;
+      const parts = [];
+      if (solver) {
+        parts.push(solverVersion ? `${solver} ${solverVersion}` : solver);
+      }
+      if (bestAction) {
+        const move = bestTo != null ? `${bestAction} to ${fmtChips(bestTo)}` : bestAction;
+        parts.push(move);
+      }
+      if (Number.isFinite(gap)) {
+        parts.push(`${gap.toFixed(2)} bb gap`);
+      }
+      if (Number.isFinite(prob)) {
+        parts.push(`${Math.round(prob * 100)}% top action`);
+      } else if (isTop != null) {
+        parts.push(isTop ? 'Top action' : 'Off-tree');
+      }
+      const text = parts.join(' • ');
+      els.solverText.textContent = text || '—';
+      els.solverText.parentElement?.classList.toggle('is-empty', !text);
+    }
+  }
+
+  function updateHandDisplay(row) {
+    if (!row) {
+      if (els.hand) els.hand.textContent = '—';
+      if (els.caption) els.caption.textContent = 'Waiting for first hand…';
+      if (els.log) els.log.textContent = '—';
+      if (els.boardText) els.boardText.textContent = 'Board: —';
+      if (els.turn) els.turn.textContent = 'Turn: —';
+      updateSeatFocus(null);
+      return;
+    }
+
+    const handLabel = row.hand_id ? `Hand ${row.hand_id}` : 'Hand';
+    const street = row.street || '—';
+    if (els.hand) {
+      els.hand.textContent = `${handLabel} — ${street}`;
+    }
+
+    const actionText = fmtAction(row);
+    if (els.caption) {
+      els.caption.textContent = actionText;
+    }
+    if (els.log) {
+      els.log.textContent = actionText;
+    }
+
+    const boardArr = Array.isArray(row.board) ? row.board : [];
+    const boardKey = boardArr.join(',');
+    if (boardKey !== state.prevBoardKey) {
+      state.prevBoardKey = boardKey;
+      setCards(els.board, boardArr);
+      applyFlip(els.board, true, 120);
+    }
+    if (els.boardText) {
+      const text = boardArr.length ? formatCardLabels(boardArr) : '—';
+      els.boardText.textContent = `Board: ${text || '—'}`;
+    }
+
+    const aIsSB = isAOnSB(row.hand_id);
+    const sbName = aIsSB ? state.modelA : state.modelB;
+    const bbName = aIsSB ? state.modelB : state.modelA;
+    if (els.sbName) els.sbName.textContent = sbName || 'SB';
+    if (els.bbName) els.bbName.textContent = bbName || 'BB';
+
+    if (els.turn) {
+      const actor = describeActor(row);
+      els.turn.textContent = actor ? `Turn: ${actor}` : 'Turn: —';
+      els.turn.className = 'pill ghost';
+    }
+
+    updateSeat(row, 'SB');
+    updateSeat(row, 'BB');
+
+    updateInsights(row);
+
+    const actorSeat = seatForLabel(row.actor_label, row);
+    updateSeatFocus(actorSeat);
+  }
+
+  function updateHandState(row) {
+    if (!row) return;
+    if (state.prevHandId !== row.hand_id) {
+      state.prevHandId = row.hand_id;
+      state.winnerSeat = null;
+      updateWinnerGlow();
+      state.dealerSeat = state.dealerSeat === 'SB' ? 'BB' : 'SB';
+      updateDealerIndicator();
+      if (els.handBanner) {
+        els.handBanner.textContent = '';
+      }
+    }
+
+    const endOfHand = state.index === state.rows.length - 1 || state.rows[state.index + 1]?.hand_id !== row.hand_id;
+    if (endOfHand) {
+      if (!state.winnerSeat && row.winner_seat) {
+        const seat = String(row.winner_seat).toUpperCase();
+        if (seat === 'SB' || seat === 'BB') {
+          state.winnerSeat = seat;
+        }
+      }
+      if (!state.winnerSeat && (row.action || '').toLowerCase() === 'fold') {
+        const winnerLabel = row.actor_label === 'A' ? 'B' : row.actor_label === 'B' ? 'A' : null;
+        const seat = seatForLabel(winnerLabel, row);
+        if (seat) state.winnerSeat = seat;
+      }
+      updateWinnerGlow();
+      if (els.handBanner) {
+        if (state.index === state.rows.length - 1) {
+          els.handBanner.textContent = 'Match complete.';
+        } else {
+          let message = 'Hand complete.';
+          if (state.winnerSeat) {
+            const seat = state.winnerSeat;
+            const winnerLabel = seat === 'SB' ? (isAOnSB(row.hand_id) ? 'A' : 'B') : (isAOnSB(row.hand_id) ? 'B' : 'A');
+            const winnerName = labelName(winnerLabel);
+            message = `${winnerName} wins — ${seat}`;
+          }
+          els.handBanner.textContent = message;
+        }
+      }
+    } else if (els.handBanner) {
+      els.handBanner.textContent = '';
+    }
+  }
+
+  function updateTimeline() {
+    if (!els.timeline) return;
+    const max = Math.max(0, state.rows.length - 1);
+    els.timeline.max = String(max);
+    els.timeline.value = String(Math.min(state.index, max));
+    els.timeline.disabled = state.rows.length <= 1;
+    if (els.count) {
+      const current = state.rows.length ? state.index + 1 : 0;
+      els.count.textContent = `${current}/${state.rows.length}`;
+    }
+  }
+
+  function updateActionHighlight() {
+    state.actionButtons.forEach(btn => {
+      if (!btn) return;
+      const idx = Number(btn.dataset.index);
+      const isActive = idx === state.index;
+      if (isActive) {
+        btn.classList.add('is-active');
+        btn.setAttribute('aria-current', 'true');
+        const behavior = state.playing ? 'smooth' : 'instant';
+        btn.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: behavior === 'instant' ? 'auto' : behavior });
+      } else {
+        btn.classList.remove('is-active');
+        btn.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  function draw() {
+    if (!state.rows.length) {
+      updateHandDisplay(null);
+      updateTimeline();
+      updateActionHighlight();
+      return;
+    }
+    state.index = Math.max(0, Math.min(state.index, state.rows.length - 1));
+    const row = state.rows[state.index];
+    updateHandDisplay(row);
+    updateHandState(row);
+    if (els.pot) {
+      els.pot.textContent = fmtChips(row?.pot ?? 0);
+    }
+    updateTimeline();
+    updateActionHighlight();
+
+    if (state.playing && state.index === state.rows.length - 1) {
+      finishPlayback();
+    }
+  }
+
+  function step(delta = 1) {
+    if (!state.rows.length) return;
+    state.index = Math.max(0, Math.min(state.index + delta, state.rows.length - 1));
+    draw();
+  }
+
+  function scheduleNext() {
+    window.clearTimeout(state.timer);
+    if (!state.playing) return;
+    const delay = Math.round(state.speed * (isHandStart(state.index) ? INTRO_HOLD_FACTOR : 1));
+    state.timer = window.setTimeout(() => {
+      state.index = Math.min(state.index + 1, state.rows.length - 1);
+      draw();
+      if (state.playing && state.index < state.rows.length - 1) {
+        scheduleNext();
+      }
+    }, delay);
+  }
+
+  function play() {
+    if (!state.rows.length) return;
+    if (state.index >= state.rows.length - 1) {
+      state.index = 0;
+      draw();
+    }
+    if (state.playing) return;
+    state.playing = true;
+    updateStatus('playing');
+    scheduleNext();
+  }
+
+  function finishPlayback() {
+    state.playing = false;
+    window.clearTimeout(state.timer);
+    updateStatus('complete');
+  }
+
+  function pause() {
+    state.playing = false;
+    window.clearTimeout(state.timer);
+    updateStatus('paused');
+  }
+
+  async function getJSON(url, fallback) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      if (res.ok) return await res.json();
+    } catch (err) {
+      console.warn('Fetch failed', err);
+    }
+    if (fallback) {
+      try {
+        const res = await fetch(fallback, { cache: 'no-store' });
+        if (res.ok) return await res.json();
+      } catch (err) {
+        console.warn('Fallback fetch failed', err);
+      }
+    }
+    return null;
+  }
+
+  function dateShort(iso) {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleString([], { year: 'numeric', month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+  }
+
+  function trimName(name) {
+    if (!name) return '';
+    return name.length > 36 ? `${name.slice(0, 33)}…` : name;
+  }
+
+  function updatePlayerMap() {
+    if (!els.map) return;
+    const frag = document.createDocumentFragment();
+    const pillA = document.createElement('span');
+    pillA.className = 'pill ghost';
+    pillA.textContent = `A • ${trimName(state.modelA || 'Player A')}`;
+    frag.appendChild(pillA);
+    const pillB = document.createElement('span');
+    pillB.className = 'pill ghost';
+    pillB.textContent = `B • ${trimName(state.modelB || 'Player B')}`;
+    frag.appendChild(pillB);
+    els.map.innerHTML = '';
+    els.map.appendChild(frag);
+  }
+
+  function updateMatchMeta() {
+    if (!els.matchMeta) return;
+    const row = state.currentMatch;
+    if (!row) {
+      els.matchMeta.textContent = 'No matches recorded yet. Run a duel to start a replay.';
+      return;
+    }
+    const parts = [];
+    if (Number.isFinite(row.sb) && Number.isFinite(row.bb)) {
+      parts.push(`Blinds ${fmtChips(row.sb)}/${fmtChips(row.bb)}`);
+    }
+    if (Number.isFinite(row.start_stack)) {
+      parts.push(`Start stack ${fmtChips(row.start_stack)}`);
+    }
+    if (Number.isFinite(row.duel_seeds)) {
+      parts.push(`${row.duel_seeds} seeds`);
+    }
+    if (row.created_at) {
+      parts.push(`Played ${dateShort(row.created_at)}`);
+    }
+    if (row.seedpack_name) {
+      const version = row.seedpack_version ? ` ${row.seedpack_version}` : '';
+      parts.push(`Seedpack ${row.seedpack_name}${version}`);
+    }
+    els.matchMeta.textContent = parts.join(' • ');
+  }
+
+  function buildMatchOptions() {
+    if (!els.matchSelect) return;
+    const frag = document.createDocumentFragment();
+    state.matchList.slice(0, 60).forEach(row => {
+      const opt = document.createElement('option');
+      opt.value = String(row.id);
+      const when = row.created_at ? dateShort(row.created_at) : '';
+      opt.textContent = `#${row.id}${when ? ` • ${when}` : ''}`;
+      frag.appendChild(opt);
+    });
+    els.matchSelect.innerHTML = '';
+    els.matchSelect.appendChild(frag);
+    if (state.matchId) {
+      els.matchSelect.value = String(state.matchId);
+    }
+  }
+
+  function resolveCurrentMatch() {
+    const current = state.matchList.find(row => String(row.id) === String(state.matchId)) || state.matchList[0] || null;
+    state.currentMatch = current;
+    if (current) {
+      state.matchId = current.id;
+      state.modelA = current.model_a || 'A';
+      state.modelB = current.model_b || 'B';
+      try {
+        localStorage.setItem(`replay_models_${state.matchId}`, JSON.stringify({ A: state.modelA, B: state.modelB }));
+      } catch (err) {
+        console.warn('Unable to store replay model cache', err);
+      }
+    } else if (state.matchId) {
+      try {
+        const cached = localStorage.getItem(`replay_models_${state.matchId}`);
+        if (cached) {
+          const parsed = JSON.parse(cached);
+          if (parsed?.A && parsed?.B) {
+            state.modelA = parsed.A;
+            state.modelB = parsed.B;
+          }
+        }
+      } catch (err) {
+        console.warn('Unable to read replay model cache', err);
+      }
+    }
+    updatePlayerMap();
+    updateMatchMeta();
+  }
+
+  async function populateMatches({ refresh = false } = {}) {
+    if (!refresh && state.matchList.length) {
+      resolveCurrentMatch();
+      buildMatchOptions();
+      return state.currentMatch;
+    }
+    const data = await getJSON('/api/matches', '/web/data/matches.json');
+    state.matchList = Array.isArray(data?.rows) ? data.rows : [];
+    if (!state.matchId && state.matchList[0]) {
+      state.matchId = state.matchList[0].id;
+    }
+    buildMatchOptions();
+    resolveCurrentMatch();
+    return state.currentMatch;
+  }
+
+  function renderEmptyActionList(message) {
+    if (!els.actionList) return;
+    els.actionList.innerHTML = '';
+    const empty = document.createElement('div');
+    empty.className = 'action-list__empty';
+    empty.textContent = message;
+    els.actionList.appendChild(empty);
+    state.actionButtons = [];
+  }
+
+  function buildActionButton(row, idx) {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'action-list__item';
+    btn.dataset.index = String(idx);
+    btn.setAttribute('role', 'listitem');
+    if (isHandStart(idx)) btn.classList.add('is-hand-start');
+
+    const step = document.createElement('span');
+    step.className = 'action-list__step mono';
+    step.textContent = `#${idx + 1}`;
+
+    const hand = document.createElement('span');
+    hand.className = 'action-list__hand mono';
+    hand.textContent = row.hand_id || '—';
+
+    const street = document.createElement('span');
+    street.className = 'action-list__street';
+    street.textContent = row.street || '—';
+
+    const action = document.createElement('span');
+    action.className = 'action-list__text';
+    action.textContent = fmtAction(row);
+
+    const pot = document.createElement('span');
+    pot.className = 'action-list__pot mono';
+    pot.textContent = fmtChips(row.pot ?? 0);
+
+    btn.append(step, hand, street, action, pot);
+    return btn;
+  }
+
+  function buildActionList() {
+    if (!els.actionList) return;
+    if (!state.rows.length) {
+      renderEmptyActionList('No action logs available for this match yet.');
+      return;
+    }
+    const frag = document.createDocumentFragment();
+    state.actionButtons = [];
+    state.rows.forEach((row, idx) => {
+      const btn = buildActionButton(row, idx);
+      frag.appendChild(btn);
+      state.actionButtons.push(btn);
+    });
+    els.actionList.innerHTML = '';
+    els.actionList.appendChild(frag);
+  }
+
+  function resetStateForMatch() {
+    state.rows = [];
+    state.index = 0;
+    state.prevBoardKey = '';
+    state.prevHoles = { SB: '', BB: '' };
+    state.prevHandId = null;
+    state.winnerSeat = null;
+    state.dealerSeat = 'SB';
+    updateDealerIndicator();
+    updateWinnerGlow();
+    renderEmptyActionList('Loading actions…');
+    setCards(els.board, []);
+    setCards(els.sbHole, []);
+    setCards(els.bbHole, []);
+    updateHandDisplay(null);
+    updateTimeline();
+    updateStatus('paused');
+  }
+
+  async function loadMatchLogs() {
+    if (!state.matchId) {
+      renderEmptyActionList('Select a match to view its action log.');
+      return;
+    }
+    resetStateForMatch();
+    const data = await getJSON(`/api/match-logs?match_id=${encodeURIComponent(state.matchId)}`, `/web/data/match-logs-${encodeURIComponent(state.matchId)}.json`);
+    state.rows = Array.isArray(data?.rows) ? data.rows : [];
+    if (!state.rows.length) {
+      renderEmptyActionList('No actions recorded for this match yet.');
+      draw();
+      return;
+    }
+    const first = state.rows[0];
+    state.startStacks.SB = Number(first?.sb_stack ?? 0);
+    state.startStacks.BB = Number(first?.bb_stack ?? 0);
+    const startPot = Number(first?.pot ?? 0) / 2;
+    state.baseEquity.SB = state.startStacks.SB + startPot;
+    state.baseEquity.BB = state.startStacks.BB + startPot;
+    buildActionList();
+    draw();
+  }
+
+  function cacheElements() {
+    els.matchSelect = $('#matchSel');
+    els.map = $('#map');
+    els.matchMeta = $('#matchMeta');
+    els.board = $('#board');
+    els.boardText = $('#boardText');
+    els.sbZone = $('#sbZone');
+    els.bbZone = $('#bbZone');
+    els.sbHole = $('#sb_hole');
+    els.bbHole = $('#bb_hole');
+    els.sbHoleText = $('#sbHoleText');
+    els.bbHoleText = $('#bbHoleText');
+    els.sbStack = $('#sb_stack_tag');
+    els.bbStack = $('#bb_stack_tag');
+    els.sbDelta = $('#sb_delta');
+    els.bbDelta = $('#bb_delta');
+    els.sbName = $('#sbName');
+    els.bbName = $('#bbName');
+    els.sbDealer = $('#sbDealer');
+    els.bbDealer = $('#bbDealer');
+    els.sbEvAmount = $('#sb_ev_amount');
+    els.bbEvAmount = $('#bb_ev_amount');
+    els.sbEvValue = $('#sb_ev_value');
+    els.bbEvValue = $('#bb_ev_value');
+    els.sbEvDelta = $('#sb_ev_delta');
+    els.bbEvDelta = $('#bb_ev_delta');
+    els.sbEvMeter = $('#sb_ev_meter');
+    els.bbEvMeter = $('#bb_ev_meter');
+    els.sbEvFill = $('#sb_ev_meter .ev-meter__fill');
+    els.bbEvFill = $('#bb_ev_meter .ev-meter__fill');
+    els.status = $('#status');
+    els.turn = $('#turn');
+    els.caption = $('#caption');
+    els.log = $('#log');
+    els.hand = $('#hand');
+    els.handBanner = $('#handBanner');
+    els.pot = $('#pot');
+    els.timeline = $('#timeline');
+    els.count = $('#count');
+    els.speedSlider = $('#speedSlider');
+    els.speedValue = $('#speedValue');
+    els.holesSelect = $('#holesSelect');
+    els.playBtn = $('#play');
+    els.pauseBtn = $('#pause');
+    els.nextBtn = $('#next');
+    els.actionList = $('#actionList');
+    els.potOdds = $('#potOdds');
+    els.requiredEq = $('#requiredEq');
+    els.toCall = $('#toCall');
+    els.minRaise = $('#minRaise');
+    els.raiseWindow = $('#raiseWindow');
+    els.solverText = $('#solverText');
+  }
+
+  function attachListeners() {
+    if (els.playBtn) {
+      els.playBtn.addEventListener('click', () => {
+        play();
+      });
+    }
+    if (els.pauseBtn) {
+      els.pauseBtn.addEventListener('click', () => {
+        pause();
+      });
+    }
+    if (els.nextBtn) {
+      els.nextBtn.addEventListener('click', () => {
+        pause();
+        step(+1);
+      });
+    }
+    if (els.speedSlider) {
+      const updateSpeed = (value) => {
+        const v = Math.max(1, parseInt(value || '1', 10) || 1);
+        state.speed = SPEED_BASE / v;
+        if (els.speedValue) {
+          els.speedValue.textContent = `${v}×`;
+        }
+        if (state.playing) {
+          scheduleNext();
+        }
+      };
+      updateSpeed(els.speedSlider.value);
+      els.speedSlider.addEventListener('input', (ev) => {
+        updateSpeed(ev.target.value);
+      });
+    }
+    if (els.holesSelect) {
+      state.holeMode = els.holesSelect.value || 'both';
+      els.holesSelect.addEventListener('change', (ev) => {
+        state.holeMode = ev.target.value || 'both';
+        draw();
+      });
+    }
+    if (els.timeline) {
+      els.timeline.addEventListener('input', (ev) => {
+        const value = parseInt(ev.target.value || '0', 10) || 0;
+        pause();
+        state.index = value;
+        draw();
+      });
+    }
+    if (els.matchSelect) {
+      els.matchSelect.addEventListener('change', (ev) => {
+        state.matchId = ev.target.value;
+        try {
+          history.replaceState(null, '', `?match_id=${state.matchId}`);
+        } catch (err) {
+          console.warn('Unable to update history', err);
+        }
+        resolveCurrentMatch();
+        loadMatchLogs();
+      });
+    }
+    if (els.actionList) {
+      els.actionList.addEventListener('click', (ev) => {
+        const btn = ev.target.closest('.action-list__item');
+        if (!btn) return;
+        const idx = parseInt(btn.dataset.index || '0', 10);
+        if (Number.isInteger(idx)) {
+          pause();
+          state.index = Math.max(0, Math.min(idx, state.rows.length - 1));
+          draw();
+        }
+      });
+    }
+
+    window.addEventListener('keydown', (ev) => {
+      const target = ev.target;
+      if (target && ['INPUT', 'SELECT', 'TEXTAREA'].includes(target.tagName)) return;
+      if (ev.key === 'ArrowRight') {
+        ev.preventDefault();
+        pause();
+        step(+1);
+      } else if (ev.key === 'ArrowLeft') {
+        ev.preventDefault();
+        pause();
+        step(-1);
+      } else if (ev.code === 'Space') {
+        ev.preventDefault();
+        if (state.playing) {
+          pause();
+        } else {
+          play();
+        }
+      }
+    });
+  }
+
+  async function init() {
+    cacheElements();
+    attachListeners();
+    updateDealerIndicator();
+    updateStatus('paused');
+    await populateMatches();
+    await loadMatchLogs();
+  }
+
+  return { init };
+})();
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => ReplayPage.init(), { once: true });
+} else {
+  ReplayPage.init();
+}


### PR DESCRIPTION
## Summary
- redesign the replay view with structured sections for match selection, felt, insights, controls, and history
- add a dedicated replay module that manages playback, hole visibility, equity tracking, solver data, and an interactive action list
- refresh replay styling with new layout, status pills, seat cards, and timeline visuals

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf9816ad14832db845739c28f4cbac