### PR TITLE
Enhance Elo chart sorting and styling

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -901,6 +901,25 @@ p {
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
 }
 
+.page-elo .sort-control {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(6px);
+}
+
+.page-elo .sort-control select {
+  padding: 0.35rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
+}
+
+.page-elo .sort-control select:hover {
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
 .table,
 .lb-table,
 .matrix-table {
@@ -1550,43 +1569,103 @@ ion);
 
 /* ---------- Elo page ------------------------------------------------ */
 
+.page-elo .card.elo-card {
+  position: relative;
+  overflow: hidden;
+  padding: 32px 34px;
+  background: linear-gradient(150deg, rgba(255, 255, 255, 0.98) 0%, rgba(237, 243, 255, 0.95) 100%);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 34px 72px rgba(15, 23, 42, 0.14);
+}
+
+.page-elo .card.elo-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at top right, rgba(99, 102, 241, 0.14), transparent 58%);
+  pointer-events: none;
+}
+
+.page-elo .card.elo-card::after {
+  content: '';
+  position: absolute;
+  top: -70px;
+  right: -46px;
+  width: 220px;
+  height: 220px;
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.18) 0%, rgba(59, 130, 246, 0) 70%);
+  pointer-events: none;
+}
+
+@media (max-width: 720px) {
+  .page-elo .card.elo-card {
+    padding: 26px;
+  }
+}
+
 .elo-card {
   display: grid;
-  gap: 24px;
+  gap: 28px;
 }
 
 .elo-card__header {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  display: grid;
+  gap: 24px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+@media (min-width: 960px) {
+  .elo-card__header {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
 }
 
 .elo-card__heading {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
 }
 
 .elo-card__intro {
+  display: grid;
+  gap: 8px;
   color: var(--muted);
 }
 
 .elo-card__filters {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px 20px;
 }
 
 .elo-card__filters .sort-control {
   margin-left: auto;
 }
 
+@media (max-width: 720px) {
+  .elo-card__filters {
+    justify-content: flex-start;
+  }
+
+  .elo-card__filters .sort-control {
+    margin-left: 0;
+  }
+}
+
 .filter-group {
   display: grid;
   gap: 10px;
   min-width: 240px;
+  padding: 12px 16px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(6px);
 }
 
 .filter-group__label {
@@ -1693,8 +1772,8 @@ n);
   color: var(--muted);
   font-size: var(--fs-1);
   font-weight: 600;
-  transition: background var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transit
-ion);
+  transition: background var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transition);
+  backdrop-filter: blur(6px);
 }
 
 .filter-indicator::before {
@@ -1716,7 +1795,7 @@ ion);
 .elo-card__body {
   position: relative;
   display: grid;
-  gap: 16px;
+  gap: 20px;
 }
 
 .elo-chart {
@@ -1731,9 +1810,10 @@ ion);
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(236, 243, 255, 0.92) 100%);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 28px 60px rgba(15, 23, 42, 0.12);
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.98) 0%, rgba(235, 242, 255, 0.9) 100%);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  box-shadow: 0 32px 64px rgba(15, 23, 42, 0.14);
+  backdrop-filter: blur(10px);
   pointer-events: none;
 }
 
@@ -1752,26 +1832,32 @@ ion);
 
 .chart-legend {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
   margin-top: 18px;
 }
 
 .chart-legend__item {
   display: flex;
-  align-items: center;
-  gap: 14px;
-  padding: 14px 18px;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px 20px;
   border-radius: var(--radius-md);
   border: 1px solid rgba(15, 23, 42, 0.08);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(240, 244, 255, 0.94) 100%);
-  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.1);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
   transition: transform var(--transition), box-shadow var(--transition);
 }
 
 .chart-legend__item:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 38px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.16);
+}
+
+.chart-legend__header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .chart-legend__swatch {
@@ -1819,6 +1905,57 @@ ion);
 
 .chart-legend__company {
   font-size: var(--fs-0);
+  color: var(--muted);
+}
+
+.chart-legend__metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+}
+
+@media (min-width: 960px) {
+  .chart-legend__item {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .chart-legend__metrics {
+    margin-left: auto;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(108px, auto);
+    justify-items: end;
+  }
+}
+
+.chart-legend__metric {
+  display: grid;
+  gap: 2px;
+  text-align: left;
+}
+
+.chart-legend__metric-value {
+  font-weight: 600;
+  font-size: var(--fs-2);
+  color: var(--text);
+}
+
+.chart-legend__metric-label {
+  font-size: var(--fs-0);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.chart-legend__metric.is-positive .chart-legend__metric-value {
+  color: var(--ok);
+}
+
+.chart-legend__metric.is-negative .chart-legend__metric-value {
+  color: var(--bad);
+}
+
+.chart-legend__metric.is-neutral .chart-legend__metric-value {
   color: var(--muted);
 }
 

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -19,6 +19,7 @@
       currentSeries: [],
       companies: [],
       selectedCompany: 'all',
+      sortMode: 'company',
       colorAssignments: new Map(),
       nextColorIndex: 0,
       resizeTimer: null,
@@ -217,6 +218,25 @@
       return s;
     }
 
+    function formatEloValue(value) {
+      if (!Number.isFinite(value)) return '–';
+      return Math.round(value).toString();
+    }
+
+    function formatDeltaValue(value) {
+      if (!Number.isFinite(value)) return '–';
+      const rounded = Math.round(value);
+      if (rounded === 0) return '0';
+      return `${rounded > 0 ? '+' : ''}${rounded}`;
+    }
+
+    function deltaModifier(value) {
+      if (!Number.isFinite(value)) return 'neutral';
+      if (value > 0) return 'positive';
+      if (value < 0) return 'negative';
+      return 'neutral';
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       highlightNav();
       load();
@@ -269,6 +289,63 @@
       return state.colorAssignments.get(key);
     }
 
+    function computeSeriesStats(entry) {
+      const pts = Array.isArray(entry?.pts) ? entry.pts : [];
+      const stats = {
+        matches: pts.length,
+        latestElo: null,
+        firstElo: null,
+        bestElo: null,
+        worstElo: null,
+        deltaFromFirst: null,
+        deltaFromPrevious: null,
+        lastUpdated: null,
+        firstSeen: null,
+        range: null,
+      };
+
+      if (!pts.length) {
+        entry.stats = stats;
+        return stats;
+      }
+
+      let best = -Infinity;
+      let worst = Infinity;
+      pts.forEach(pt => {
+        if (!pt || typeof pt.elo !== 'number') return;
+        if (pt.elo > best) best = pt.elo;
+        if (pt.elo < worst) worst = pt.elo;
+      });
+
+      const first = pts[0];
+      const last = pts[pts.length - 1];
+      const prev = pts.length > 1 ? pts[pts.length - 2] : null;
+
+      stats.bestElo = Number.isFinite(best) ? best : null;
+      stats.worstElo = Number.isFinite(worst) ? worst : null;
+      stats.firstElo = first ? Number(first.elo) : null;
+      stats.latestElo = last ? Number(last.elo) : null;
+      stats.deltaFromFirst = Number.isFinite(stats.latestElo) && Number.isFinite(stats.firstElo)
+        ? stats.latestElo - stats.firstElo
+        : null;
+      stats.deltaFromPrevious = prev && Number.isFinite(stats.latestElo) && Number.isFinite(prev.elo)
+        ? stats.latestElo - Number(prev.elo)
+        : null;
+      stats.lastUpdated = last?.t instanceof Date ? last.t : (last ? new Date(last.t) : null);
+      stats.firstSeen = first?.t instanceof Date ? first.t : (first ? new Date(first.t) : null);
+      stats.range = Number.isFinite(stats.bestElo) && Number.isFinite(stats.worstElo)
+        ? stats.bestElo - stats.worstElo
+        : null;
+
+      entry.stats = stats;
+      entry.meta.latestElo = stats.latestElo;
+      entry.meta.lastUpdated = stats.lastUpdated;
+      entry.meta.matches = stats.matches;
+      entry.meta.deltaFromFirst = stats.deltaFromFirst;
+      entry.meta.deltaFromPrevious = stats.deltaFromPrevious;
+      return stats;
+    }
+
     function groupByBot(rows) {
       const map = new Map();
       rows.forEach(r => {
@@ -300,7 +377,10 @@
         if (Number.isNaN(when.getTime())) return;
         entry.pts.push({ t: when, elo: Number(r.elo || 0) });
       });
-      map.forEach(entry => entry.pts.sort((a, b) => a.t - b.t));
+      map.forEach(entry => {
+        entry.pts.sort((a, b) => a.t - b.t);
+        computeSeriesStats(entry);
+      });
       return Array.from(map.values());
     }
 
@@ -397,6 +477,7 @@
         return xForIndex(idx == null ? 0 : idx);
       };
       const y = (val) => height - pad.bottom - ((val - yMin) * (height - pad.top - pad.bottom)) / (yMax - yMin);
+      const baselineY = y(yMin);
 
       const defs = mk('defs');
       const bgGrad = mk('linearGradient');
@@ -405,8 +486,8 @@
       bgGrad.setAttribute('x2', '0');
       bgGrad.setAttribute('y1', '0');
       bgGrad.setAttribute('y2', '1');
-      const bgStop1 = mk('stop'); bgStop1.setAttribute('offset', '0%'); bgStop1.setAttribute('stop-color', 'rgba(255,255,255,0.98)');
-      const bgStop2 = mk('stop'); bgStop2.setAttribute('offset', '100%'); bgStop2.setAttribute('stop-color', 'rgba(233,239,255,0.94)');
+      const bgStop1 = mk('stop'); bgStop1.setAttribute('offset', '0%'); bgStop1.setAttribute('stop-color', 'rgba(248,250,255,0.98)');
+      const bgStop2 = mk('stop'); bgStop2.setAttribute('offset', '100%'); bgStop2.setAttribute('stop-color', 'rgba(228,238,255,0.94)');
       bgGrad.appendChild(bgStop1); bgGrad.appendChild(bgStop2);
       defs.appendChild(bgGrad);
       svg.appendChild(defs);
@@ -420,7 +501,7 @@
       svg.appendChild(bg);
 
       const grid = mk('g');
-      grid.setAttribute('stroke', 'rgba(15, 23, 42, 0.08)');
+      grid.setAttribute('stroke', 'rgba(15, 23, 42, 0.1)');
       grid.setAttribute('stroke-width', '1');
       grid.setAttribute('fill', 'none');
 
@@ -538,14 +619,27 @@
         });
 
         const pathData = pts.map((pt, idx) => `${idx === 0 ? 'M' : 'L'} ${pt.x} ${pt.y}`).join(' ');
+
+        if (pts.length) {
+          const areaCommands = [`M ${pts[0].x} ${baselineY}`];
+          pts.forEach(pt => areaCommands.push(`L ${pt.x} ${pt.y}`));
+          areaCommands.push(`L ${pts[pts.length - 1].x} ${baselineY}`);
+          areaCommands.push('Z');
+          const area = mk('path');
+          area.setAttribute('d', areaCommands.join(' '));
+          area.setAttribute('fill', colorWithAlpha(stroke, 0.12));
+          area.setAttribute('stroke', 'none');
+          group.appendChild(area);
+        }
+
         const glow = mk('path');
         glow.setAttribute('d', pathData);
         glow.setAttribute('fill', 'none');
-        glow.setAttribute('stroke', stroke);
-        glow.setAttribute('stroke-width', '6');
+        glow.setAttribute('stroke', colorWithAlpha(stroke, 0.35));
+        glow.setAttribute('stroke-width', '7');
         glow.setAttribute('stroke-linecap', 'round');
         glow.setAttribute('stroke-linejoin', 'round');
-        glow.setAttribute('opacity', '.18');
+        glow.setAttribute('opacity', '1');
 
         const line = mk('path');
         line.setAttribute('d', pathData);
@@ -562,9 +656,10 @@
           const circle = mk('circle');
           circle.setAttribute('cx', String(pt.x));
           circle.setAttribute('cy', String(pt.y));
-          circle.setAttribute('r', '3');
-          circle.setAttribute('fill', stroke);
-          circle.setAttribute('opacity', '.85');
+          circle.setAttribute('r', '3.2');
+          circle.setAttribute('fill', '#ffffff');
+          circle.setAttribute('stroke', colorWithAlpha(stroke, 0.82));
+          circle.setAttribute('stroke-width', '1.6');
           group.appendChild(circle);
         });
 
@@ -575,7 +670,7 @@
         marker.style.display = 'none';
         markerGroup.appendChild(marker);
 
-        const plot = { meta: entry.meta, color: stroke, points: pts, marker };
+        const plot = { meta: entry.meta, stats: entry.stats, color: stroke, points: pts, marker };
         pts.forEach(p => {
           p.plot = plot;
           p.hoverKey = String(p.timeMs);
@@ -589,14 +684,36 @@
 
       if (!plots.length) return;
 
+      const createMetric = (labelText, valueText, modifier) => {
+        const metric = document.createElement('div');
+        metric.className = 'chart-legend__metric';
+        if (modifier && modifier !== 'neutral') {
+          metric.classList.add(`is-${modifier}`);
+        } else if (modifier === 'neutral') {
+          metric.classList.add('is-neutral');
+        }
+        const valueEl = document.createElement('span');
+        valueEl.className = 'chart-legend__metric-value';
+        valueEl.textContent = valueText;
+        const labelEl = document.createElement('span');
+        labelEl.className = 'chart-legend__metric-label';
+        labelEl.textContent = labelText;
+        metric.appendChild(valueEl);
+        metric.appendChild(labelEl);
+        return metric;
+      };
+
       plots.forEach(plot => {
         const item = document.createElement('div');
         item.className = 'chart-legend__item';
         item.style.setProperty('--legend-color', plot.color);
 
+        const header = document.createElement('div');
+        header.className = 'chart-legend__header';
+
         const swatch = document.createElement('span');
         swatch.className = 'chart-legend__swatch';
-        item.appendChild(swatch);
+        header.appendChild(swatch);
 
         const label = document.createElement('div');
         label.className = 'chart-legend__label';
@@ -617,7 +734,25 @@
         textWrap.appendChild(companyEl);
 
         label.appendChild(textWrap);
-        item.appendChild(label);
+        header.appendChild(label);
+        item.appendChild(header);
+
+        const metrics = document.createElement('div');
+        metrics.className = 'chart-legend__metrics';
+        const stats = plot.stats || {};
+
+        metrics.appendChild(createMetric('Latest Elo', formatEloValue(stats.latestElo)));
+        const deltaMetric = createMetric('Δ overall', formatDeltaValue(stats.deltaFromFirst), deltaModifier(stats.deltaFromFirst));
+        metrics.appendChild(deltaMetric);
+        const matchesValue = Number.isFinite(stats.matches) ? String(stats.matches) : '–';
+        metrics.appendChild(createMetric('Matches', matchesValue));
+
+        if (stats.lastUpdated instanceof Date) {
+          const updatedLabel = shortDate.format(stats.lastUpdated);
+          metrics.appendChild(createMetric('Last duel', updatedLabel));
+        }
+
+        item.appendChild(metrics);
         legend.appendChild(item);
       });
 
@@ -833,6 +968,7 @@
         ? state.fullSeries
         : state.fullSeries.filter(entry => entry.meta.companyKey === key);
       const sorted = sortSeries(filtered);
+      updateSortControl();
       draw(sorted);
       updateActiveIndicator();
     }
@@ -858,26 +994,84 @@
 
     function sortSeries(list) {
       const items = Array.isArray(list) ? list.slice() : [];
-      return items.sort((a, b) => {
-        const aCompany = compareStrings(a.meta.company, b.meta.company);
-        if (aCompany !== 0) return aCompany;
-        const aModel = compareStrings(a.meta.model, b.meta.model);
-        if (aModel !== 0) return aModel;
+      const fallback = (a, b) => {
+        const byCompany = compareStrings(a.meta.company, b.meta.company);
+        if (byCompany !== 0) return byCompany;
+        const byModel = compareStrings(a.meta.model, b.meta.model);
+        if (byModel !== 0) return byModel;
         return (a.botId || 0) - (b.botId || 0);
-      });
+      };
+
+      const mode = state.sortMode || 'company';
+      const safeNumber = (value, fallbackValue) => Number.isFinite(value) ? value : fallbackValue;
+      const safeTime = (value, fallbackValue) => (value instanceof Date ? value.getTime() : fallbackValue);
+
+      if (mode === 'latest-desc') {
+        return items.sort((a, b) => {
+          const aVal = safeNumber(a.stats?.latestElo, -Infinity);
+          const bVal = safeNumber(b.stats?.latestElo, -Infinity);
+          if (aVal !== bVal) return bVal - aVal;
+          return fallback(a, b);
+        });
+      }
+
+      if (mode === 'latest-asc') {
+        return items.sort((a, b) => {
+          const aVal = safeNumber(a.stats?.latestElo, Infinity);
+          const bVal = safeNumber(b.stats?.latestElo, Infinity);
+          if (aVal !== bVal) return aVal - bVal;
+          return fallback(a, b);
+        });
+      }
+
+      if (mode === 'recent') {
+        return items.sort((a, b) => {
+          const aTime = safeTime(a.stats?.lastUpdated, 0);
+          const bTime = safeTime(b.stats?.lastUpdated, 0);
+          if (aTime !== bTime) return bTime - aTime;
+          return fallback(a, b);
+        });
+      }
+
+      if (mode === 'delta-desc') {
+        return items.sort((a, b) => {
+          const aVal = safeNumber(a.stats?.deltaFromFirst, -Infinity);
+          const bVal = safeNumber(b.stats?.deltaFromFirst, -Infinity);
+          if (aVal !== bVal) return bVal - aVal;
+          return fallback(a, b);
+        });
+      }
+
+      if (mode === 'delta-asc') {
+        return items.sort((a, b) => {
+          const aVal = safeNumber(a.stats?.deltaFromFirst, Infinity);
+          const bVal = safeNumber(b.stats?.deltaFromFirst, Infinity);
+          if (aVal !== bVal) return aVal - bVal;
+          return fallback(a, b);
+        });
+      }
+
+      return items.sort(fallback);
     }
 
     function bindSortControl() {
       const select = document.getElementById('sortMode');
       if (!select || select.dataset.bound === 'true') return;
-      select.value = 'company';
+      select.value = state.sortMode || 'company';
+      select.addEventListener('change', evt => {
+        const nextMode = evt.target.value || 'company';
+        if (state.sortMode === nextMode) return;
+        state.sortMode = nextMode;
+        applyFilters();
+      });
       select.dataset.bound = 'true';
     }
 
     function updateSortControl() {
       const select = document.getElementById('sortMode');
       if (!select) return;
-      if (select.value !== 'company') select.value = 'company';
+      const nextValue = state.sortMode || 'company';
+      if (select.value !== nextValue) select.value = nextValue;
     }
 
     function handleResize() {
@@ -1072,6 +1266,11 @@
             <span class="sort-control__label">Sort by</span>
             <select id="sortMode" name="sortMode" aria-label="Sort Elo series">
               <option value="company">Company (A → Z)</option>
+              <option value="latest-desc">Latest Elo (high → low)</option>
+              <option value="latest-asc">Latest Elo (low → high)</option>
+              <option value="recent">Most recent activity</option>
+              <option value="delta-desc">Biggest climb (Δ overall)</option>
+              <option value="delta-asc">Biggest drop (Δ overall)</option>
             </select>
           </label>
         </div>


### PR DESCRIPTION
## Summary
- add additional sort modes to the Elo history view and keep the selector in sync
- compute per-series statistics to drive new legend metrics and richer chart rendering
- refresh the Elo page styling with a gradient card container and polished controls

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d034c886b4832da93535d10deb3dfd