### PR TITLE
Improve replay UX consistency

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -1977,8 +1977,9 @@ ion);
   --card-front-bg: linear-gradient(180deg, #ffffff 0%, #eef1f7 100%);
   --card-front-border: rgba(15, 23, 42, 0.14);
   --card-front-color: #111827;
-  --card-back-bg: linear-gradient(160deg, #111827 0%, #1f2937 100%);
-  --card-back-pattern: rgba(148, 163, 184, 0.22);
+  --card-back-bg: linear-gradient(155deg, #1f2937 0%, #0f172a 52%, #1c1f3a 100%);
+  --card-back-pattern: rgba(96, 165, 250, 0.28);
+  --card-back-shine: rgba(148, 163, 184, 0.18);
   --card-glyph: '';
   width: var(--card-w);
   height: var(--card-h);
@@ -2022,12 +2023,25 @@ ion);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
 }
 
+.cardx .back::before {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 0 18px rgba(15, 23, 42, 0.45);
+  opacity: 0.75;
+}
+
 .cardx .back::after {
   content: '';
   position: absolute;
-  inset: -8px;
-  background: repeating-linear-gradient(45deg, transparent 0, transparent 14px, var(--card-back-pattern) 14px, var(--card-back-pattern) 22px);
-  opacity: 0.42;
+  inset: -6px;
+  background:
+    radial-gradient(circle at 24% 26%, var(--card-back-shine) 0%, transparent 55%),
+    radial-gradient(circle at 74% 72%, rgba(59, 130, 246, 0.24) 0%, transparent 58%),
+    repeating-linear-gradient(135deg, transparent 0, transparent 16px, var(--card-back-pattern) 16px, var(--card-back-pattern) 28px);
+  opacity: 0.55;
   mix-blend-mode: screen;
 }
 
@@ -2092,8 +2106,6 @@ ion);
   --card-front-bg: linear-gradient(180deg, #ffffff 0%, #e2e8f0 100%);
   --card-front-border: rgba(15, 23, 42, 0.18);
   --card-front-color: #111827;
-  --card-back-bg: linear-gradient(160deg, #111827 0%, #0f172a 100%);
-  --card-back-pattern: rgba(148, 163, 184, 0.28);
   --card-glyph: '\2660';
 }
 
@@ -2101,8 +2113,6 @@ ion);
   --card-front-bg: linear-gradient(180deg, #fff5f5 0%, #fee2e2 100%);
   --card-front-border: rgba(248, 113, 113, 0.3);
   --card-front-color: #b91c1c;
-  --card-back-bg: linear-gradient(160deg, #991b1b 0%, #be123c 100%);
-  --card-back-pattern: rgba(254, 226, 226, 0.36);
   --card-glyph: '\2665';
 }
 
@@ -2110,8 +2120,6 @@ ion);
   --card-front-bg: linear-gradient(180deg, #fff7fb 0%, #ffe4e6 100%);
   --card-front-border: rgba(251, 113, 133, 0.3);
   --card-front-color: #b91c1c;
-  --card-back-bg: linear-gradient(160deg, #9d174d 0%, #be185d 100%);
-  --card-back-pattern: rgba(255, 228, 230, 0.34);
   --card-glyph: '\2666';
 }
 
@@ -2119,9 +2127,29 @@ ion);
   --card-front-bg: linear-gradient(180deg, #f4fff8 0%, #dcfce7 100%);
   --card-front-border: rgba(22, 163, 74, 0.28);
   --card-front-color: #047857;
-  --card-back-bg: linear-gradient(160deg, #065f46 0%, #047857 100%);
-  --card-back-pattern: rgba(187, 247, 208, 0.32);
   --card-glyph: '\\2663';
+}
+
+.cardx.cardx--placeholder {
+  --card-glyph: '';
+  display: block;
+  place-items: stretch;
+  padding: 0;
+  background: transparent;
+  border: 1px dashed rgba(148, 163, 184, 0.42);
+  box-shadow: none;
+  transform: none;
+  transition: none;
+  pointer-events: none;
+  opacity: 0.7;
+}
+
+.cardx.cardx--placeholder .cardx__placeholder {
+  width: 100%;
+  height: 100%;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.24) 0%, rgba(148, 163, 184, 0.12) 100%);
+  border: 1px dashed rgba(148, 163, 184, 0.38);
 }
 
 body.replay-theme {
@@ -3388,6 +3416,7 @@ body.tooltips-disabled .inline-tip {
   gap: 18px;
   width: 100%;
   justify-content: center;
+  flex-wrap: nowrap;
 }
 
 .board-display__label {
@@ -3467,28 +3496,6 @@ body.tooltips-disabled .inline-tip {
   min-height: 1.6em;
 }
 
-.stage-controls {
-  display: flex;
-  flex-direction: column;
-  gap: 24px;
-  padding: 26px 28px;
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: rgba(248, 250, 255, 0.9);
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.1);
-}
-
-.stage-controls__intro {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.stage-controls__intro h2,
-.stage-controls__intro p {
-  margin: 0;
-}
-
 .replay-controls {
   display: flex;
   flex-direction: column;
@@ -3504,6 +3511,43 @@ body.tooltips-disabled .inline-tip {
 .replay-controls__buttons .pill {
   min-width: 96px;
   justify-content: center;
+}
+
+.replay-control-btn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.replay-control-btn::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0) 65%);
+  opacity: 0;
+  transform: scale(0.6);
+  transition: opacity 320ms ease, transform 320ms ease;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.replay-control-btn.is-pressing {
+  transform: translateY(1px) scale(0.96);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.18);
+}
+
+.replay-control-btn.did-press::after {
+  opacity: 0.55;
+  transform: scale(1.25);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .replay-control-btn,
+  .replay-control-btn::after {
+    transition: none !important;
+  }
 }
 
 .replay-controls__row {

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -140,9 +140,9 @@
             <div class="stage-controls" id="controlCard" aria-label="Playback controls">
               <div class="stage-controls__primary">
                 <div class="replay-controls__buttons" role="group" aria-label="Playback">
-                  <button class="pill accent" id="play" type="button">Play</button>
-                  <button class="pill ghost" id="pause" type="button">Pause</button>
-                  <button class="pill ghost" id="next" type="button">Next</button>
+                  <button class="pill accent replay-control-btn" id="play" type="button">Play</button>
+                  <button class="pill ghost replay-control-btn" id="pause" type="button">Pause</button>
+                  <button class="pill ghost replay-control-btn" id="next" type="button">Next</button>
                 </div>
                 <div class="stage-controls__status" aria-live="polite">
                   <span class="stage-controls__label muted">Playback</span>
@@ -239,7 +239,7 @@
             <div class="stage-table__center">
               <div class="board-display">
                 <div class="board-display__surface">
-                  <div class="cards board-display__cards" id="board" aria-label="Community cards"></div>
+                  <div class="cards board-display__cards" id="board" aria-label="Community cards" data-card-slots="5"></div>
                 </div>
                 <div class="board-display__label" id="boardText">Board: —</div>
               </div>
@@ -310,53 +310,6 @@
           </div>
 
           <div class="stage-banner" id="handBanner" aria-live="polite"></div>
-
-          <div class="stage-controls" id="controlCard">
-            <div class="stage-controls__intro">
-              <h2>Controls</h2>
-              <p class="muted">Scrub through the match or let it auto-play every action.</p>
-            </div>
-            <div class="replay-controls">
-              <div class="replay-controls__buttons" role="group" aria-label="Playback">
-                <button class="pill accent" id="play" type="button">Play</button>
-                <button class="pill ghost" id="pause" type="button">Pause</button>
-                <button class="pill ghost" id="next" type="button">Next</button>
-              </div>
-              <div class="replay-controls__row">
-                <div class="replay-control">
-                  <div class="replay-control__label">
-                    <label for="speedSlider">Speed</label>
-                    <button class="inline-tip" type="button" data-tip="Slide right to shorten the delay between actions. Playback automatically pauses once the match completes." aria-label="Tip: adjust playback speed">i</button>
-                  </div>
-                  <input id="speedSlider" class="replay-control__range" type="range" min="1" max="5" value="1"/>
-                  <div class="replay-control__hint mono" id="speedValue">1×</div>
-                </div>
-                <div class="replay-control">
-                  <div class="replay-control__label">
-                    <label for="holesSelect">Hole cards</label>
-                    <button class="inline-tip" type="button" data-tip="Reveal one or both players' hole cards. Hidden keeps them face down until showdown." aria-label="Tip: toggle hole card visibility">i</button>
-                  </div>
-                  <div class="select-pill__wrap">
-                    <select id="holesSelect" class="select-pill select-pill--condensed">
-                      <option value="both">Both</option>
-                      <option value="sb">SB Only</option>
-                      <option value="bb">BB Only</option>
-                      <option value="none">Hidden</option>
-                    </select>
-                  </div>
-                </div>
-              </div>
-              <div class="replay-control replay-control--timeline">
-                <div class="replay-control__label">
-                  <label for="timeline">Timeline</label>
-                </div>
-                <input id="timeline" class="replay-control__range" type="range" min="0" value="0"/>
-                <div class="replay-control__timeline-meta">
-                  <span class="mono" id="count">0/0</span>
-                </div>
-              </div>
-            </div>
-          </div>
         </section>
       </div>
     </div>

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -151,7 +151,11 @@ const ReplayPage = (() => {
     if (!el) return;
     el.innerHTML = '';
     const list = Array.isArray(arr) ? arr : (arr != null ? [arr] : []);
-    list.forEach((entry, idx) => {
+    const slotCount = parseInt(el.dataset.cardSlots ?? el.getAttribute('data-card-slots') ?? '0', 10);
+    const maxCards = Number.isFinite(slotCount) && slotCount > 0 ? Math.min(list.length, slotCount) : list.length;
+    const cardsToRender = list.slice(0, maxCards);
+
+    cardsToRender.forEach((entry, idx) => {
       const { rank, suitName, suitGlyph, label, aria } = cardParts(entry);
       const card = document.createElement('div');
       card.className = 'cardx deal';
@@ -189,12 +193,28 @@ const ReplayPage = (() => {
       card.appendChild(front);
       el.appendChild(card);
     });
+
+    if (Number.isFinite(slotCount) && slotCount > 0) {
+      for (let idx = cardsToRender.length; idx < slotCount; idx += 1) {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'cardx cardx--placeholder';
+        placeholder.dataset.placeholder = 'true';
+        placeholder.setAttribute('aria-hidden', 'true');
+        const shell = document.createElement('div');
+        shell.className = 'cardx__placeholder';
+        placeholder.appendChild(shell);
+        el.appendChild(placeholder);
+      }
+    }
   }
 
   function applyFlip(el, reveal, delayStep = FLIP_DELAY) {
     if (!el) return;
     const cards = $$('.cardx', el);
     cards.forEach((card, idx) => {
+      if (card.dataset && card.dataset.placeholder === 'true') {
+        return;
+      }
       if (card._flipTimer) {
         window.clearTimeout(card._flipTimer);
         card._flipTimer = null;
@@ -255,6 +275,31 @@ const ReplayPage = (() => {
     const num = Number(value);
     if (!Number.isFinite(num)) return null;
     return `${(num * 100).toFixed(1)}%`;
+  }
+
+  function computePotOddsValue(row) {
+    const direct = Number(row?.pot_odds);
+    if (Number.isFinite(direct) && direct >= 0) {
+      return direct;
+    }
+    const toCall = Number(row?.to_call);
+    const pot = Number(row?.pot);
+    if (!Number.isFinite(toCall) || toCall <= 0) {
+      return null;
+    }
+    const potSize = Number.isFinite(pot) && pot >= 0 ? pot : 0;
+    const denom = potSize + toCall;
+    if (denom <= 0) return null;
+    return toCall / denom;
+  }
+
+  function computeRequiredEquityValue(row) {
+    const direct = Number(row?.required_equity);
+    if (Number.isFinite(direct) && direct >= 0) {
+      return direct;
+    }
+    const odds = computePotOddsValue(row);
+    return Number.isFinite(odds) ? odds : null;
   }
 
   function formatCardLabels(cards) {
@@ -371,18 +416,14 @@ const ReplayPage = (() => {
   function updateDealerIndicator() {
     const seat = state.dealerSeat;
     if (els.sbDealer) {
-      if (seat === 'SB') {
-        els.sbDealer.hidden = false;
-      } else {
-        els.sbDealer.hidden = true;
-      }
+      const isDealer = seat === 'SB';
+      els.sbDealer.hidden = !isDealer;
+      els.sbDealer.setAttribute('aria-hidden', isDealer ? 'false' : 'true');
     }
     if (els.bbDealer) {
-      if (seat === 'BB') {
-        els.bbDealer.hidden = false;
-      } else {
-        els.bbDealer.hidden = true;
-      }
+      const isDealer = seat === 'BB';
+      els.bbDealer.hidden = !isDealer;
+      els.bbDealer.setAttribute('aria-hidden', isDealer ? 'false' : 'true');
     }
     if (els.sbZone) {
       els.sbZone.classList.toggle('seat-card--dealer', seat === 'SB');
@@ -466,8 +507,10 @@ const ReplayPage = (() => {
   }
 
   function updateInsights(row) {
-    const potOdds = formatPercent(row?.pot_odds);
-    const reqEq = formatPercent(row?.required_equity);
+    const potOddsValue = computePotOddsValue(row);
+    const potOdds = formatPercent(potOddsValue);
+    const reqEqValue = computeRequiredEquityValue(row);
+    const reqEq = formatPercent(reqEqValue);
     const toCall = Number(row?.to_call);
     const minRaise = Number(row?.min_raise_to);
     const maxRaise = Number(row?.max_raise_to);
@@ -532,6 +575,34 @@ const ReplayPage = (() => {
       els.solverText.textContent = text || '—';
       els.solverText.parentElement?.classList.toggle('is-empty', !text);
     }
+  }
+
+  function addPressFeedback(btn) {
+    if (!btn) return;
+    const clearPress = () => {
+      btn.classList.remove('is-pressing');
+    };
+    btn.addEventListener('pointerdown', () => {
+      btn.classList.add('is-pressing');
+    });
+    ['pointerup', 'pointerleave', 'pointercancel'].forEach(evt => {
+      btn.addEventListener(evt, clearPress);
+    });
+    btn.addEventListener('blur', clearPress);
+    btn.addEventListener('keydown', (ev) => {
+      if (ev.key === ' ' || ev.key === 'Enter') {
+        btn.classList.add('is-pressing');
+      }
+    });
+    btn.addEventListener('keyup', clearPress);
+    btn.addEventListener('click', () => {
+      btn.classList.remove('did-press');
+      void btn.offsetWidth;
+      btn.classList.add('did-press');
+      window.setTimeout(() => {
+        btn.classList.remove('did-press');
+      }, 280);
+    });
   }
 
   function updateHandDisplay(row) {
@@ -1035,6 +1106,8 @@ const ReplayPage = (() => {
   }
 
   function attachListeners() {
+    [els.playBtn, els.pauseBtn, els.nextBtn].forEach(addPressFeedback);
+
     if (els.playBtn) {
       els.playBtn.addEventListener('click', () => {
         play();


### PR DESCRIPTION
## Summary
- polish the replay playback controls with a single toolbar and add animated press feedback on play, pause, and next
- compute pot odds and required equity when missing from the feed while tightening dealer chip visibility
- keep the board width steady with placeholder cards and neutral card backs that no longer reveal suit information

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d033fe808c832da67dd30728ce4b42