### PR TITLE
Revamp replay layout and playback styling

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -564,6 +564,36 @@ p {
   color: #92400e;
 }
 
+.replay-page .pill.accent {
+  background: linear-gradient(135deg, #111111 0%, #1f1f1f 100%);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 14px 26px rgba(17, 17, 17, 0.24);
+}
+
+.replay-page .pill.accent:hover {
+  background: linear-gradient(135deg, #1f1f1f 0%, #111111 100%);
+  color: #ffffff;
+}
+
+.replay-page .pill.ghost {
+  border-color: rgba(17, 24, 39, 0.12);
+  color: var(--accent);
+  background: rgba(17, 24, 39, 0.04);
+}
+
+.replay-page .pill.warn {
+  border-color: rgba(34, 197, 94, 0.32);
+  background: rgba(34, 197, 94, 0.18);
+  color: #14532d;
+}
+
+.replay-page .pill.ok {
+  border-color: rgba(234, 179, 8, 0.3);
+  background: rgba(234, 179, 8, 0.22);
+  color: #854d0e;
+}
+
 .select-pill {
   appearance: none;
   -webkit-appearance: none;
@@ -1938,38 +1968,40 @@ ion);
   justify-content: flex-end;
 }
 
+
 .cardx {
-  --corner-pad: 10px;
-  --rank-size: 28px;
-  --glyph-size: 3.6em;
+  --corner-pad: 12px;
+  --rank-size: 26px;
+  --glyph-size: 3.2em;
   --tilt: 0deg;
-  --card-front-bg: linear-gradient(165deg, #ffffff 0%, #f1f5f9 100%);
-  --card-front-border: rgba(15, 23, 42, 0.12);
+  --card-front-bg: linear-gradient(180deg, #ffffff 0%, #eef1f7 100%);
+  --card-front-border: rgba(15, 23, 42, 0.14);
   --card-front-color: #111827;
-  --card-back-bg: linear-gradient(140deg, #0f172a 0%, #111827 100%);
-  --card-back-pattern: rgba(148, 163, 184, 0.18);
+  --card-back-bg: linear-gradient(160deg, #111827 0%, #1f2937 100%);
+  --card-back-pattern: rgba(148, 163, 184, 0.22);
   --card-glyph: '';
   width: var(--card-w);
   height: var(--card-h);
-  border-radius: 18px;
+  border-radius: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
   position: relative;
   display: grid;
   place-items: center;
   font-family: var(--font-display);
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.015em;
   color: var(--card-front-color);
   transform-style: preserve-3d;
   transform: rotateY(var(--tilt));
   transition: transform 320ms ease;
-  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 24px 52px rgba(15, 23, 42, 0.2);
   background: transparent;
 }
 
 .cardx .face {
   position: absolute;
   inset: 0;
-  border-radius: 18px;
+  border-radius: 20px;
   backface-visibility: hidden;
   display: grid;
   place-items: center;
@@ -1981,27 +2013,28 @@ ion);
   color: inherit;
   transform: rotateY(180deg);
   border: 1px solid var(--card-front-border);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 -2px 8px rgba(15, 23, 42, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85), inset 0 -2px 10px rgba(15, 23, 42, 0.1);
 }
 
 .cardx .back {
   background: var(--card-back-bg);
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
 }
 
 .cardx .back::after {
   content: '';
   position: absolute;
-  inset: -10px;
-  background: repeating-linear-gradient(45deg, transparent 0, transparent 12px, var(--card-back-pattern) 12px, var(--card-back-pattern) 20px);
-  opacity: 0.4;
+  inset: -8px;
+  background: repeating-linear-gradient(45deg, transparent 0, transparent 14px, var(--card-back-pattern) 14px, var(--card-back-pattern) 22px);
+  opacity: 0.42;
   mix-blend-mode: screen;
 }
 
 .cardx.flip {
   --tilt: 180deg;
 }
+
 
 .cardx .num-box {
   position: absolute;
@@ -2030,10 +2063,11 @@ ion);
   content: var(--card-glyph, '');
 }
 
+
 .cardx .suit {
   font-size: var(--glyph-size);
   color: currentColor;
-  text-shadow: 0 12px 28px rgba(15, 23, 42, 0.25);
+  text-shadow: 0 14px 32px rgba(15, 23, 42, 0.26);
 }
 
 .cardx .suit::after {
@@ -2053,38 +2087,39 @@ ion);
   color: #15803d;
 }
 
+
 .cardx.spade {
-  --card-front-bg: linear-gradient(165deg, #ffffff 0%, #e2e8f0 100%);
-  --card-front-border: rgba(15, 23, 42, 0.16);
+  --card-front-bg: linear-gradient(180deg, #ffffff 0%, #e2e8f0 100%);
+  --card-front-border: rgba(15, 23, 42, 0.18);
   --card-front-color: #111827;
-  --card-back-bg: linear-gradient(140deg, #111827 0%, #0f172a 100%);
-  --card-back-pattern: rgba(148, 163, 184, 0.24);
+  --card-back-bg: linear-gradient(160deg, #111827 0%, #0f172a 100%);
+  --card-back-pattern: rgba(148, 163, 184, 0.28);
   --card-glyph: '\2660';
 }
 
 .cardx.heart {
-  --card-front-bg: linear-gradient(165deg, #fff7f7 0%, #fee2e2 100%);
-  --card-front-border: rgba(248, 113, 113, 0.35);
+  --card-front-bg: linear-gradient(180deg, #fff5f5 0%, #fee2e2 100%);
+  --card-front-border: rgba(248, 113, 113, 0.3);
   --card-front-color: #b91c1c;
-  --card-back-bg: linear-gradient(140deg, #991b1b 0%, #be123c 100%);
-  --card-back-pattern: rgba(254, 226, 226, 0.32);
+  --card-back-bg: linear-gradient(160deg, #991b1b 0%, #be123c 100%);
+  --card-back-pattern: rgba(254, 226, 226, 0.36);
   --card-glyph: '\2665';
 }
 
 .cardx.diamond {
-  --card-front-bg: linear-gradient(165deg, #fff7fb 0%, #ffe4e6 100%);
-  --card-front-border: rgba(251, 113, 133, 0.32);
+  --card-front-bg: linear-gradient(180deg, #fff7fb 0%, #ffe4e6 100%);
+  --card-front-border: rgba(251, 113, 133, 0.3);
   --card-front-color: #b91c1c;
-  --card-back-bg: linear-gradient(140deg, #9d174d 0%, #be185d 100%);
-  --card-back-pattern: rgba(255, 228, 230, 0.3);
+  --card-back-bg: linear-gradient(160deg, #9d174d 0%, #be185d 100%);
+  --card-back-pattern: rgba(255, 228, 230, 0.34);
   --card-glyph: '\2666';
 }
 
 .cardx.club {
-  --card-front-bg: linear-gradient(165deg, #f4fff8 0%, #dcfce7 100%);
+  --card-front-bg: linear-gradient(180deg, #f4fff8 0%, #dcfce7 100%);
   --card-front-border: rgba(22, 163, 74, 0.28);
   --card-front-color: #047857;
-  --card-back-bg: linear-gradient(140deg, #065f46 0%, #047857 100%);
+  --card-back-bg: linear-gradient(160deg, #065f46 0%, #047857 100%);
   --card-back-pattern: rgba(187, 247, 208, 0.32);
   --card-glyph: '\\2663';
 }
@@ -2954,19 +2989,15 @@ body.tooltips-disabled .inline-tip {
   flex-direction: column;
   gap: 32px;
   padding: 32px;
-  background: linear-gradient(150deg, rgba(255, 255, 255, 0.95) 0%, rgba(244, 247, 255, 0.88) 100%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
   overflow: hidden;
 }
 
 .card--stage::before {
-  content: '';
-  position: absolute;
-  inset: -20% 0 auto;
-  height: 360px;
-  background: radial-gradient(60% 80% at 20% 0%, rgba(22, 163, 74, 0.16), transparent),
-              radial-gradient(60% 80% at 80% 10%, rgba(15, 118, 110, 0.14), transparent 60%);
-  pointer-events: none;
-  mix-blend-mode: soft-light;
+  display: none;
 }
 
 .card--stage > * {
@@ -2974,89 +3005,169 @@ body.tooltips-disabled .inline-tip {
   z-index: 1;
 }
 
-.stage-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
+.stage-toolbar {
+  display: grid;
   gap: 24px;
 }
 
-.stage-header__hand {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+@media (min-width: 1080px) {
+  .stage-toolbar {
+    grid-template-columns: minmax(0, 7fr) minmax(260px, 3fr);
+    align-items: stretch;
+  }
 }
 
-.stage-header__hand-id {
-  font-family: var(--font-display);
-  font-size: var(--fs-4);
-  font-weight: 600;
-  color: var(--accent);
+.stage-controls {
+  display: grid;
+  gap: 18px;
+  padding: 22px 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 16px 34px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(6px);
 }
 
-.stage-header__meta {
+@media (min-width: 720px) {
+  .stage-controls {
+    padding: 24px 28px;
+  }
+}
+
+.stage-controls__primary {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 20px;
-  margin-left: auto;
+  justify-content: space-between;
+  gap: 16px;
 }
 
-.stage-header__pot {
+.stage-controls__status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.stage-controls__label {
+  font-size: var(--fs-0);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.stage-controls__secondary {
   display: grid;
-  justify-items: end;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .stage-controls__secondary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.stage-control {
+  padding: 18px 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+.stage-control--timeline {
+  grid-column: 1 / -1;
+  padding: 20px 22px;
+}
+
+.stage-controls__status .pill {
+  padding: 0.35rem 0.9rem;
+  font-size: var(--fs-0);
+}
+
+.stage-summary {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  padding: 22px 24px;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(248, 250, 252, 0.72);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.stage-summary__item {
+  display: grid;
   gap: 6px;
 }
 
-.stage-header__pot-value {
+.stage-summary__label {
+  font-size: var(--fs-0);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.stage-summary__value {
+  font-family: var(--font-display);
   font-size: var(--fs-3);
-  font-family: var(--font-mono);
   font-weight: 600;
   color: var(--accent);
 }
 
-.stage-header__status {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
+.stage-summary__item--log {
+  grid-column: 1 / -1;
 }
 
+.stage-summary__value--log {
+  font-family: var(--font-sans);
+  font-size: var(--fs-1);
+  font-weight: 500;
+  color: var(--muted);
+  line-height: 1.5;
+  min-height: 1.5em;
+}
+
+
 .stage-table {
-  display: flex;
-  align-items: stretch;
-  justify-content: center;
+  display: grid;
   gap: 28px;
-  flex-wrap: wrap;
+}
+
+@media (min-width: 1080px) {
+  .stage-table {
+    grid-template-columns: minmax(260px, 1fr) minmax(340px, 1.35fr) minmax(260px, 1fr);
+    align-items: stretch;
+  }
 }
 
 .stage-seat {
-  flex: 1 1 280px;
-  max-width: 340px;
+  min-height: 100%;
 }
 
 .seat-card {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 22px 24px;
+  display: grid;
+  grid-template-rows: auto auto auto 1fr;
+  gap: 18px;
+  padding: 24px;
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(148, 163, 184, 0.24);
-  background: rgba(255, 255, 255, 0.94);
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
-  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.12);
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
 }
 
 .seat-card--active {
-  transform: translateY(-4px);
-  border-color: rgba(22, 163, 74, 0.45);
-  box-shadow: 0 24px 48px rgba(22, 163, 74, 0.18);
+  transform: translateY(-6px);
+  border-color: rgba(34, 197, 94, 0.4);
+  box-shadow: 0 26px 52px rgba(34, 197, 94, 0.2);
 }
 
 .seat-card--winner {
-  border-color: rgba(250, 204, 21, 0.65);
-  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.35), 0 28px 50px rgba(250, 204, 21, 0.24);
+  border-color: rgba(250, 204, 21, 0.6);
+  box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.3), 0 28px 56px rgba(250, 204, 21, 0.2);
 }
 
 .seat-card__header {
@@ -3064,6 +3175,7 @@ body.tooltips-disabled .inline-tip {
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
+  order: 0;
 }
 
 .seat-card__identity {
@@ -3100,11 +3212,53 @@ body.tooltips-disabled .inline-tip {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18), 0 12px 24px rgba(15, 23, 42, 0.22);
 }
 
+
+.seat-card__cards {
+  order: 1;
+  display: grid;
+  gap: 12px;
+  justify-items: stretch;
+}
+
+.seat-card__cards .cards {
+  justify-content: center;
+}
+
+.seat-card[data-seat="sb"] .seat-card__cards .cards {
+  justify-content: flex-start;
+}
+
+.seat-card[data-seat="bb"] .seat-card__cards .cards {
+  justify-content: flex-end;
+}
+
+.seat-card__cards #sb_hole,
+.seat-card__cards #bb_hole {
+  margin-top: 0;
+}
+
+.seat-card__cards-text {
+  font-family: var(--font-mono);
+  font-size: var(--fs-1);
+  color: var(--muted);
+  text-align: center;
+}
+
+.seat-card[data-seat="sb"] .seat-card__cards-text {
+  text-align: left;
+}
+
+.seat-card[data-seat="bb"] .seat-card__cards-text {
+  text-align: right;
+}
+
 .seat-card__stacks {
+  order: 2;
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
+  gap: 14px;
   align-items: baseline;
+  justify-content: space-between;
   font-family: var(--font-mono);
   font-size: var(--fs-1);
   color: var(--muted);
@@ -3131,9 +3285,15 @@ body.tooltips-disabled .inline-tip {
 }
 
 .seat-card__ev {
+  order: 3;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
+  padding: 16px 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(248, 250, 252, 0.82);
+  margin-top: auto;
 }
 
 .seat-card__ev-head {
@@ -3184,7 +3344,7 @@ body.tooltips-disabled .inline-tip {
 }
 
 .seat-card[data-seat="bb"] .ev-meter__fill {
-  background: linear-gradient(135deg, #14b8a6 0%, #0ea5e9 100%);
+  background: linear-gradient(135deg, #f97316 0%, #fb923c 100%);
 }
 
 .seat-card__ev-meta {
@@ -3196,79 +3356,60 @@ body.tooltips-disabled .inline-tip {
   color: var(--muted);
 }
 
-.seat-card__cards {
-  display: grid;
-  gap: 10px;
-  justify-items: center;
-}
-
-.seat-card__cards-text {
-  font-family: var(--font-mono);
-  font-size: var(--fs-1);
-  color: var(--muted);
-  text-align: center;
-}
-
 .stage-table__center {
-  flex: 1 1 320px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 20px;
+  display: grid;
+  gap: 24px;
+  align-content: center;
+  justify-items: center;
   padding: 0 12px;
+  min-height: calc(var(--card-h) + 160px);
 }
 
 .board-display {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 14px;
+  display: grid;
+  gap: 18px;
+  justify-items: center;
 }
 
 .board-display__surface {
   position: relative;
   width: min(640px, 100%);
-  padding: 24px 28px;
-  border-radius: 28px;
-  background: linear-gradient(160deg, #111827 0%, #0f172a 100%);
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.12), 0 28px 60px rgba(15, 23, 42, 0.24);
-}
-
-.board-display__surface::after {
-  content: '';
-  position: absolute;
-  inset: 18px;
-  border-radius: 22px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  opacity: 0.55;
-  pointer-events: none;
+  padding: 28px 32px;
+  border-radius: 26px;
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(243, 246, 252, 0.92) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 26px 52px rgba(15, 23, 42, 0.18);
+  min-height: calc(var(--card-h) + 72px);
 }
 
 .board-display__cards {
   position: relative;
   z-index: 1;
-  gap: 16px;
+  gap: 18px;
+  width: 100%;
+  justify-content: center;
 }
 
 .board-display__label {
   font-family: var(--font-mono);
   font-size: var(--fs-1);
-  color: rgba(226, 232, 240, 0.7);
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
+  color: var(--muted);
 }
 
 .stage-table__caption {
-  width: min(420px, 100%);
+  width: min(460px, 100%);
   text-align: center;
   font-family: var(--font-display);
   font-size: var(--fs-2);
   font-weight: 600;
   color: var(--accent);
-  padding: 16px 20px;
+  padding: 18px 22px;
   border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.15);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(248, 250, 252, 0.9);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .stage-insights {
@@ -3467,29 +3608,40 @@ body.tooltips-disabled .inline-tip {
   color: var(--muted);
 }
 
-@media (max-width: 960px) {
+@media (max-width: 1080px) {
   .card--stage {
     padding: 28px 24px;
   }
 
-  .stage-table {
-    gap: 20px;
+  .stage-toolbar {
+    grid-template-columns: minmax(0, 1fr);
   }
+}
 
-  .stage-seat {
-    flex-basis: 240px;
-    max-width: none;
+@media (max-width: 960px) {
+  .stage-table {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 24px;
   }
 
   .board-display__surface {
-    padding: 22px;
+    padding: 24px;
   }
 }
 
 @media (max-width: 720px) {
+  .stage-controls {
+    padding: 20px;
+  }
+
+  .stage-summary {
+    padding: 20px;
+  }
+
   .stage-table__center {
     order: -1;
     width: 100%;
+    min-height: calc(var(--card-h) + 140px);
   }
 
   .stage-table__caption {

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -136,22 +136,69 @@
 
       <div class="replay-layout">
         <section class="card card--stage" id="tableCard">
-          <header class="stage-header">
-            <div class="stage-header__hand">
-              <span class="muted">Hand</span>
-              <div id="hand" class="stage-header__hand-id">—</div>
-            </div>
-            <div class="stage-header__meta">
-              <div class="stage-header__pot">
-                <span class="muted">Pot</span>
-                <span class="stage-header__pot-value mono" id="pot">0</span>
+          <div class="stage-toolbar">
+            <div class="stage-controls" id="controlCard" aria-label="Playback controls">
+              <div class="stage-controls__primary">
+                <div class="replay-controls__buttons" role="group" aria-label="Playback">
+                  <button class="pill accent" id="play" type="button">Play</button>
+                  <button class="pill ghost" id="pause" type="button">Pause</button>
+                  <button class="pill ghost" id="next" type="button">Next</button>
+                </div>
+                <div class="stage-controls__status" aria-live="polite">
+                  <span class="stage-controls__label muted">Playback</span>
+                  <span id="status" class="pill ghost" aria-live="polite">Paused</span>
+                  <span id="turn" class="pill ghost" aria-live="polite">Turn: —</span>
+                </div>
               </div>
-              <div class="stage-header__status">
-                <span id="status" class="pill ghost" aria-live="polite">Paused</span>
-                <span id="turn" class="pill ghost" aria-live="polite">Turn: —</span>
+              <div class="stage-controls__secondary">
+                <div class="replay-control stage-control">
+                  <div class="replay-control__label">
+                    <label for="speedSlider">Speed</label>
+                    <button class="inline-tip" type="button" data-tip="Slide right to shorten the delay between actions. Playback automatically pauses once the match completes." aria-label="Tip: adjust playback speed">i</button>
+                  </div>
+                  <input id="speedSlider" class="replay-control__range" type="range" min="1" max="5" value="1"/>
+                  <div class="replay-control__hint mono" id="speedValue">1×</div>
+                </div>
+                <div class="replay-control stage-control">
+                  <div class="replay-control__label">
+                    <label for="holesSelect">Hole cards</label>
+                    <button class="inline-tip" type="button" data-tip="Reveal one or both players' hole cards. Hidden keeps them face down until showdown." aria-label="Tip: toggle hole card visibility">i</button>
+                  </div>
+                  <div class="select-pill__wrap">
+                    <select id="holesSelect" class="select-pill select-pill--condensed">
+                      <option value="both">Both</option>
+                      <option value="sb">SB Only</option>
+                      <option value="bb">BB Only</option>
+                      <option value="none">Hidden</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+              <div class="replay-control replay-control--timeline stage-control stage-control--timeline">
+                <div class="replay-control__label">
+                  <label for="timeline">Timeline</label>
+                </div>
+                <input id="timeline" class="replay-control__range" type="range" min="0" value="0"/>
+                <div class="replay-control__timeline-meta">
+                  <span class="mono" id="count">0/0</span>
+                </div>
               </div>
             </div>
-          </header>
+            <div class="stage-summary">
+              <div class="stage-summary__item">
+                <span class="stage-summary__label muted">Hand</span>
+                <div id="hand" class="stage-summary__value">—</div>
+              </div>
+              <div class="stage-summary__item">
+                <span class="stage-summary__label muted">Pot</span>
+                <div class="stage-summary__value mono" id="pot">0</div>
+              </div>
+              <div class="stage-summary__item stage-summary__item--log">
+                <span class="stage-summary__label muted">Action</span>
+                <div id="log" class="stage-summary__value stage-summary__value--log" aria-live="polite">—</div>
+              </div>
+            </div>
+          </div>
 
           <div class="stage-table">
             <article class="seat-card stage-seat stage-seat--sb" id="sbZone" data-seat="sb">
@@ -162,6 +209,10 @@
                 </div>
                 <span class="seat-card__dealer" id="sbDealer" aria-hidden="true" hidden>D</span>
               </header>
+              <div class="seat-card__cards">
+                <div class="cards cards--hole" id="sb_hole" aria-label="Small blind hole cards"></div>
+                <div class="seat-card__cards-text" id="sbHoleText">Hidden</div>
+              </div>
               <div class="seat-card__stacks">
                 <span class="muted">Stack</span>
                 <span id="sb_stack_tag" class="seat-card__stack mono">0</span>
@@ -183,10 +234,6 @@
                   <span id="sb_ev_delta" class="seat-card__ev-delta mono">±0</span>
                 </div>
               </div>
-              <div class="seat-card__cards">
-                <div class="cards cards--hole" id="sb_hole" aria-label="Small blind hole cards"></div>
-                <div class="seat-card__cards-text" id="sbHoleText">Hidden</div>
-              </div>
             </article>
 
             <div class="stage-table__center">
@@ -207,6 +254,10 @@
                 </div>
                 <span class="seat-card__dealer" id="bbDealer" aria-hidden="true" hidden>D</span>
               </header>
+              <div class="seat-card__cards">
+                <div class="cards cards--hole" id="bb_hole" aria-label="Big blind hole cards"></div>
+                <div class="seat-card__cards-text" id="bbHoleText">Hidden</div>
+              </div>
               <div class="seat-card__stacks">
                 <span class="muted">Stack</span>
                 <span id="bb_stack_tag" class="seat-card__stack mono">0</span>
@@ -227,10 +278,6 @@
                   <span id="bb_ev_value" class="mono">0%</span>
                   <span id="bb_ev_delta" class="seat-card__ev-delta mono">±0</span>
                 </div>
-              </div>
-              <div class="seat-card__cards">
-                <div class="cards cards--hole" id="bb_hole" aria-label="Big blind hole cards"></div>
-                <div class="seat-card__cards-text" id="bbHoleText">Hidden</div>
               </div>
             </article>
           </div>

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -698,6 +698,7 @@ const ReplayPage = (() => {
 
   function scheduleNext() {
     window.clearTimeout(state.timer);
+    state.timer = null;
     if (!state.playing) return;
     const delay = Math.round(state.speed * (isHandStart(state.index) ? INTRO_HOLD_FACTOR : 1));
     state.timer = window.setTimeout(() => {
@@ -724,12 +725,14 @@ const ReplayPage = (() => {
   function finishPlayback() {
     state.playing = false;
     window.clearTimeout(state.timer);
+    state.timer = null;
     updateStatus('complete');
   }
 
   function pause() {
     state.playing = false;
     window.clearTimeout(state.timer);
+    state.timer = null;
     updateStatus('paused');
   }
 
@@ -927,6 +930,9 @@ const ReplayPage = (() => {
   }
 
   function resetStateForMatch() {
+    state.playing = false;
+    window.clearTimeout(state.timer);
+    state.timer = null;
     state.rows = [];
     state.index = 0;
     state.prevBoardKey = '';
@@ -934,6 +940,7 @@ const ReplayPage = (() => {
     state.prevHandId = null;
     state.winnerSeat = null;
     state.dealerSeat = 'SB';
+    state.actionButtons = [];
     updateDealerIndicator();
     updateWinnerGlow();
     renderEmptyActionList('Loading actions…');
@@ -970,6 +977,7 @@ const ReplayPage = (() => {
     state.baseEquity.BB = state.startStacks.BB + startPot;
     buildActionList();
     draw();
+    play();
   }
 
   function cacheElements() {


### PR DESCRIPTION
## Summary
- move the replay controls into a top toolbar with a live action summary so the current state is always visible
- refresh the table, seat and card styling with a neutral palette and fixed dimensions to keep the layout steady
- start match playback automatically while cleaning up timer handling so the status chips stay in sync

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cfa37c7a58832d99aef45ab1510144