### PR TITLE
Redesign replay experience with centered table layout

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -552,6 +552,18 @@ p {
   background: transparent;
 }
 
+.pill.warn {
+  border-color: rgba(22, 163, 74, 0.32);
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+}
+
+.pill.ok {
+  border-color: rgba(250, 204, 21, 0.42);
+  background: rgba(250, 204, 21, 0.2);
+  color: #92400e;
+}
+
 .select-pill {
   appearance: none;
   -webkit-appearance: none;
@@ -1892,7 +1904,7 @@ ion);
 
 .cards {
   display: flex;
-  gap: 18px;
+  gap: 16px;
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
@@ -1905,13 +1917,9 @@ ion);
   min-height: var(--card-h);
 }
 
-#board {
-  margin-top: 18px;
-}
-
 #sb_hole,
 #bb_hole {
-  margin-top: 16px;
+  margin-top: 12px;
 }
 
 #sb_hole {
@@ -1932,14 +1940,14 @@ ion);
 
 .cardx {
   --corner-pad: 10px;
-  --rank-size: 32px;
-  --glyph-size: 4.35em;
+  --rank-size: 28px;
+  --glyph-size: 3.6em;
   --tilt: 0deg;
-  --card-front-bg: radial-gradient(145deg, #ffffff 0%, #eef2f7 100%);
-  --card-front-border: rgba(15, 23, 42, 0.14);
-  --card-front-color: #0f172a;
-  --card-back-bg: radial-gradient(circle at 25% 25%, #16213a 0%, #0b1226 70%, #020617 100%);
-  --card-back-pattern: rgba(255, 255, 255, 0.08);
+  --card-front-bg: linear-gradient(165deg, #ffffff 0%, #f1f5f9 100%);
+  --card-front-border: rgba(15, 23, 42, 0.12);
+  --card-front-color: #111827;
+  --card-back-bg: linear-gradient(140deg, #0f172a 0%, #111827 100%);
+  --card-back-pattern: rgba(148, 163, 184, 0.18);
   --card-glyph: '';
   width: var(--card-w);
   height: var(--card-h);
@@ -1947,14 +1955,15 @@ ion);
   position: relative;
   display: grid;
   place-items: center;
-  font-family: 'Space Grotesk', var(--font-display), var(--font-sans);
+  font-family: var(--font-display);
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.02em;
   color: var(--card-front-color);
   transform-style: preserve-3d;
   transform: rotateY(var(--tilt));
-  transition: transform 360ms ease;
-  filter: drop-shadow(0 20px 40px rgba(15, 23, 42, 0.24));
+  transition: transform 320ms ease;
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.18);
+  background: transparent;
 }
 
 .cardx .face {
@@ -1972,21 +1981,21 @@ ion);
   color: inherit;
   transform: rotateY(180deg);
   border: 1px solid var(--card-front-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.9), inset 0 -2px 12px rgba(15, 23, 42, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 -2px 8px rgba(15, 23, 42, 0.12);
 }
 
 .cardx .back {
   background: var(--card-back-bg);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
 }
 
 .cardx .back::after {
   content: '';
   position: absolute;
-  inset: -6px;
-  background: repeating-linear-gradient(45deg, transparent 0, transparent 10px, var(--card-back-pattern) 10px, var(--card-back-pattern) 18px);
-  opacity: 0.5;
+  inset: -10px;
+  background: repeating-linear-gradient(45deg, transparent 0, transparent 12px, var(--card-back-pattern) 12px, var(--card-back-pattern) 20px);
+  opacity: 0.4;
   mix-blend-mode: screen;
 }
 
@@ -2001,7 +2010,6 @@ ion);
   line-height: 1;
   font-weight: 700;
   color: var(--card-front-color);
-  text-shadow: 0 0 6px rgba(255, 255, 255, 0.9), 0 1px 3px rgba(15, 23, 42, 0.35);
 }
 
 .cardx .num-box.top {
@@ -2017,13 +2025,15 @@ ion);
 
 .cardx .num-box.suit::after {
   display: block;
-  font-size: 0.65em;
-  margin-top: 2px;
+  font-size: 0.62em;
+  margin-top: 3px;
   content: var(--card-glyph, '');
 }
 
 .cardx .suit {
   font-size: var(--glyph-size);
+  color: currentColor;
+  text-shadow: 0 12px 28px rgba(15, 23, 42, 0.25);
 }
 
 .cardx .suit::after {
@@ -2036,76 +2046,72 @@ ion);
 
 .heart,
 .diamond {
-  color: #e11d48;
+  color: #dc2626;
 }
 
 .club {
-  color: #0f766e;
+  color: #15803d;
 }
 
 .cardx.spade {
-  --card-front-bg: radial-gradient(circle at 25% 25%, #f8fafc 0%, #e2e8f0 100%);
-  --card-front-border: rgba(15, 23, 42, 0.18);
-  --card-front-color: #0f172a;
-  --card-back-bg: radial-gradient(circle at 25% 25%, #1e293b 0%, #0f172a 65%, #020617 100%);
-  --card-back-pattern: rgba(148, 163, 184, 0.22);
+  --card-front-bg: linear-gradient(165deg, #ffffff 0%, #e2e8f0 100%);
+  --card-front-border: rgba(15, 23, 42, 0.16);
+  --card-front-color: #111827;
+  --card-back-bg: linear-gradient(140deg, #111827 0%, #0f172a 100%);
+  --card-back-pattern: rgba(148, 163, 184, 0.24);
   --card-glyph: '\2660';
 }
 
 .cardx.heart {
-  --card-front-bg: radial-gradient(circle at 25% 25%, #fff5f5 0%, #fee2e2 65%, #fecaca 100%);
-  --card-front-border: rgba(248, 113, 113, 0.45);
+  --card-front-bg: linear-gradient(165deg, #fff7f7 0%, #fee2e2 100%);
+  --card-front-border: rgba(248, 113, 113, 0.35);
   --card-front-color: #b91c1c;
-  --card-back-bg: linear-gradient(130deg, #7f1d1d 0%, #be123c 55%, #9f1239 100%);
-  --card-back-pattern: rgba(254, 226, 226, 0.25);
+  --card-back-bg: linear-gradient(140deg, #991b1b 0%, #be123c 100%);
+  --card-back-pattern: rgba(254, 226, 226, 0.32);
   --card-glyph: '\2665';
 }
 
 .cardx.diamond {
-  --card-front-bg: radial-gradient(circle at 25% 25%, #fff5f8 0%, #ffe4e6 65%, #fecdd3 100%);
-  --card-front-border: rgba(251, 113, 133, 0.4);
+  --card-front-bg: linear-gradient(165deg, #fff7fb 0%, #ffe4e6 100%);
+  --card-front-border: rgba(251, 113, 133, 0.32);
   --card-front-color: #b91c1c;
-  --card-back-bg: linear-gradient(135deg, #9d174d 0%, #be185d 55%, #831843 100%);
-  --card-back-pattern: rgba(255, 228, 230, 0.28);
+  --card-back-bg: linear-gradient(140deg, #9d174d 0%, #be185d 100%);
+  --card-back-pattern: rgba(255, 228, 230, 0.3);
   --card-glyph: '\2666';
 }
 
 .cardx.club {
-  --card-front-bg: radial-gradient(circle at 25% 25%, #f1fcf5 0%, #dcfce7 65%, #bbf7d0 100%);
-  --card-front-border: rgba(22, 163, 74, 0.35);
-  --card-front-color: #065f46;
-  --card-back-bg: linear-gradient(135deg, #064e3b 0%, #047857 55%, #065f46 100%);
+  --card-front-bg: linear-gradient(165deg, #f4fff8 0%, #dcfce7 100%);
+  --card-front-border: rgba(22, 163, 74, 0.28);
+  --card-front-color: #047857;
+  --card-back-bg: linear-gradient(140deg, #065f46 0%, #047857 100%);
   --card-back-pattern: rgba(187, 247, 208, 0.32);
-  --card-glyph: '\2663';
+  --card-glyph: '\\2663';
+}
+
+body.replay-theme {
+  --card-w: 112px;
+  --card-h: 162px;
 }
 
 @media (max-width: 1080px) {
   body.replay-theme {
-    --card-w: 120px;
-    --card-h: 170px;
+    --card-w: 102px;
+    --card-h: 148px;
   }
 }
 
 @media (max-width: 720px) {
   body.replay-theme {
-    --card-w: 96px;
-    --card-h: 138px;
-  }
-  body.replay-theme .felt {
-    padding: 32px 24px 26px;
-  }
-  body.replay-theme .replay__controls {
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    --card-w: 88px;
+    --card-h: 126px;
   }
 }
 
 @media (max-width: 540px) {
   body.replay-theme {
-    --card-w: 82px;
-    --card-h: 118px;
-  }
-  body.replay-theme .felt {
-    padding: 24px 18px 22px;
+    --card-w: 74px;
+    --card-h: 108px;
   }
 }
 
@@ -2937,147 +2943,96 @@ body.tooltips-disabled .inline-tip {
   font-weight: 500;
 }
 
-.replay-grid {
-  display: grid;
-  gap: var(--gutter);
+.replay-layout {
+  display: flex;
+  justify-content: center;
 }
 
-@media (min-width: 1120px) {
-  .replay-grid {
-    grid-template-columns: minmax(0, 1.55fr) minmax(0, 1fr);
-    align-items: start;
-  }
-}
-
-.card--table {
+.card--stage {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 28px;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96) 0%, rgba(242, 246, 255, 0.9) 100%);
-  position: relative;
+  gap: 32px;
+  padding: 32px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.95) 0%, rgba(244, 247, 255, 0.88) 100%);
   overflow: hidden;
 }
 
-.card--table::after {
+.card--stage::before {
   content: '';
   position: absolute;
-  inset: 0;
+  inset: -20% 0 auto;
+  height: 360px;
+  background: radial-gradient(60% 80% at 20% 0%, rgba(22, 163, 74, 0.16), transparent),
+              radial-gradient(60% 80% at 80% 10%, rgba(15, 118, 110, 0.14), transparent 60%);
   pointer-events: none;
-  background: radial-gradient(circle at 18% 12%, rgba(37, 99, 235, 0.12), transparent 55%),
-              radial-gradient(circle at 85% 24%, rgba(20, 184, 166, 0.12), transparent 60%);
-  z-index: 0;
+  mix-blend-mode: soft-light;
 }
 
-.card--table > * {
+.card--stage > * {
   position: relative;
   z-index: 1;
 }
 
-.card--controls,
-.card--log {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-}
-
-.replay-table__header {
+.stage-header {
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-between;
   align-items: flex-start;
+  justify-content: space-between;
   gap: 24px;
 }
 
-.replay-table__handwrap {
-  display: grid;
+.stage-header__hand {
+  display: flex;
+  flex-direction: column;
   gap: 6px;
 }
 
-.replay-table__hand {
+.stage-header__hand-id {
   font-family: var(--font-display);
   font-size: var(--fs-4);
   font-weight: 600;
   color: var(--accent);
 }
 
-.replay-table__status {
+.stage-header__meta {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 20px;
+  margin-left: auto;
 }
 
-.replay-table__pot {
+.stage-header__pot {
   display: grid;
   justify-items: end;
   gap: 6px;
 }
 
-.replay-table__pot-value {
+.stage-header__pot-value {
   font-size: var(--fs-3);
   font-family: var(--font-mono);
   font-weight: 600;
+  color: var(--accent);
 }
 
-.replay-table__pills {
+.stage-header__status {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
 }
 
-.pill.warn {
-  border-color: rgba(37, 99, 235, 0.25);
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
+.stage-table {
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: 28px;
+  flex-wrap: wrap;
 }
 
-.pill.ok {
-  border-color: rgba(16, 185, 129, 0.28);
-  background: rgba(16, 185, 129, 0.14);
-  color: #047857;
-}
-
-.replay-table__action {
-  display: grid;
-  gap: 8px;
-  padding: 18px 22px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(255, 255, 255, 0.85);
-}
-
-.replay-table__action-main {
-  font-family: var(--font-display);
-  font-size: var(--fs-3);
-  font-weight: 600;
-  color: var(--accent);
-}
-
-.replay-table__action-sub {
-  font-size: var(--fs-1);
-}
-
-.replay-table__board {
-  display: grid;
-  justify-items: center;
-  gap: 12px;
-}
-
-.replay-table__board-text {
-  font-family: var(--font-mono);
-  font-size: var(--fs-1);
-  color: var(--muted);
-}
-
-.replay-table__seats {
-  display: grid;
-  gap: 18px;
-}
-
-@media (min-width: 680px) {
-  .replay-table__seats {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+.stage-seat {
+  flex: 1 1 280px;
+  max-width: 340px;
 }
 
 .seat-card {
@@ -3085,23 +3040,23 @@ body.tooltips-disabled .inline-tip {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 22px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.08);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+  padding: 22px 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
 .seat-card--active {
   transform: translateY(-4px);
-  border-color: rgba(37, 99, 235, 0.38);
-  box-shadow: 0 22px 48px rgba(37, 99, 235, 0.16);
+  border-color: rgba(22, 163, 74, 0.45);
+  box-shadow: 0 24px 48px rgba(22, 163, 74, 0.18);
 }
 
 .seat-card--winner {
   border-color: rgba(250, 204, 21, 0.65);
-  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.35), 0 26px 50px rgba(250, 204, 21, 0.22);
+  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.35), 0 28px 50px rgba(250, 204, 21, 0.24);
 }
 
 .seat-card__header {
@@ -3112,13 +3067,14 @@ body.tooltips-disabled .inline-tip {
 }
 
 .seat-card__identity {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 6px;
 }
 
 .seat-card__role {
   font-size: var(--fs-0);
-  letter-spacing: 0.16em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--muted);
   font-weight: 600;
@@ -3134,14 +3090,14 @@ body.tooltips-disabled .inline-tip {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   border-radius: 50%;
-  background: rgba(37, 99, 235, 0.12);
-  color: #1d4ed8;
+  background: linear-gradient(135deg, #0f172a 0%, #1f2937 100%);
+  color: #f8fafc;
   font-weight: 600;
   font-size: var(--fs-1);
-  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18), 0 12px 24px rgba(15, 23, 42, 0.22);
 }
 
 .seat-card__stacks {
@@ -3166,7 +3122,7 @@ body.tooltips-disabled .inline-tip {
 
 .seat-card__delta.positive,
 .seat-card__ev-delta.positive {
-  color: #047857;
+  color: #15803d;
 }
 
 .seat-card__delta.negative,
@@ -3188,7 +3144,8 @@ body.tooltips-disabled .inline-tip {
 }
 
 .seat-card__ev-title {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 6px;
 }
 
@@ -3211,9 +3168,9 @@ body.tooltips-disabled .inline-tip {
   --ev-pct: 50%;
   position: relative;
   width: 100%;
-  height: 12px;
+  height: 10px;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.08);
+  background: rgba(148, 163, 184, 0.22);
   overflow: hidden;
 }
 
@@ -3222,12 +3179,12 @@ body.tooltips-disabled .inline-tip {
   inset: 0;
   width: var(--ev-pct);
   border-radius: inherit;
-  background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%);
+  background: linear-gradient(135deg, #16a34a 0%, #0f766e 100%);
   transition: width 200ms ease;
 }
 
 .seat-card[data-seat="bb"] .ev-meter__fill {
-  background: linear-gradient(135deg, #14b8a6 0%, #0f766e 100%);
+  background: linear-gradient(135deg, #14b8a6 0%, #0ea5e9 100%);
 }
 
 .seat-card__ev-meta {
@@ -3242,6 +3199,7 @@ body.tooltips-disabled .inline-tip {
 .seat-card__cards {
   display: grid;
   gap: 10px;
+  justify-items: center;
 }
 
 .seat-card__cards-text {
@@ -3251,24 +3209,86 @@ body.tooltips-disabled .inline-tip {
   text-align: center;
 }
 
-.replay-table__insights {
+.stage-table__center {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  padding: 0 12px;
+}
+
+.board-display {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.board-display__surface {
+  position: relative;
+  width: min(640px, 100%);
+  padding: 24px 28px;
+  border-radius: 28px;
+  background: linear-gradient(160deg, #111827 0%, #0f172a 100%);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12), 0 28px 60px rgba(15, 23, 42, 0.24);
+}
+
+.board-display__surface::after {
+  content: '';
+  position: absolute;
+  inset: 18px;
+  border-radius: 22px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  opacity: 0.55;
+  pointer-events: none;
+}
+
+.board-display__cards {
+  position: relative;
+  z-index: 1;
+  gap: 16px;
+}
+
+.board-display__label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: rgba(226, 232, 240, 0.7);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stage-table__caption {
+  width: min(420px, 100%);
+  text-align: center;
+  font-family: var(--font-display);
+  font-size: var(--fs-2);
+  font-weight: 600;
+  color: var(--accent);
+  padding: 16px 20px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.15);
+}
+
+.stage-insights {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
 }
 
 .insight {
   display: grid;
-  gap: 8px;
+  gap: 6px;
   padding: 16px 18px;
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.22);
-  background: rgba(255, 255, 255, 0.86);
-  min-height: 88px;
+  background: rgba(255, 255, 255, 0.88);
+  min-height: 80px;
 }
 
 .insight.is-empty {
-  opacity: 0.7;
+  opacity: 0.65;
 }
 
 .insight__label {
@@ -3298,12 +3318,34 @@ body.tooltips-disabled .inline-tip {
   color: var(--muted);
 }
 
-.replay-table__banner {
+.stage-banner {
   text-align: center;
   font-family: var(--font-display);
   font-size: var(--fs-2);
   color: var(--muted);
   min-height: 1.6em;
+}
+
+.stage-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 26px 28px;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: rgba(248, 250, 255, 0.9);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.1);
+}
+
+.stage-controls__intro {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.stage-controls__intro h2,
+.stage-controls__intro p {
+  margin: 0;
 }
 
 .replay-controls {
@@ -3340,8 +3382,9 @@ body.tooltips-disabled .inline-tip {
   gap: 12px;
   padding: 18px 20px;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(248, 250, 255, 0.86);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .replay-control__label {
@@ -3357,8 +3400,53 @@ body.tooltips-disabled .inline-tip {
 }
 
 .replay-control__range {
+  --progress: 0.0;
+  appearance: none;
   width: 100%;
-  accent-color: #2563eb;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #16a34a 0%, #16a34a calc(var(--progress) * 100%), rgba(148, 163, 184, 0.32) calc(var(--progress) * 100%), rgba(148, 163, 184, 0.32) 100%);
+  outline: none;
+  accent-color: #16a34a;
+}
+
+.replay-control__range::-webkit-slider-runnable-track {
+  appearance: none;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #16a34a 0%, #16a34a calc(var(--progress) * 100%), rgba(148, 163, 184, 0.32) calc(var(--progress) * 100%), rgba(148, 163, 184, 0.32) 100%);
+}
+
+.replay-control__range::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #16a34a;
+  box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.18);
+  border: none;
+  margin-top: -5px;
+}
+
+.replay-control__range::-moz-range-track {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.32);
+}
+
+.replay-control__range::-moz-range-progress {
+  height: 8px;
+  border-radius: 999px;
+  background: #16a34a;
+}
+
+.replay-control__range::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #16a34a;
+  border: none;
+  box-shadow: 0 0 0 4px rgba(22, 163, 74, 0.18);
 }
 
 .replay-control__hint {
@@ -3379,87 +3467,32 @@ body.tooltips-disabled .inline-tip {
   color: var(--muted);
 }
 
-.action-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  max-height: 540px;
-  overflow: auto;
-}
+@media (max-width: 960px) {
+  .card--stage {
+    padding: 28px 24px;
+  }
 
-.action-list__item {
-  position: relative;
-  display: grid;
-  grid-template-columns: auto auto auto 1fr auto;
-  gap: 12px;
-  align-items: center;
-  padding: 14px 18px;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(248, 250, 255, 0.9);
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-  transition: transform var(--transition), border-color var(--transition), box-shadow var(--transition), background var(--transition);
-}
+  .stage-table {
+    gap: 20px;
+  }
 
-.action-list__item:hover,
-.action-list__item:focus-visible {
-  border-color: rgba(37, 99, 235, 0.4);
-  background: rgba(37, 99, 235, 0.12);
-  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.12);
-  transform: translateY(-2px);
-}
+  .stage-seat {
+    flex-basis: 240px;
+    max-width: none;
+  }
 
-.action-list__item.is-active {
-  border-color: rgba(79, 70, 229, 0.5);
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.22) 0%, rgba(37, 99, 235, 0.18) 100%);
-  box-shadow: 0 24px 40px rgba(79, 70, 229, 0.22);
-  color: var(--accent);
-}
-
-.action-list__item.is-hand-start::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px dashed rgba(148, 163, 184, 0.32);
-  pointer-events: none;
-}
-
-.action-list__step,
-.action-list__hand,
-.action-list__pot {
-  font-family: var(--font-mono);
-  font-size: var(--fs-1);
-  color: var(--muted);
-}
-
-.action-list__street {
-  font-weight: 600;
-  color: var(--accent);
-}
-
-.action-list__text {
-  font-size: var(--fs-1);
-  color: var(--muted);
-}
-
-.action-list__item.is-active .action-list__text {
-  color: var(--accent);
-}
-
-.action-list__empty {
-  padding: 36px 24px;
-  border-radius: var(--radius-md);
-  border: 1px dashed var(--border);
-  text-align: center;
-  color: var(--muted);
-  font-size: var(--fs-1);
+  .board-display__surface {
+    padding: 22px;
+  }
 }
 
 @media (max-width: 720px) {
-  .replay-page .page-content {
-    padding-top: 56px;
+  .stage-table__center {
+    order: -1;
+    width: 100%;
+  }
+
+  .stage-table__caption {
+    width: 100%;
   }
 }

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -134,37 +134,27 @@
         </div>
       </section>
 
-      <div class="replay-grid">
-        <section class="card card--table" id="tableCard">
-          <header class="replay-table__header">
-            <div class="replay-table__handwrap">
+      <div class="replay-layout">
+        <section class="card card--stage" id="tableCard">
+          <header class="stage-header">
+            <div class="stage-header__hand">
               <span class="muted">Hand</span>
-              <div id="hand" class="replay-table__hand">—</div>
+              <div id="hand" class="stage-header__hand-id">—</div>
             </div>
-            <div class="replay-table__status">
-              <div class="replay-table__pot">
+            <div class="stage-header__meta">
+              <div class="stage-header__pot">
                 <span class="muted">Pot</span>
-                <span class="replay-table__pot-value mono" id="pot">0</span>
+                <span class="stage-header__pot-value mono" id="pot">0</span>
               </div>
-              <div class="replay-table__pills">
+              <div class="stage-header__status">
                 <span id="status" class="pill ghost" aria-live="polite">Paused</span>
                 <span id="turn" class="pill ghost" aria-live="polite">Turn: —</span>
               </div>
             </div>
           </header>
 
-          <div class="replay-table__action">
-            <div id="caption" class="replay-table__action-main">Waiting for first hand…</div>
-            <div id="log" class="replay-table__action-sub muted">—</div>
-          </div>
-
-          <div class="replay-table__board">
-            <div class="cards felt__board" id="board" aria-label="Community cards"></div>
-            <div class="replay-table__board-text" id="boardText">Board: —</div>
-          </div>
-
-          <div class="replay-table__seats">
-            <article class="seat-card" id="sbZone" data-seat="sb">
+          <div class="stage-table">
+            <article class="seat-card stage-seat stage-seat--sb" id="sbZone" data-seat="sb">
               <header class="seat-card__header">
                 <div class="seat-card__identity">
                   <span class="seat-card__role">Small blind</span>
@@ -199,7 +189,17 @@
               </div>
             </article>
 
-            <article class="seat-card" id="bbZone" data-seat="bb">
+            <div class="stage-table__center">
+              <div class="board-display">
+                <div class="board-display__surface">
+                  <div class="cards board-display__cards" id="board" aria-label="Community cards"></div>
+                </div>
+                <div class="board-display__label" id="boardText">Board: —</div>
+              </div>
+              <div id="caption" class="stage-table__caption" aria-live="polite">Waiting for first hand…</div>
+            </div>
+
+            <article class="seat-card stage-seat stage-seat--bb" id="bbZone" data-seat="bb">
               <header class="seat-card__header">
                 <div class="seat-card__identity">
                   <span class="seat-card__role">Big blind</span>
@@ -235,7 +235,7 @@
             </article>
           </div>
 
-          <div class="replay-table__insights" id="insightGrid">
+          <div class="stage-insights" id="insightGrid">
             <div class="insight" id="insightPotOdds">
               <span class="insight__label">Pot odds</span>
               <span class="insight__value" id="potOdds">—</span>
@@ -262,63 +262,53 @@
             </div>
           </div>
 
-          <div class="replay-table__banner" id="handBanner" aria-live="polite"></div>
-        </section>
+          <div class="stage-banner" id="handBanner" aria-live="polite"></div>
 
-        <section class="card card--controls" id="controlCard">
-          <header class="card__header">
-            <h2>Controls</h2>
-            <p class="muted">Scrub through the match or let it auto-play every action.</p>
-          </header>
-          <div class="replay-controls">
-            <div class="replay-controls__buttons" role="group" aria-label="Playback">
-              <button class="pill accent" id="play" type="button">Play</button>
-              <button class="pill ghost" id="pause" type="button">Pause</button>
-              <button class="pill ghost" id="next" type="button">Next</button>
+          <div class="stage-controls" id="controlCard">
+            <div class="stage-controls__intro">
+              <h2>Controls</h2>
+              <p class="muted">Scrub through the match or let it auto-play every action.</p>
             </div>
-            <div class="replay-controls__row">
-              <div class="replay-control">
+            <div class="replay-controls">
+              <div class="replay-controls__buttons" role="group" aria-label="Playback">
+                <button class="pill accent" id="play" type="button">Play</button>
+                <button class="pill ghost" id="pause" type="button">Pause</button>
+                <button class="pill ghost" id="next" type="button">Next</button>
+              </div>
+              <div class="replay-controls__row">
+                <div class="replay-control">
+                  <div class="replay-control__label">
+                    <label for="speedSlider">Speed</label>
+                    <button class="inline-tip" type="button" data-tip="Slide right to shorten the delay between actions. Playback automatically pauses once the match completes." aria-label="Tip: adjust playback speed">i</button>
+                  </div>
+                  <input id="speedSlider" class="replay-control__range" type="range" min="1" max="5" value="1"/>
+                  <div class="replay-control__hint mono" id="speedValue">1×</div>
+                </div>
+                <div class="replay-control">
+                  <div class="replay-control__label">
+                    <label for="holesSelect">Hole cards</label>
+                    <button class="inline-tip" type="button" data-tip="Reveal one or both players' hole cards. Hidden keeps them face down until showdown." aria-label="Tip: toggle hole card visibility">i</button>
+                  </div>
+                  <div class="select-pill__wrap">
+                    <select id="holesSelect" class="select-pill select-pill--condensed">
+                      <option value="both">Both</option>
+                      <option value="sb">SB Only</option>
+                      <option value="bb">BB Only</option>
+                      <option value="none">Hidden</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+              <div class="replay-control replay-control--timeline">
                 <div class="replay-control__label">
-                  <label for="speedSlider">Speed</label>
-                  <button class="inline-tip" type="button" data-tip="Slide right to shorten the delay between actions. Playback automatically pauses once the match completes." aria-label="Tip: adjust playback speed">i</button>
+                  <label for="timeline">Timeline</label>
                 </div>
-                <input id="speedSlider" class="replay-control__range" type="range" min="1" max="5" value="1"/>
-                <div class="replay-control__hint mono" id="speedValue">1×</div>
-              </div>
-              <div class="replay-control">
-                <div class="replay-control__label">
-                  <label for="holesSelect">Hole cards</label>
-                  <button class="inline-tip" type="button" data-tip="Reveal one or both players' hole cards. Hidden keeps them face down until showdown." aria-label="Tip: toggle hole card visibility">i</button>
-                </div>
-                <div class="select-pill__wrap">
-                  <select id="holesSelect" class="select-pill select-pill--condensed">
-                    <option value="both">Both</option>
-                    <option value="sb">SB Only</option>
-                    <option value="bb">BB Only</option>
-                    <option value="none">Hidden</option>
-                  </select>
+                <input id="timeline" class="replay-control__range" type="range" min="0" value="0"/>
+                <div class="replay-control__timeline-meta">
+                  <span class="mono" id="count">0/0</span>
                 </div>
               </div>
             </div>
-            <div class="replay-control replay-control--timeline">
-              <div class="replay-control__label">
-                <label for="timeline">Timeline</label>
-              </div>
-              <input id="timeline" class="replay-control__range" type="range" min="0" value="0"/>
-              <div class="replay-control__timeline-meta">
-                <span class="mono" id="count">0/0</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section class="card card--log" id="logCard">
-          <header class="card__header">
-            <h2>Action history</h2>
-            <p class="muted">Tap a step to jump directly to that moment.</p>
-          </header>
-          <div class="action-list" id="actionList" role="list">
-            <div class="action-list__empty">Select a match to view its action log.</div>
           </div>
         </section>
       </div>

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -212,6 +212,19 @@ const ReplayPage = (() => {
     });
   }
 
+  function setRangeProgress(el) {
+    if (!el) return;
+    const min = Number(el.min ?? 0);
+    const max = Number(el.max ?? 100);
+    const value = Number(el.value ?? min);
+    let pct = 0;
+    if (Number.isFinite(min) && Number.isFinite(max) && max > min) {
+      pct = (value - min) / (max - min);
+    }
+    pct = Math.max(0, Math.min(1, pct));
+    el.style.setProperty('--progress', `${pct}`);
+  }
+
   function formatNumber(value, precision) {
     const num = Number(value);
     if (!Number.isFinite(num)) return '0';
@@ -631,6 +644,7 @@ const ReplayPage = (() => {
     els.timeline.max = String(max);
     els.timeline.value = String(Math.min(state.index, max));
     els.timeline.disabled = state.rows.length <= 1;
+    setRangeProgress(els.timeline);
     if (els.count) {
       const current = state.rows.length ? state.index + 1 : 0;
       els.count.textContent = `${current}/${state.rows.length}`;
@@ -1036,6 +1050,7 @@ const ReplayPage = (() => {
         if (els.speedValue) {
           els.speedValue.textContent = `${v}×`;
         }
+        setRangeProgress(els.speedSlider);
         if (state.playing) {
           scheduleNext();
         }
@@ -1043,6 +1058,7 @@ const ReplayPage = (() => {
       updateSpeed(els.speedSlider.value);
       els.speedSlider.addEventListener('input', (ev) => {
         updateSpeed(ev.target.value);
+        setRangeProgress(ev.target);
       });
     }
     if (els.holesSelect) {
@@ -1058,6 +1074,7 @@ const ReplayPage = (() => {
         pause();
         state.index = value;
         draw();
+        setRangeProgress(ev.target);
       });
     }
     if (els.matchSelect) {


### PR DESCRIPTION
## Summary
- rework replay.html into a single stage layout that centers the board between player seats, removes the action log, and pulls controls into the primary card
- refresh replay styling with cleaner seat cards, an updated dealer chip, refined felt board presentation, and simplified poker card artwork with suit colors
- theme the timeline slider green and drive its progress indicator through CSS variables updated from JavaScript for a minimal playback control set

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cf9fa776b4832dbe8a97795e0cf347