### PR TITLE
Enhance Elo interactions and redesign history filters

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -206,16 +206,18 @@ func Router(db *store.DB) http.Handler {
 			Seeds           int        `json:"duel_seeds"`
 			ModelA          string     `json:"model_a"`
 			ModelB          string     `json:"model_b"`
+			ResultDelta     int        `json:"result_delta"`
 			SeedpackName    *string    `json:"seedpack_name,omitempty"`
 			SeedpackVersion *string    `json:"seedpack_version,omitempty"`
 			SeedpackCount   *int       `json:"seedpack_count,omitempty"`
 			SeedpackSHA     *string    `json:"seedpack_sha256,omitempty"`
 		}
 		rows, err := db.Query(ctx, `
-            SELECT m.id, m.created_at, m.ended_at, m.sb, m.bb, m.start_stack, m.duel_seeds,
-                   MAX(CASE WHEN p.label='A' THEN p.name_snapshot END) AS model_a,
-                   MAX(CASE WHEN p.label='B' THEN p.name_snapshot END) AS model_b,
-                   m.seedpack_name, m.seedpack_version, m.seedpack_count, m.seedpack_sha256
+           SELECT m.id, m.created_at, m.ended_at, m.sb, m.bb, m.start_stack, m.duel_seeds,
+                  MAX(CASE WHEN p.label='A' THEN p.name_snapshot END) AS model_a,
+                  MAX(CASE WHEN p.label='B' THEN p.name_snapshot END) AS model_b,
+                  MAX(CASE WHEN p.label='A' THEN p.net_chips END) AS result_delta,
+                  m.seedpack_name, m.seedpack_version, m.seedpack_count, m.seedpack_sha256
               FROM matches m
               LEFT JOIN match_participants p ON p.match_id = m.id
              GROUP BY m.id
@@ -231,7 +233,7 @@ func Router(db *store.DB) http.Handler {
 		for rows.Next() {
 			var x Row
 			if err := rows.Scan(&x.ID, &x.CreatedAt, &x.EndedAt, &x.SBA, &x.BBA, &x.Start, &x.Seeds, &x.ModelA, &x.ModelB,
-				&x.SeedpackName, &x.SeedpackVersion, &x.SeedpackCount, &x.SeedpackSHA); err != nil {
+				&x.ResultDelta, &x.SeedpackName, &x.SeedpackVersion, &x.SeedpackCount, &x.SeedpackSHA); err != nil {
 				http.Error(w, err.Error(), 500)
 				return
 			}

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -1499,6 +1499,23 @@ ion);
   z-index: 1;
 }
 
+.chart-series {
+  transition: opacity var(--transition), filter var(--transition);
+}
+
+.chart-series.is-dimmed {
+  opacity: 0.22;
+  filter: none;
+}
+
+.chart-series.is-active {
+  filter: drop-shadow(0 4px 14px rgba(15, 23, 42, 0.14));
+}
+
+.chart-series.is-pinned {
+  filter: drop-shadow(0 6px 18px rgba(15, 23, 42, 0.22));
+}
+
 .elo-chart .chart-tooltip {
   z-index: 2;
 }
@@ -1520,11 +1537,28 @@ ion);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(240, 244, 255, 0.94) 100%);
   box-shadow: 0 14px 32px rgba(15, 23, 42, 0.1);
   transition: transform var(--transition), box-shadow var(--transition);
+  cursor: pointer;
 }
 
 .chart-legend__item:hover {
   transform: translateY(-2px);
   box-shadow: 0 18px 38px rgba(15, 23, 42, 0.14);
+}
+
+.chart-legend__item.is-dimmed {
+  opacity: 0.45;
+  transform: none;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+}
+
+.chart-legend__item.is-active {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 42px rgba(15, 23, 42, 0.16);
+}
+
+.chart-legend__item.is-pinned {
+  border-color: var(--legend-color);
+  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.18);
 }
 
 .chart-legend__swatch {
@@ -1557,6 +1591,35 @@ ion);
   display: grid;
   gap: 2px;
   min-width: 0;
+}
+
+.chart-legend__delta {
+  margin-top: 4px;
+  display: inline-flex;
+  align-items: center;
+  width: max-content;
+  font-family: var(--font-mono);
+  font-size: var(--fs-0);
+  font-weight: 600;
+  padding: 2px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.05);
+  color: var(--muted);
+}
+
+.chart-legend__delta.positive {
+  background: rgba(34, 197, 94, 0.16);
+  color: #15803d;
+}
+
+.chart-legend__delta.negative {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+.chart-legend__delta.neutral {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--muted);
 }
 
 .chart-legend__text span {
@@ -2973,36 +3036,151 @@ body.tooltips-disabled .inline-tip {
   background: var(--surface);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-sm);
-  overflow: visible;
-  padding: 6px 6px 18px;
+  padding: 24px 28px 32px;
+  display: grid;
+  gap: 24px;
 }
 
-.page-history table thead th {
+.history-filters {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  align-items: end;
+}
+
+.history-filter label {
+  display: block;
+  margin-bottom: 6px;
+  font-size: var(--fs-0);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.history-filter select,
+.history-filter input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
   background: var(--surface-alt);
+  font-size: var(--fs-1);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.history-filter select:focus,
+.history-filter input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.08);
+  outline: none;
+}
+
+.history-filter__inputs {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  gap: 8px;
+  align-items: center;
+}
+
+.history-filter__inputs span {
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.history-filter--span-2 {
+  grid-column: span 2;
+}
+
+.history-filters__reset {
+  align-self: stretch;
+  justify-self: end;
+  padding: 10px 18px;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: transparent;
+  font-weight: 600;
+  font-size: var(--fs-1);
+  color: var(--muted);
+  transition: color var(--transition), border-color var(--transition), background var(--transition);
+  cursor: pointer;
+}
+
+.history-filters__reset:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(15, 23, 42, 0.05);
+}
+
+.history-filters__reset:focus-visible {
+  outline: 3px solid var(--focus-ring);
+  outline-offset: 3px;
+}
+
+.history-table__wrapper {
+  overflow-x: auto;
+}
+
+.history-table__grid {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 820px;
+}
+
+.history-table__grid thead th {
+  padding: 10px 14px;
+  font-size: var(--fs-0);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  border-bottom: 1px solid var(--border);
+  background: transparent;
+}
+
+.history-table__grid tbody td {
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--fs-1);
+}
+
+.history-table__grid tbody tr {
+  transition: background var(--transition), box-shadow var(--transition);
+}
+
+.history-table__grid tbody tr:hover {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.history-table__grid tbody tr:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.4);
+  outline-offset: -2px;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.history-table__grid tbody tr:last-child td {
   border-bottom: none;
 }
 
-.page-history table tbody tr {
-  transition: transform var(--transition), box-shadow var(--transition);
-}
-
-.page-history table tbody tr:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
-}
-
 .history-table__cell {
-  padding: 20px 25px;
+  vertical-align: middle;
 }
 
 .history-date {
   display: grid;
-  gap: 4px;
+  gap: 6px;
 }
 
 .history-date__primary {
   font-weight: 600;
   color: var(--text);
+  font-size: var(--fs-1);
+}
+
+.history-date__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
 .history-date__secondary {
@@ -3010,50 +3188,66 @@ body.tooltips-disabled .inline-tip {
   color: var(--muted);
 }
 
-.page-history .history-table table {
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0 6px;
-  margin-top: 6px;
-}
-
-.page-history .history-table thead th {
-  border-radius: 12px 12px 0 0;
-}
-
-.page-history .history-table tbody tr {
-  background: var(--surface);
-  border-radius: 16px;
-}
-
-.page-history .history-table tbody tr td:first-child {
-  border-top-left-radius: 16px;
-  border-bottom-left-radius: 16px;
-}
-
-.page-history .history-table tbody tr td:last-child {
-  border-top-right-radius: 16px;
-  border-bottom-right-radius: 16px;
-}
-
-.history-models {
-  display: flex;
-  align-items: baseline;
-  gap: 8px;
-  flex-wrap: wrap;
+.history-model {
   font-weight: 600;
-}
-
-.history-models__vs {
-  font-size: var(--fs-0);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--muted);
+  font-size: var(--fs-1);
+  max-width: 220px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .history-blinds {
   font-family: var(--font-mono);
   font-weight: 600;
+  font-size: var(--fs-1);
+}
+
+.history-delta {
+  min-width: 120px;
+}
+
+.history-delta__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: var(--fs-0);
+  font-family: var(--font-mono);
+  font-weight: 600;
+  background: rgba(15, 23, 42, 0.05);
+  color: var(--muted);
+}
+
+.history-delta__badge--positive {
+  background: rgba(34, 197, 94, 0.16);
+  color: #15803d;
+}
+
+.history-delta__badge--negative {
+  background: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+.history-delta__badge--neutral {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--muted);
+}
+
+.history-row {
+  cursor: pointer;
+}
+
+@media (max-width: 640px) {
+  .history-filter--span-2 {
+    grid-column: 1 / -1;
+  }
+  .history-table__grid {
+    min-width: 100%;
+  }
+  .history-filters__reset {
+    justify-self: stretch;
+  }
 }
 
 .history-status {
@@ -3110,7 +3304,4 @@ body.tooltips-disabled .inline-tip {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
-}
-.page-history .history-table tbody tr td {
-  border-bottom: none;
 }

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -19,14 +19,18 @@
       currentSeries: [],
       companies: [],
       selectedCompany: 'all',
+      sortMode: 'company',
       colorAssignments: new Map(),
       nextColorIndex: 0,
       resizeTimer: null,
       resizeBound: null,
-      lastHoverKey: null
+      lastHoverKey: null,
+      hoveredKey: null,
+      pinnedKeys: []
     };
     const dateFormatter = new Intl.DateTimeFormat(undefined, { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
     const shortDate = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+    const deltaFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0, signDisplay: 'always' });
     const $ = (sel) => document.querySelector(sel);
 
     const COMPANY_ICON_DATA = {
@@ -251,6 +255,13 @@
       return `rgba(${r}, ${g}, ${b}, ${clamped})`;
     }
 
+    function formatDelta(value) {
+      if (!Number.isFinite(value)) return '±0';
+      const rounded = Math.round(value);
+      if (rounded === 0) return '±0';
+      return deltaFormatter.format(rounded);
+    }
+
     function resetColorAssignments() {
       if (state.colorAssignments && typeof state.colorAssignments.clear === 'function') {
         state.colorAssignments.clear();
@@ -285,7 +296,11 @@
               model,
               company: companyLabel,
               companyKey: companySlug,
-              iconMarkup: companyIconMarkup(r.company, model)
+              iconMarkup: companyIconMarkup(r.company, model),
+              deltaFromStart: 0,
+              firstElo: null,
+              lastElo: null,
+              lastActive: null
             },
             pts: []
           };
@@ -300,7 +315,20 @@
         if (Number.isNaN(when.getTime())) return;
         entry.pts.push({ t: when, elo: Number(r.elo || 0) });
       });
-      map.forEach(entry => entry.pts.sort((a, b) => a.t - b.t));
+      map.forEach(entry => {
+        entry.pts.sort((a, b) => a.t - b.t);
+        if (!entry.pts.length) return;
+        const first = entry.pts[0];
+        const last = entry.pts[entry.pts.length - 1];
+        entry.meta.firstElo = first ? first.elo : null;
+        entry.meta.lastElo = last ? last.elo : null;
+        entry.meta.lastActive = last ? last.t : null;
+        if (first && last) {
+          entry.meta.deltaFromStart = last.elo - first.elo;
+        } else {
+          entry.meta.deltaFromStart = 0;
+        }
+      });
       return Array.from(map.values());
     }
 
@@ -360,6 +388,7 @@
       state.flat = [];
       state.flatSorted = [];
       state.lastHoverKey = null;
+      state.hoveredKey = null;
 
       const allPts = [];
       series.forEach(entry => entry.pts.forEach(p => allPts.push(p)));
@@ -383,7 +412,7 @@
       const elos = allPts.map(p => p.elo);
       const rawMin = Math.min(...elos);
       const rawMax = Math.max(...elos);
-      const yPad = Math.max(10, (rawMax - rawMin) * 0.08);
+      const yPad = Math.max(20, (rawMax - rawMin) * 0.12);
       let yMin = rawMin - yPad;
       let yMax = rawMax + yPad;
       if (yMin === yMax) {
@@ -516,8 +545,13 @@
       series.forEach((entry, seriesIndex) => {
         if (!entry.pts.length) return;
         const stroke = getSeriesColor(entry, seriesIndex);
+        const seriesKey = entry.botId != null
+          ? `bot:${entry.botId}`
+          : `series:${entry.meta.companyKey || 'company'}:${seriesIndex}`;
 
         const group = mk('g');
+        group.classList.add('chart-series');
+        group.dataset.key = seriesKey;
         svg.appendChild(group);
 
         const pts = entry.pts.map((pt, idx) => {
@@ -542,7 +576,7 @@
         glow.setAttribute('d', pathData);
         glow.setAttribute('fill', 'none');
         glow.setAttribute('stroke', stroke);
-        glow.setAttribute('stroke-width', '6');
+        glow.setAttribute('stroke-width', '5');
         glow.setAttribute('stroke-linecap', 'round');
         glow.setAttribute('stroke-linejoin', 'round');
         glow.setAttribute('opacity', '.18');
@@ -551,7 +585,7 @@
         line.setAttribute('d', pathData);
         line.setAttribute('fill', 'none');
         line.setAttribute('stroke', stroke);
-        line.setAttribute('stroke-width', '2.6');
+        line.setAttribute('stroke-width', '2.1');
         line.setAttribute('stroke-linecap', 'round');
         line.setAttribute('stroke-linejoin', 'round');
 
@@ -562,7 +596,7 @@
           const circle = mk('circle');
           circle.setAttribute('cx', String(pt.x));
           circle.setAttribute('cy', String(pt.y));
-          circle.setAttribute('r', '3');
+          circle.setAttribute('r', '2.6');
           circle.setAttribute('fill', stroke);
           circle.setAttribute('opacity', '.85');
           group.appendChild(circle);
@@ -575,7 +609,18 @@
         marker.style.display = 'none';
         markerGroup.appendChild(marker);
 
-        const plot = { meta: entry.meta, color: stroke, points: pts, marker };
+        const plot = {
+          meta: entry.meta,
+          color: stroke,
+          points: pts,
+          marker,
+          key: seriesKey,
+          group,
+          deltaFromStart: entry.meta?.deltaFromStart ?? 0,
+          lastActive: entry.meta?.lastActive ?? null,
+          lastElo: entry.meta?.lastElo ?? null,
+          firstElo: entry.meta?.firstElo ?? null
+        };
         pts.forEach(p => {
           p.plot = plot;
           p.hoverKey = String(p.timeMs);
@@ -587,12 +632,57 @@
       state.flat = plots.flatMap(plot => plot.points);
       state.flatSorted = state.flat.slice().sort((a, b) => a.x - b.x);
 
+      const availableKeys = new Set(plots.map(p => p.key));
+      state.pinnedKeys = state.pinnedKeys.filter(key => availableKeys.has(key));
+      if (state.hoveredKey && !availableKeys.has(state.hoveredKey)) {
+        state.hoveredKey = null;
+      }
+
       if (!plots.length) return;
+
+      function updatePlotStates() {
+        const activeKeys = new Set(state.pinnedKeys);
+        if (state.hoveredKey) activeKeys.add(state.hoveredKey);
+        const hasActive = activeKeys.size > 0;
+        plots.forEach(plot => {
+          const isActive = hasActive ? activeKeys.has(plot.key) : true;
+          const isPinned = state.pinnedKeys.includes(plot.key);
+          plot.group.classList.toggle('is-dimmed', hasActive && !isActive);
+          plot.group.classList.toggle('is-active', hasActive && isActive);
+          plot.group.classList.toggle('is-pinned', isPinned);
+          if (plot.legendEl) {
+            plot.legendEl.classList.toggle('is-dimmed', hasActive && !isActive);
+            plot.legendEl.classList.toggle('is-active', hasActive && isActive);
+            plot.legendEl.classList.toggle('is-pinned', isPinned);
+            plot.legendEl.setAttribute('aria-pressed', isPinned ? 'true' : 'false');
+          }
+        });
+      }
+
+      function setHoveredKey(key) {
+        if (state.hoveredKey === key) return;
+        state.hoveredKey = key;
+        updatePlotStates();
+      }
+
+      function togglePin(key) {
+        if (!key) return;
+        if (state.pinnedKeys.includes(key)) {
+          state.pinnedKeys = state.pinnedKeys.filter(item => item !== key);
+        } else {
+          const next = state.pinnedKeys.slice();
+          next.push(key);
+          if (next.length > 2) next.splice(0, next.length - 2);
+          state.pinnedKeys = next;
+        }
+        updatePlotStates();
+      }
 
       plots.forEach(plot => {
         const item = document.createElement('div');
         item.className = 'chart-legend__item';
         item.style.setProperty('--legend-color', plot.color);
+        item.title = 'Click to pin for comparison';
 
         const swatch = document.createElement('span');
         swatch.className = 'chart-legend__swatch';
@@ -619,16 +709,55 @@
         label.appendChild(textWrap);
         item.appendChild(label);
         legend.appendChild(item);
+        plot.legendEl = item;
+
+        const deltaEl = document.createElement('span');
+        deltaEl.className = 'chart-legend__delta';
+        const deltaValue = plot.deltaFromStart || 0;
+        deltaEl.textContent = formatDelta(deltaValue);
+        if (Math.round(deltaValue) > 0) {
+          deltaEl.classList.add('positive');
+        } else if (Math.round(deltaValue) < 0) {
+          deltaEl.classList.add('negative');
+        } else {
+          deltaEl.classList.add('neutral');
+        }
+        textWrap.appendChild(deltaEl);
+
+        item.dataset.key = plot.key;
+        item.setAttribute('role', 'button');
+        item.setAttribute('tabindex', '0');
+        item.setAttribute('aria-pressed', state.pinnedKeys.includes(plot.key) ? 'true' : 'false');
+        item.addEventListener('pointerenter', () => setHoveredKey(plot.key));
+        item.addEventListener('pointerleave', () => setHoveredKey(null));
+        item.addEventListener('focus', () => setHoveredKey(plot.key));
+        item.addEventListener('blur', () => setHoveredKey(null));
+        item.addEventListener('click', evt => {
+          evt.preventDefault();
+          togglePin(plot.key);
+        });
+        item.addEventListener('keydown', evt => {
+          if (evt.key === 'Enter' || evt.key === ' ') {
+            evt.preventDefault();
+            togglePin(plot.key);
+          }
+        });
       });
+
+      updatePlotStates();
 
       function hideHover() {
         tooltip.classList.remove('visible');
         crosshair.setAttribute('opacity', '0');
         plots.forEach(plot => (plot.marker.style.display = 'none'));
         state.lastHoverKey = null;
+        setHoveredKey(null);
       }
 
       function showAtPoint(point) {
+        if (point?.plot) {
+          setHoveredKey(point.plot.key);
+        }
         crosshair.setAttribute('opacity', '1');
         crosshair.setAttribute('x1', String(point.x));
         crosshair.setAttribute('x2', String(point.x));
@@ -834,6 +963,7 @@
         : state.fullSeries.filter(entry => entry.meta.companyKey === key);
       const sorted = sortSeries(filtered);
       draw(sorted);
+      updateSortControl();
       updateActiveIndicator();
     }
 
@@ -858,26 +988,55 @@
 
     function sortSeries(list) {
       const items = Array.isArray(list) ? list.slice() : [];
-      return items.sort((a, b) => {
+      const mode = state.sortMode || 'company';
+      const byCompany = (a, b) => {
         const aCompany = compareStrings(a.meta.company, b.meta.company);
         if (aCompany !== 0) return aCompany;
         const aModel = compareStrings(a.meta.model, b.meta.model);
         if (aModel !== 0) return aModel;
         return (a.botId || 0) - (b.botId || 0);
-      });
+      };
+      if (mode === 'delta') {
+        return items.sort((a, b) => {
+          const deltaA = Number(a.meta?.deltaFromStart ?? 0);
+          const deltaB = Number(b.meta?.deltaFromStart ?? 0);
+          if (deltaB !== deltaA) return deltaB - deltaA;
+          const lastA = a.meta?.lastActive ? new Date(a.meta.lastActive).getTime() : 0;
+          const lastB = b.meta?.lastActive ? new Date(b.meta.lastActive).getTime() : 0;
+          if (lastB !== lastA) return lastB - lastA;
+          return byCompany(a, b);
+        });
+      }
+      if (mode === 'recent') {
+        return items.sort((a, b) => {
+          const lastA = a.meta?.lastActive ? new Date(a.meta.lastActive).getTime() : 0;
+          const lastB = b.meta?.lastActive ? new Date(b.meta.lastActive).getTime() : 0;
+          if (lastB !== lastA) return lastB - lastA;
+          const deltaA = Number(a.meta?.deltaFromStart ?? 0);
+          const deltaB = Number(b.meta?.deltaFromStart ?? 0);
+          if (deltaB !== deltaA) return deltaB - deltaA;
+          return byCompany(a, b);
+        });
+      }
+      return items.sort(byCompany);
     }
 
     function bindSortControl() {
       const select = document.getElementById('sortMode');
       if (!select || select.dataset.bound === 'true') return;
-      select.value = 'company';
+      select.value = state.sortMode || 'company';
+      select.addEventListener('change', evt => {
+        state.sortMode = evt.target.value || 'company';
+        applyFilters();
+      });
       select.dataset.bound = 'true';
     }
 
     function updateSortControl() {
       const select = document.getElementById('sortMode');
       if (!select) return;
-      if (select.value !== 'company') select.value = 'company';
+      const desired = state.sortMode || 'company';
+      if (select.value !== desired) select.value = desired;
     }
 
     function handleResize() {
@@ -1072,6 +1231,8 @@
             <span class="sort-control__label">Sort by</span>
             <select id="sortMode" name="sortMode" aria-label="Sort Elo series">
               <option value="company">Company (A → Z)</option>
+              <option value="delta">Top Δ</option>
+              <option value="recent">Most recent activity</option>
             </select>
           </label>
         </div>

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -8,9 +8,33 @@
   <link rel="icon" href="/web/favicon.svg" type="image/svg+xml"/>
   <script src="/web/app.js" defer></script>
   <script>
-    const state = { rows: [], sortKey: 'created_at', sortDir: 'desc' };
+    const UNKNOWN_MODEL = '__unknown__';
+    const UNKNOWN_BLINDS = '__unknown__';
+    const deltaFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0, signDisplay: 'always' });
+
+    const state = {
+      rows: [],
+      sortKey: 'created_at',
+      sortDir: 'desc',
+      filters: {
+        modelA: 'all',
+        modelB: 'all',
+        blinds: 'all',
+        dateFrom: '',
+        dateTo: '',
+        deltaMin: '',
+        deltaMax: ''
+      },
+      options: {
+        modelA: [],
+        modelB: [],
+        blinds: []
+      }
+    };
     const $ = (selector) => document.querySelector(selector);
     const formatNumber = (value) => Number(value ?? 0).toLocaleString();
+    const HTML_ESCAPE = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+    const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, ch => HTML_ESCAPE[ch] || ch);
     const formatDate = (value) => {
       if (!value) return '—';
       try { return new Date(value).toLocaleString(); } catch (_) { return '—'; }
@@ -23,6 +47,7 @@
       blinds: (a, b) => (a.sb ?? 0) - (b.sb ?? 0),
       start_stack: (a, b) => (a.start_stack ?? 0) - (b.start_stack ?? 0),
       duel_seeds: (a, b) => (a.duel_seeds ?? 0) - (b.duel_seeds ?? 0),
+      result_delta: (a, b) => (a.result_delta ?? 0) - (b.result_delta ?? 0),
     };
 
     async function getJSON(url, fallback) {
@@ -54,32 +79,261 @@
       return rows;
     }
 
+    function normalizeModelValue(value) {
+      const trimmed = String(value ?? '').trim();
+      return trimmed ? trimmed : UNKNOWN_MODEL;
+    }
+
+    function modelLabel(value) {
+      return value === UNKNOWN_MODEL ? 'Unknown' : value;
+    }
+
+    function normalizeBlindsValue(row) {
+      if (row == null) return UNKNOWN_BLINDS;
+      const sb = Number(row.sb);
+      const bb = Number(row.bb);
+      if (!Number.isFinite(sb) || !Number.isFinite(bb)) return UNKNOWN_BLINDS;
+      return `${sb}/${bb}`;
+    }
+
+    function blindsLabel(value) {
+      return value === UNKNOWN_BLINDS ? 'Unknown' : value;
+    }
+
+    function formatBlinds(row) {
+      const value = normalizeBlindsValue(row);
+      return value === UNKNOWN_BLINDS ? '—' : value;
+    }
+
+    function formatDelta(value) {
+      if (!Number.isFinite(value)) return '±0';
+      const rounded = Math.round(value);
+      if (rounded === 0) return '±0';
+      return deltaFormatter.format(rounded);
+    }
+
+    function deltaClass(value) {
+      if (!Number.isFinite(value)) return 'neutral';
+      if (value > 0) return 'positive';
+      if (value < 0) return 'negative';
+      return 'neutral';
+    }
+
+    function parseDateInput(value) {
+      if (!value) return null;
+      const parts = String(value).split('-').map(part => Number(part));
+      if (parts.length !== 3 || parts.some(num => Number.isNaN(num))) return null;
+      return new Date(parts[0], parts[1] - 1, parts[2]);
+    }
+
+    function addDays(date, days) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) return null;
+      const copy = new Date(date.getTime());
+      copy.setDate(copy.getDate() + days);
+      return copy;
+    }
+
+    function buildFilterOptions(rows) {
+      const modelsA = new Map();
+      const modelsB = new Map();
+      const blinds = new Map();
+      rows.forEach(row => {
+        const normA = normalizeModelValue(row.model_a);
+        const normB = normalizeModelValue(row.model_b);
+        const blindKey = normalizeBlindsValue(row);
+        if (!modelsA.has(normA)) modelsA.set(normA, modelLabel(normA));
+        if (!modelsB.has(normB)) modelsB.set(normB, modelLabel(normB));
+        if (!blinds.has(blindKey)) blinds.set(blindKey, blindsLabel(blindKey));
+      });
+      const sortAlpha = (a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' });
+      const sortBlinds = (a, b) => {
+        if (a.value === UNKNOWN_BLINDS) return 1;
+        if (b.value === UNKNOWN_BLINDS) return -1;
+        const [asb, abb] = a.value.split('/').map(Number);
+        const [bsb, bbb] = b.value.split('/').map(Number);
+        if (asb !== bsb) return asb - bsb;
+        return abb - bbb;
+      };
+      const options = {
+        modelA: Array.from(modelsA.entries()).map(([value, label]) => ({ value, label })).sort((a, b) => {
+          if (a.value === UNKNOWN_MODEL) return 1;
+          if (b.value === UNKNOWN_MODEL) return -1;
+          return sortAlpha(a, b);
+        }),
+        modelB: Array.from(modelsB.entries()).map(([value, label]) => ({ value, label })).sort((a, b) => {
+          if (a.value === UNKNOWN_MODEL) return 1;
+          if (b.value === UNKNOWN_MODEL) return -1;
+          return sortAlpha(a, b);
+        }),
+        blinds: Array.from(blinds.entries()).map(([value, label]) => ({ value, label })).sort(sortBlinds)
+      };
+      state.options = options;
+    }
+
+    function ensureFilterValues() {
+      ['modelA', 'modelB', 'blinds'].forEach(key => {
+        const options = state.options[key] || [];
+        const allowed = new Set(options.map(opt => opt.value));
+        const current = state.filters[key];
+        if (current !== 'all' && !allowed.has(current)) {
+          state.filters[key] = 'all';
+        }
+      });
+    }
+
+    function renderFilterOptions() {
+      const renderSelect = (id, options) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        const opts = [`<option value="all">All</option>`]
+          .concat(options.map(opt => `<option value="${escapeHtml(opt.value)}">${escapeHtml(opt.label)}</option>`));
+        el.innerHTML = opts.join('');
+      };
+      renderSelect('filterModelA', state.options.modelA);
+      renderSelect('filterModelB', state.options.modelB);
+      renderSelect('filterBlinds', state.options.blinds);
+    }
+
+    function syncFilterControls() {
+      const { filters } = state;
+      const assign = (id, value) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.value = value ?? '';
+      };
+      assign('filterModelA', filters.modelA);
+      assign('filterModelB', filters.modelB);
+      assign('filterBlinds', filters.blinds);
+      assign('filterDateFrom', filters.dateFrom);
+      assign('filterDateTo', filters.dateTo);
+      assign('filterDeltaMin', filters.deltaMin);
+      assign('filterDeltaMax', filters.deltaMax);
+    }
+
+    function setFilter(key, value) {
+      if (!(key in state.filters)) return;
+      state.filters[key] = value;
+      render();
+    }
+
+    function resetFilters() {
+      state.filters = {
+        modelA: 'all',
+        modelB: 'all',
+        blinds: 'all',
+        dateFrom: '',
+        dateTo: '',
+        deltaMin: '',
+        deltaMax: ''
+      };
+      syncFilterControls();
+      render();
+    }
+
+    function bindFilterControls() {
+      const modelA = document.getElementById('filterModelA');
+      const modelB = document.getElementById('filterModelB');
+      const blinds = document.getElementById('filterBlinds');
+      const dateFrom = document.getElementById('filterDateFrom');
+      const dateTo = document.getElementById('filterDateTo');
+      const deltaMin = document.getElementById('filterDeltaMin');
+      const deltaMax = document.getElementById('filterDeltaMax');
+      const resetBtn = document.getElementById('filterReset');
+
+      if (modelA && !modelA.dataset.bound) {
+        modelA.addEventListener('change', evt => setFilter('modelA', evt.target.value || 'all'));
+        modelA.dataset.bound = 'true';
+      }
+      if (modelB && !modelB.dataset.bound) {
+        modelB.addEventListener('change', evt => setFilter('modelB', evt.target.value || 'all'));
+        modelB.dataset.bound = 'true';
+      }
+      if (blinds && !blinds.dataset.bound) {
+        blinds.addEventListener('change', evt => setFilter('blinds', evt.target.value || 'all'));
+        blinds.dataset.bound = 'true';
+      }
+      if (dateFrom && !dateFrom.dataset.bound) {
+        dateFrom.addEventListener('change', evt => setFilter('dateFrom', evt.target.value || ''));
+        dateFrom.dataset.bound = 'true';
+      }
+      if (dateTo && !dateTo.dataset.bound) {
+        dateTo.addEventListener('change', evt => setFilter('dateTo', evt.target.value || ''));
+        dateTo.dataset.bound = 'true';
+      }
+      if (deltaMin && !deltaMin.dataset.bound) {
+        deltaMin.addEventListener('input', evt => setFilter('deltaMin', evt.target.value));
+        deltaMin.dataset.bound = 'true';
+      }
+      if (deltaMax && !deltaMax.dataset.bound) {
+        deltaMax.addEventListener('input', evt => setFilter('deltaMax', evt.target.value));
+        deltaMax.dataset.bound = 'true';
+      }
+      if (resetBtn && !resetBtn.dataset.bound) {
+        resetBtn.addEventListener('click', resetFilters);
+        resetBtn.dataset.bound = 'true';
+      }
+    }
+
+    function filterRows(list) {
+      const rows = Array.isArray(list) ? list : [];
+      const { filters } = state;
+      const modelAFilter = filters.modelA;
+      const modelBFilter = filters.modelB;
+      const blindFilter = filters.blinds;
+      const dateFrom = parseDateInput(filters.dateFrom);
+      const dateTo = parseDateInput(filters.dateTo);
+      const dateToExclusive = dateTo ? addDays(dateTo, 1) : null;
+      const deltaMin = filters.deltaMin !== '' ? Number(filters.deltaMin) : null;
+      const deltaMax = filters.deltaMax !== '' ? Number(filters.deltaMax) : null;
+
+      return rows.filter(row => {
+        if (modelAFilter !== 'all' && normalizeModelValue(row.model_a) !== modelAFilter) return false;
+        if (modelBFilter !== 'all' && normalizeModelValue(row.model_b) !== modelBFilter) return false;
+        if (blindFilter !== 'all' && normalizeBlindsValue(row) !== blindFilter) return false;
+
+        if (dateFrom) {
+          const created = row.created_at ? new Date(row.created_at) : null;
+          if (!created || created < dateFrom) return false;
+        }
+        if (dateToExclusive) {
+          const created = row.created_at ? new Date(row.created_at) : null;
+          if (!created || created >= dateToExclusive) return false;
+        }
+
+        const delta = Number(row.result_delta ?? 0);
+        if (deltaMin != null && Number.isFinite(deltaMin) && delta < deltaMin) return false;
+        if (deltaMax != null && Number.isFinite(deltaMax) && delta > deltaMax) return false;
+
+        return true;
+      });
+    }
+
     function rowMarkup(m) {
       const status = statusMeta(m);
-      const blinds = (m.sb != null && m.bb != null) ? `${m.sb}/${m.bb}` : '—';
+      const blinds = formatBlinds(m);
+      const deltaValue = Number(m.result_delta ?? 0);
+      const deltaLabel = formatDelta(deltaValue);
+      const deltaState = deltaClass(deltaValue);
+      const modelALabel = m.model_a ? escapeHtml(m.model_a) : 'Unknown';
+      const modelBLabel = m.model_b ? escapeHtml(m.model_b) : 'Unknown';
       return `
-        <tr>
+        <tr class="history-row" data-match-id="${m.id}" tabindex="0" role="link" aria-label="Open replay for match ${m.id}">
           <td class="history-table__cell num mono">${m.id}</td>
           <td class="history-table__cell">
             <div class="history-date">
               <div class="history-date__primary">${formatDate(m.created_at)}</div>
+              <div class="history-date__meta">
+                <span class="history-date__secondary">${formatDate(m.ended_at)}</span>
+                <span class="${status.className}"><span class="history-status__dot"></span>${status.label}</span>
+              </div>
             </div>
           </td>
-          <td class="history-table__cell">
-            <div class="history-date">
-              <div class="history-date__primary">${formatDate(m.ended_at)}</div>
-              <span class="${status.className}"><span class="history-status__dot"></span>${status.label}</span>
-            </div>
-          </td>
-          <td class="history-table__cell">
-            <div class="history-models">
-              <span>${m.model_a || 'A'}</span>
-              <span class="history-models__vs">vs</span>
-              <span>${m.model_b || 'B'}</span>
-            </div>
-          </td>
+          <td class="history-table__cell history-model">${modelALabel}</td>
+          <td class="history-table__cell history-model">${modelBLabel}</td>
           <td class="history-table__cell num history-blinds">${blinds}</td>
-          <td class="history-table__cell num history-blinds">${formatNumber(m.start_stack)}</td>
+          <td class="history-table__cell history-delta">
+            <span class="history-delta__badge history-delta__badge--${deltaState}">${deltaLabel}</span>
+          </td>
           <td class="history-table__cell num history-blinds">${formatNumber(m.duel_seeds)}</td>
           <td class="history-table__cell history-table__actions">
             <a class="pill accent" href="/web/replay.html?match_id=${m.id}">Replay</a>
@@ -109,7 +363,13 @@
         updateHeaderState();
         return;
       }
-      const sorted = sortRows(state.rows);
+      const filtered = filterRows(state.rows);
+      if (!filtered.length) {
+        tbody.innerHTML = `<tr><td class="history-table__cell" colspan="8">No matches match the current filters.</td></tr>`;
+        updateHeaderState();
+        return;
+      }
+      const sorted = sortRows(filtered);
       tbody.innerHTML = sorted.map(rowMarkup).join('');
       updateHeaderState();
     }
@@ -127,9 +387,45 @@
       render();
     }
 
+    function navigateToReplay(matchId) {
+      if (!matchId) return;
+      const url = `/web/replay.html?match_id=${encodeURIComponent(matchId)}`;
+      window.location.href = url;
+    }
+
+    function bindTableInteractions() {
+      const tbody = $('#tbody');
+      if (!tbody || tbody.dataset.bound === 'true') return;
+      tbody.addEventListener('click', evt => {
+        const targetLink = evt.target.closest('a, button');
+        if (targetLink) return;
+        const row = evt.target.closest('tr[data-match-id]');
+        if (!row) return;
+        const matchId = row.getAttribute('data-match-id');
+        navigateToReplay(matchId);
+      });
+      tbody.addEventListener('keydown', evt => {
+        if (evt.key !== 'Enter' && evt.key !== ' ') return;
+        if (evt.target.closest('a, button')) return;
+        const row = evt.target.closest('tr[data-match-id]');
+        if (!row) return;
+        evt.preventDefault();
+        const matchId = row.getAttribute('data-match-id');
+        navigateToReplay(matchId);
+      });
+      tbody.dataset.bound = 'true';
+    }
+
     async function load() {
       const data = await getJSON('/api/matches', '/web/data/matches.json');
-      state.rows = data.rows || [];
+      state.rows = (data.rows || []).map(row => ({
+        ...row,
+        result_delta: Number(row.result_delta ?? 0)
+      }));
+      buildFilterOptions(state.rows);
+      ensureFilterValues();
+      renderFilterOptions();
+      syncFilterControls();
       render();
     }
 
@@ -137,6 +433,8 @@
       document.querySelectorAll('th[data-sort]').forEach((th) => {
         th.addEventListener('click', handleSortClick);
       });
+      bindFilterControls();
+      bindTableInteractions();
       load();
     });
   </script>
@@ -258,21 +556,54 @@
       </div>
 
       <div class="history-table">
-        <table class="table">
-          <thead>
-            <tr>
-              <th class="num sortable" data-sort="id" aria-sort="none" title="Sort by ID">ID</th>
-              <th class="sortable" data-sort="created_at" aria-sort="descending" title="Sort by created date">Created</th>
-              <th class="sortable" data-sort="ended_at" title="Sort by ended date">Ended</th>
-              <th>Models</th>
-              <th class="num sortable" data-sort="blinds" title="Sort by blinds">Blinds</th>
-              <th class="num sortable" data-sort="start_stack" title="Sort by start stack">Start</th>
-              <th class="num sortable" data-sort="duel_seeds" title="Sort by duel seeds">Pairs</th>
-              <th class="num">Replay</th>
-            </tr>
-          </thead>
-          <tbody id="tbody"><tr><td class="history-table__cell" colspan="8">Loading…</td></tr></tbody>
-        </table>
+        <div class="history-filters" role="region" aria-label="Match filters">
+          <div class="history-filter">
+            <label for="filterModelA">Model A</label>
+            <select id="filterModelA" name="filterModelA"></select>
+          </div>
+          <div class="history-filter">
+            <label for="filterModelB">Model B</label>
+            <select id="filterModelB" name="filterModelB"></select>
+          </div>
+          <div class="history-filter">
+            <label for="filterBlinds">Blinds</label>
+            <select id="filterBlinds" name="filterBlinds"></select>
+          </div>
+          <div class="history-filter history-filter--range history-filter--span-2">
+            <label for="filterDateFrom">Date range</label>
+            <div class="history-filter__inputs">
+              <input type="date" id="filterDateFrom" name="filterDateFrom"/>
+              <span aria-hidden="true">–</span>
+              <input type="date" id="filterDateTo" name="filterDateTo"/>
+            </div>
+          </div>
+          <div class="history-filter history-filter--range history-filter--span-2">
+            <label for="filterDeltaMin">Result Δ (chips)</label>
+            <div class="history-filter__inputs">
+              <input type="number" id="filterDeltaMin" name="filterDeltaMin" placeholder="Min" inputmode="numeric"/>
+              <span aria-hidden="true">–</span>
+              <input type="number" id="filterDeltaMax" name="filterDeltaMax" placeholder="Max" inputmode="numeric"/>
+            </div>
+          </div>
+          <button id="filterReset" class="history-filters__reset" type="button">Reset filters</button>
+        </div>
+        <div class="history-table__wrapper">
+          <table class="table history-table__grid">
+            <thead>
+              <tr>
+                <th class="num sortable" data-sort="id" aria-sort="none" title="Sort by ID">ID</th>
+                <th class="sortable" data-sort="created_at" aria-sort="descending" title="Sort by created date">Created</th>
+                <th>Model A</th>
+                <th>Model B</th>
+                <th class="num sortable" data-sort="blinds" title="Sort by blinds">Blinds</th>
+                <th class="num sortable" data-sort="result_delta" title="Sort by result delta">Result Δ</th>
+                <th class="num sortable" data-sort="duel_seeds" title="Sort by duel seeds">Pairs</th>
+                <th class="num">Replay</th>
+              </tr>
+            </thead>
+            <tbody id="tbody"><tr><td class="history-table__cell" colspan="8">Loading…</td></tr></tbody>
+          </table>
+        </div>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- expose per-match result deltas from the API to drive history filtering
- enrich the Elo timeline with delta badges, hover dimming, and pin-able legends plus new sort orders
- rebuild the history page as a dense, filterable table with clickable rows and refreshed styling

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf9764a060832d8c70752584daf3dc