### PR TITLE
Revamp match history layout and controls

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -2794,27 +2794,117 @@ body.tooltips-disabled .inline-tip {
 .page-history .history-table {
   background: var(--surface);
   border-radius: var(--radius-md);
+  border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
-  overflow: visible;
-  padding: 6px 6px 18px;
+  padding: 20px 24px 24px;
+  display: grid;
+  gap: 18px;
 }
 
-.page-history table thead th {
+.history-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 16px;
+}
+
+.history-toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.history-toolbar__group--status {
+  margin-left: auto;
+}
+
+.history-toolbar__label {
+  font-size: var(--fs-0);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.history-select {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.45rem 2.2rem 0.45rem 0.9rem;
+  font-size: var(--fs-1);
+  font-weight: 500;
+  color: var(--accent);
+  background: var(--surface-alt) no-repeat right 12px center / 12px;
+  background-image: url('data:image/svg+xml,%3csvg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="%2344516a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"%3e%3cpath d="M3 5l3 3 3-3"/%3e%3c/svg%3e');
+  transition: border-color var(--transition), background-color var(--transition), color var(--transition);
+  min-width: 180px;
+}
+
+.history-select:hover {
+  border-color: var(--border-strong);
+  background-color: var(--surface-soft);
+}
+
+.history-toolbar__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
   background: var(--surface-alt);
-  border-bottom: none;
+  padding: 0.45rem 0.95rem;
+  font-size: var(--fs-1);
+  font-weight: 600;
+  color: var(--accent);
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
 }
 
-.page-history table tbody tr {
-  transition: transform var(--transition), box-shadow var(--transition);
+.history-toolbar__toggle:hover {
+  background: var(--surface-soft);
+  border-color: var(--border-strong);
 }
 
-.page-history table tbody tr:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+.history-toolbar__icon svg {
+  width: 14px;
+  height: 14px;
+  fill: currentColor;
+  transition: transform var(--transition);
+}
+
+.history-toolbar__toggle[data-dir="asc"] .history-toolbar__icon svg {
+  transform: rotate(180deg);
 }
 
 .history-table__cell {
-  padding: 20px 25px;
+  padding: 16px 18px;
+  vertical-align: top;
+  background: var(--surface);
+  border-right: 1px solid var(--border);
+}
+
+@media (max-width: 720px) {
+  .history-toolbar {
+    align-items: stretch;
+  }
+
+  .history-toolbar__group,
+  .history-toolbar__group--status {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-start;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+
+  .history-toolbar__toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .history-select {
+    width: 100%;
+  }
 }
 
 .history-date {
@@ -2834,28 +2924,39 @@ body.tooltips-disabled .inline-tip {
 
 .page-history .history-table table {
   width: 100%;
-  border-collapse: separate;
-  border-spacing: 0 6px;
-  margin-top: 6px;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 .page-history .history-table thead th {
-  border-radius: 12px 12px 0 0;
+  background: var(--surface-alt);
+  border-bottom: 1px solid var(--border);
+  border-right: 1px solid var(--border);
+  padding: 12px 18px;
+}
+
+.page-history .history-table thead th:last-child {
+  border-right: none;
 }
 
 .page-history .history-table tbody tr {
-  background: var(--surface);
-  border-radius: 16px;
+  transition: background var(--transition);
 }
 
-.page-history .history-table tbody tr td:first-child {
-  border-top-left-radius: 16px;
-  border-bottom-left-radius: 16px;
+.page-history .history-table tbody tr:nth-child(even) td {
+  background: var(--surface-alt);
+}
+
+.page-history .history-table tbody tr:hover td {
+  background: var(--surface-soft);
 }
 
 .page-history .history-table tbody tr td:last-child {
-  border-top-right-radius: 16px;
-  border-bottom-right-radius: 16px;
+  border-right: none;
+}
+
+.page-history .history-table tbody tr:last-child td {
+  border-bottom: none;
 }
 
 .history-models {
@@ -2905,20 +3006,30 @@ body.tooltips-disabled .inline-tip {
 }
 
 .history-status--done {
-  background: rgba(59, 130, 246, 0.18);
-  color: #1d4ed8;
+  background: rgba(17, 24, 39, 0.12);
+  color: #1f2937;
 }
 
 .history-table__actions {
   text-align: right;
 }
 
-.page-history .table tbody tr:hover td {
-  background: transparent;
+.page-history .pill.accent {
+  background: linear-gradient(135deg, #111827 0%, #1f2937 100%);
+  color: var(--accent-contrast);
+  border-color: rgba(15, 23, 42, 0.22);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.22);
 }
 
-.page-history .pill.accent {
-  box-shadow: 0 12px 28px rgba(59, 130, 246, 0.22);
+.page-history .pill.accent:hover {
+  background: linear-gradient(135deg, #0f172a 0%, #111827 100%);
+}
+
+.history-table__cell--empty {
+  text-align: center;
+  padding: 36px 18px;
+  color: var(--muted);
+  font-style: italic;
 }
 
 /* ---------- Reduced motion ------------------------------------------ */
@@ -2932,9 +3043,6 @@ body.tooltips-disabled .inline-tip {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
-}
-.page-history .history-table tbody tr td {
-  border-bottom: none;
 }
 
 /* ---------- Replay 2.0 layout ------------------------------------- */

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -8,7 +8,7 @@
   <link rel="icon" href="/web/favicon.svg" type="image/svg+xml"/>
   <script src="/web/app.js" defer></script>
   <script>
-    const state = { rows: [], sortKey: 'created_at', sortDir: 'desc' };
+    const state = { rows: [], sortKey: 'created_at', sortDir: 'desc', statusFilter: 'all' };
     const $ = (selector) => document.querySelector(selector);
     const formatNumber = (value) => Number(value ?? 0).toLocaleString();
     const formatDate = (value) => {
@@ -44,6 +44,15 @@
         return { className: 'history-status history-status--done', label: 'Complete' };
       }
       return { className: 'history-status history-status--live', label: 'In Progress' };
+    }
+
+    function applyFilters(list) {
+      if (!Array.isArray(list)) return [];
+      return list.filter((row) => {
+        if (state.statusFilter === 'live') return !row?.ended_at;
+        if (state.statusFilter === 'done') return Boolean(row?.ended_at);
+        return true;
+      });
     }
 
     function sortRows(list) {
@@ -101,17 +110,41 @@
       });
     }
 
+    function emptyMessage() {
+      if (!state.rows.length) return 'No matches available.';
+      return 'No matches match the current filters.';
+    }
+
+    function syncControls() {
+      const sortKeySelect = document.getElementById('historySortKey');
+      const sortDirButton = document.getElementById('historySortDir');
+      const sortDirLabel = document.getElementById('historySortDirLabel');
+      const statusSelect = document.getElementById('historyStatusFilter');
+      const dirLabel = state.sortDir === 'asc' ? 'Oldest first' : 'Newest first';
+
+      if (sortKeySelect) sortKeySelect.value = state.sortKey;
+      if (statusSelect) statusSelect.value = state.statusFilter;
+      if (sortDirButton) {
+        sortDirButton.setAttribute('data-dir', state.sortDir);
+        sortDirButton.setAttribute('aria-label', `Sort direction: ${dirLabel}. Activate to switch.`);
+      }
+      if (sortDirLabel) sortDirLabel.textContent = dirLabel;
+    }
+
     function render() {
       const tbody = $('#tbody');
       if (!tbody) return;
-      if (!state.rows.length) {
-        tbody.innerHTML = `<tr><td class="history-table__cell" colspan="8">No matches available.</td></tr>`;
+      const filtered = applyFilters(state.rows);
+      if (!filtered.length) {
+        tbody.innerHTML = `<tr><td class="history-table__cell history-table__cell--empty" colspan="8">${emptyMessage()}</td></tr>`;
         updateHeaderState();
+        syncControls();
         return;
       }
-      const sorted = sortRows(state.rows);
+      const sorted = sortRows(filtered);
       tbody.innerHTML = sorted.map(rowMarkup).join('');
       updateHeaderState();
+      syncControls();
     }
 
     function handleSortClick(event) {
@@ -137,6 +170,30 @@
       document.querySelectorAll('th[data-sort]').forEach((th) => {
         th.addEventListener('click', handleSortClick);
       });
+      const sortKeySelect = document.getElementById('historySortKey');
+      const sortDirButton = document.getElementById('historySortDir');
+      const statusSelect = document.getElementById('historyStatusFilter');
+
+      if (sortKeySelect) {
+        sortKeySelect.addEventListener('change', (event) => {
+          state.sortKey = event.target.value;
+          render();
+        });
+      }
+      if (sortDirButton) {
+        sortDirButton.addEventListener('click', () => {
+          state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
+          render();
+        });
+      }
+      if (statusSelect) {
+        statusSelect.addEventListener('change', (event) => {
+          state.statusFilter = event.target.value;
+          render();
+        });
+      }
+
+      syncControls();
       load();
     });
   </script>
@@ -258,21 +315,52 @@
       </div>
 
       <div class="history-table">
-        <table class="table">
-          <thead>
-            <tr>
-              <th class="num sortable" data-sort="id" aria-sort="none" title="Sort by ID">ID</th>
-              <th class="sortable" data-sort="created_at" aria-sort="descending" title="Sort by created date">Created</th>
-              <th class="sortable" data-sort="ended_at" title="Sort by ended date">Ended</th>
-              <th>Models</th>
-              <th class="num sortable" data-sort="blinds" title="Sort by blinds">Blinds</th>
-              <th class="num sortable" data-sort="start_stack" title="Sort by start stack">Start</th>
-              <th class="num sortable" data-sort="duel_seeds" title="Sort by duel seeds">Pairs</th>
-              <th class="num">Replay</th>
-            </tr>
-          </thead>
-          <tbody id="tbody"><tr><td class="history-table__cell" colspan="8">Loading…</td></tr></tbody>
-        </table>
+        <div class="history-toolbar" role="region" aria-label="Match history controls">
+          <div class="history-toolbar__group">
+            <label class="history-toolbar__label" for="historySortKey">Sort by</label>
+            <select class="history-select" id="historySortKey" name="historySortKey">
+              <option value="created_at" selected>Created date</option>
+              <option value="ended_at">Ended date</option>
+              <option value="id">Match ID</option>
+              <option value="blinds">Blinds</option>
+              <option value="start_stack">Starting stack</option>
+              <option value="duel_seeds">Pairs</option>
+            </select>
+          </div>
+          <button class="history-toolbar__toggle" type="button" id="historySortDir" aria-label="Sort direction">
+            <span class="history-toolbar__icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" focusable="false" role="presentation">
+                <path d="M8 3.25 4.25 7h7.5L8 3.25Zm0 9.5L11.75 9h-7.5L8 12.75Z"></path>
+              </svg>
+            </span>
+            <span id="historySortDirLabel">Newest first</span>
+          </button>
+          <div class="history-toolbar__group history-toolbar__group--status">
+            <label class="history-toolbar__label" for="historyStatusFilter">Show</label>
+            <select class="history-select" id="historyStatusFilter" name="historyStatusFilter">
+              <option value="all" selected>All matches</option>
+              <option value="live">In progress</option>
+              <option value="done">Completed</option>
+            </select>
+          </div>
+        </div>
+        <div class="table-wrap">
+          <table class="table">
+            <thead>
+              <tr>
+                <th class="num sortable" data-sort="id" aria-sort="none" title="Sort by ID">ID</th>
+                <th class="sortable" data-sort="created_at" aria-sort="descending" title="Sort by created date">Created</th>
+                <th class="sortable" data-sort="ended_at" title="Sort by ended date">Ended</th>
+                <th>Models</th>
+                <th class="num sortable" data-sort="blinds" title="Sort by blinds">Blinds</th>
+                <th class="num sortable" data-sort="start_stack" title="Sort by start stack">Start</th>
+                <th class="num sortable" data-sort="duel_seeds" title="Sort by duel seeds">Pairs</th>
+                <th class="num">Replay</th>
+              </tr>
+            </thead>
+            <tbody id="tbody"><tr><td class="history-table__cell history-table__cell--empty" colspan="8">Loading…</td></tr></tbody>
+          </table>
+        </div>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- add a toolbar on the match history page that exposes sort direction controls and a status filter while keeping column sorting intact
- restyle the history table with zebra rows, column separators, and a darker replay pill to replace the previous bright blue accent
- soften status colors and empty states so the dense table is easier to scan on both desktop and mobile widths

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d034a350cc832db1903fdeff514c98