### PR TITLE
Add compare drawer for leaderboard and matrix matchups

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -809,6 +809,185 @@ func Router(db *store.DB) http.Handler {
 		writeJSON(w, map[string]any{"bots": bots, "pairs": pairs})
 	})
 
+	mux.HandleFunc("/api/matchup", func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		aStr := r.URL.Query().Get("a")
+		bStr := r.URL.Query().Get("b")
+		if aStr == "" || bStr == "" {
+			http.Error(w, "missing bot ids", http.StatusBadRequest)
+			return
+		}
+
+		var aID, bID int64
+		if _, err := fmt.Sscan(aStr, &aID); err != nil || aID <= 0 {
+			http.Error(w, "invalid a", http.StatusBadRequest)
+			return
+		}
+		if _, err := fmt.Sscan(bStr, &bID); err != nil || bID <= 0 {
+			http.Error(w, "invalid b", http.StatusBadRequest)
+			return
+		}
+		if aID == bID {
+			http.Error(w, "ids must differ", http.StatusBadRequest)
+			return
+		}
+
+		type botSummary struct {
+			ID      int64   `json:"id"`
+			Name    string  `json:"name"`
+			Company string  `json:"company"`
+			Elo     float64 `json:"elo"`
+			GRating float64 `json:"g_rating"`
+			GRD     float64 `json:"g_rd"`
+		}
+		bots := make([]botSummary, 0, 2)
+		rows, err := db.Query(ctx, `
+            SELECT id, name, company,
+                   COALESCE(elo,1500) AS elo,
+                   COALESCE(g_rating,1500) AS g_rating,
+                   COALESCE(g_rd,350) AS g_rd
+              FROM v_bot_career
+             WHERE id = $1 OR id = $2
+        `, aID, bID)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var b botSummary
+			if err := rows.Scan(&b.ID, &b.Name, &b.Company, &b.Elo, &b.GRating, &b.GRD); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			bots = append(bots, b)
+		}
+		if err := rows.Err(); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		if len(bots) != 2 {
+			http.Error(w, "pair not found", http.StatusNotFound)
+			return
+		}
+
+		type headSummary struct {
+			AWins   int `json:"a_wins"`
+			BWins   int `json:"b_wins"`
+			Hands   int `json:"hands"`
+			Matches int `json:"matches"`
+		}
+		var summary headSummary
+		err = db.QueryRow(ctx, `
+            SELECT
+                COALESCE(SUM(a.wins),0) AS a_wins,
+                COALESCE(SUM(b.wins),0) AS b_wins,
+                COALESCE(SUM(a.hands_dealt),0) AS hands,
+                COUNT(*) AS matches
+              FROM match_participants a
+              JOIN match_participants b ON a.match_id = b.match_id
+             WHERE a.bot_id = $1 AND b.bot_id = $2
+        `, aID, bID).Scan(&summary.AWins, &summary.BWins, &summary.Hands, &summary.Matches)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		type matchParticipant struct {
+			BotID     int64  `json:"bot_id"`
+			Label     string `json:"label"`
+			Model     string `json:"model"`
+			StartBank int    `json:"start_bank"`
+			EndBank   int    `json:"end_bank"`
+			Wins      int    `json:"wins"`
+			Hands     int    `json:"hands"`
+			NetChips  int    `json:"net_chips"`
+		}
+
+		type pairMatch struct {
+			MatchID      int64              `json:"match_id"`
+			CreatedAt    time.Time          `json:"created_at"`
+			EndedAt      *time.Time         `json:"ended_at,omitempty"`
+			Hands        int                `json:"hands"`
+			Participants []matchParticipant `json:"participants"`
+		}
+
+		rows2, err := db.Query(ctx, `
+            WITH pair_matches AS (
+                SELECT m.id, m.created_at, m.ended_at
+                  FROM matches m
+                  JOIN match_participants a ON a.match_id = m.id AND a.bot_id = $1
+                  JOIN match_participants b ON b.match_id = m.id AND b.bot_id = $2
+                 ORDER BY m.id DESC
+                 LIMIT 12
+            )
+            SELECT pm.id, pm.created_at, pm.ended_at,
+                   p.bot_id, p.label, p.name_snapshot,
+                   p.start_bank, p.end_bank, p.wins, p.hands_dealt, p.net_chips
+              FROM pair_matches pm
+              JOIN match_participants p ON p.match_id = pm.id
+             WHERE p.bot_id = $1 OR p.bot_id = $2
+             ORDER BY pm.id DESC, p.bot_id
+        `, aID, bID)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		defer rows2.Close()
+		matchIndex := make(map[int64]*pairMatch)
+		order := make([]*pairMatch, 0, 12)
+		for rows2.Next() {
+			var matchID int64
+			var created time.Time
+			var ended *time.Time
+			var part matchParticipant
+			if err := rows2.Scan(&matchID, &created, &ended, &part.BotID, &part.Label, &part.Model, &part.StartBank, &part.EndBank, &part.Wins, &part.Hands, &part.NetChips); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			pm := matchIndex[matchID]
+			if pm == nil {
+				pm = &pairMatch{MatchID: matchID, CreatedAt: created, EndedAt: ended}
+				matchIndex[matchID] = pm
+				order = append(order, pm)
+			}
+			pm.Participants = append(pm.Participants, part)
+			if part.Hands > pm.Hands {
+				pm.Hands = part.Hands
+			}
+		}
+		if err := rows2.Err(); err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		for _, pm := range order {
+			if len(pm.Participants) == 2 {
+				if pm.Participants[0].BotID != aID && pm.Participants[0].BotID == bID {
+					pm.Participants[0], pm.Participants[1] = pm.Participants[1], pm.Participants[0]
+				}
+			}
+		}
+		flatMatches := make([]pairMatch, len(order))
+		for i := range order {
+			flatMatches[i] = *order[i]
+		}
+
+		payload := struct {
+			AID     int64        `json:"a_id"`
+			BID     int64        `json:"b_id"`
+			Bots    []botSummary `json:"bots"`
+			Summary headSummary  `json:"summary"`
+			Matches []pairMatch  `json:"recent_matches"`
+		}{
+			AID:     aID,
+			BID:     bID,
+			Bots:    bots,
+			Summary: summary,
+			Matches: flatMatches,
+		}
+		writeJSON(w, payload)
+	})
+
 	mux.HandleFunc("/api/stability", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		finalOrder, err := db.RankingOrder(ctx, nil)

--- a/server/web/app.css
+++ b/server/web/app.css
@@ -855,6 +855,424 @@ p {
   gap: 20px;
 }
 
+.lb-card__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.compare-toggle {
+  border-color: var(--border);
+  background: var(--surface-alt);
+  color: var(--muted);
+  padding-inline: 1rem;
+}
+
+.compare-toggle:hover {
+  color: var(--accent);
+  border-color: var(--border-strong);
+  background: rgba(17, 24, 39, 0.04);
+}
+
+.compare-toggle__icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 2px solid currentColor;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: background var(--transition), border-color var(--transition);
+}
+
+.compare-toggle__icon::after {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: transparent;
+  transition: background var(--transition);
+}
+
+.compare-toggle.is-active {
+  color: var(--accent-3);
+  background: rgba(37, 99, 235, 0.14);
+  border-color: rgba(37, 99, 235, 0.3);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.12);
+}
+
+.compare-toggle.is-active .compare-toggle__icon {
+  border-color: var(--accent-3);
+}
+
+.compare-toggle.is-active .compare-toggle__icon::after {
+  background: var(--accent-3);
+}
+
+.compare-layout {
+  display: grid;
+  gap: 20px;
+}
+
+.compare-layout--matrix {
+  gap: 24px;
+}
+
+.compare-layout__main {
+  min-width: 0;
+}
+
+@media (min-width: 1120px) {
+  .compare-layout {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+    align-items: start;
+  }
+}
+
+.compare-layout--matrix .compare-drawer {
+  align-self: start;
+}
+
+@media (min-width: 1120px) {
+  .compare-layout--matrix .compare-drawer {
+    position: sticky;
+    top: 20px;
+  }
+}
+
+.compare-drawer {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 22px 24px;
+  display: grid;
+  gap: 18px;
+}
+
+.compare-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.compare-drawer__eyebrow {
+  font-size: var(--fs-0);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.compare-drawer__title {
+  margin: 0;
+  font-size: var(--fs-3);
+}
+
+.compare-drawer__close {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.4rem;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.compare-drawer__close:hover {
+  background: var(--surface-alt);
+  color: var(--accent);
+}
+
+.compare-drawer__body {
+  display: grid;
+  gap: 18px;
+}
+
+.compare-drawer__status {
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.compare-drawer__status p {
+  margin: 0;
+}
+
+.compare-drawer__status p + p {
+  margin-top: 6px;
+}
+
+.compare-drawer__summary {
+  display: grid;
+  gap: 18px;
+}
+
+.compare-drawer__pair {
+  display: grid;
+  gap: 12px;
+}
+
+@media (min-width: 540px) {
+  .compare-drawer__pair {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: stretch;
+  }
+}
+
+.compare-drawer__versus {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--fs-1);
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+}
+
+.compare-drawer__bot-card {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 14px 16px;
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.compare-drawer__bot-name {
+  font-weight: 600;
+  font-size: var(--fs-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-drawer__bot-meta {
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.compare-drawer__bot-metric {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  color: var(--muted);
+  font-size: var(--fs-1);
+}
+
+.compare-drawer__bot-metric strong {
+  font-size: var(--fs-3);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.compare-drawer__stat-grid {
+  display: grid;
+  gap: 12px;
+}
+
+@media (min-width: 540px) {
+  .compare-drawer__stat-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+}
+
+.compare-drawer__stat {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 14px 16px;
+  display: grid;
+  gap: 4px;
+}
+
+.compare-drawer__stat-label {
+  font-size: var(--fs-1);
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.compare-drawer__stat-value {
+  font-weight: 600;
+  font-size: var(--fs-2);
+}
+
+.compare-drawer__stat-meta {
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.compare-drawer__matches {
+  display: grid;
+  gap: 12px;
+}
+
+.compare-drawer__section-title {
+  font-size: var(--fs-1);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+.compare-drawer__match-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.compare-drawer__match {
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  transition: border-color var(--transition), box-shadow var(--transition), transform var(--transition);
+  color: inherit;
+  text-decoration: none;
+}
+
+.compare-drawer__match:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-2px);
+  color: inherit;
+}
+
+.compare-drawer__match-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: var(--fs-1);
+  color: var(--muted);
+}
+
+.compare-drawer__match-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-weight: 500;
+}
+
+.compare-drawer__match-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compare-drawer__chips {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.compare-drawer__chips--positive {
+  color: #15803d;
+}
+
+.compare-drawer__chips--negative {
+  color: #b91c1c;
+}
+
+.compare-drawer__chips--neutral {
+  color: var(--muted);
+}
+
+.compare-drawer__empty {
+  font-size: var(--fs-1);
+  color: var(--muted);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  background: var(--surface-alt);
+  text-align: center;
+}
+
+.compare-select {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--muted);
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.compare-select:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.22);
+}
+
+.compare-select__icon {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  display: inline-block;
+  position: relative;
+}
+
+.lb-card.is-compare-mode .compare-select {
+  display: inline-flex;
+}
+
+.lb-card.is-compare-mode .lb-model {
+  gap: 10px;
+}
+
+.compare-select:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.compare-select.is-selected {
+  background: rgba(37, 99, 235, 0.14);
+  border-color: rgba(37, 99, 235, 0.34);
+  color: var(--accent-3);
+  box-shadow: 0 6px 18px rgba(37, 99, 235, 0.16);
+}
+
+.compare-select.is-selected .compare-select__icon {
+  border-color: currentColor;
+  background: currentColor;
+}
+
+.compare-select.is-selected .compare-select__icon::after {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: 50%;
+  background: var(--accent-contrast);
+}
+
+.lb-row.is-selectable {
+  cursor: pointer;
+}
+
+.lb-row.is-selected {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+.lb-row.is-selected:hover {
+  background: rgba(37, 99, 235, 0.12);
+}
+
 .sort-control {
   display: inline-flex;
   align-items: center;

--- a/server/web/compare.js
+++ b/server/web/compare.js
@@ -1,0 +1,354 @@
+(() => {
+  const ensureNamespace = () => {
+    if (!window.PokerBench) window.PokerBench = {};
+    if (!window.PokerBench.CompareDrawer) window.PokerBench.CompareDrawer = {};
+    return window.PokerBench.CompareDrawer;
+  };
+
+  const escapeHtml = (value = '') => String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+  const numberFormatter = new Intl.NumberFormat();
+  const dateTimeFormatter = new Intl.DateTimeFormat([], {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit'
+  });
+
+  const formatNumber = (value, placeholder = '—') => {
+    const num = Number(value);
+    if (!Number.isFinite(num)) return placeholder;
+    return numberFormatter.format(num);
+  };
+
+  const formatPercent = (wins, hands) => {
+    const w = Number(wins);
+    const h = Number(hands);
+    if (!Number.isFinite(w) || !Number.isFinite(h) || h <= 0) return '—';
+    const pct = Math.max(0, Math.min(100, (w / h) * 100));
+    const rounded = Math.round(pct * 10) / 10;
+    return `${rounded.toFixed(1)}%`;
+  };
+
+  const formatDateTime = (iso) => {
+    if (!iso) return '—';
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return '—';
+    return dateTimeFormatter.format(date);
+  };
+
+  const formatChips = (value) => {
+    const num = Number(value);
+    if (!Number.isFinite(num) || num === 0) return '0';
+    const prefix = num > 0 ? '+' : '−';
+    return `${prefix}${formatNumber(Math.abs(num))}`;
+  };
+
+  const chipClass = (value) => {
+    const num = Number(value);
+    if (!Number.isFinite(num) || num === 0) return 'neutral';
+    return num > 0 ? 'positive' : 'negative';
+  };
+
+  class Drawer {
+    constructor(root, options = {}) {
+      if (!root) throw new Error('CompareDrawer requires a root element');
+      this.root = root;
+      this.options = options;
+      this.cache = new Map();
+      this.currentKey = '';
+      this.active = false;
+      this.lastMeta = null;
+      this.build();
+      this.close({ silent: true });
+    }
+
+    build() {
+      if (!this.root.classList.contains('compare-drawer')) {
+        this.root.classList.add('compare-drawer');
+      }
+      this.root.innerHTML = `
+        <div class="compare-drawer__header">
+          <div>
+            <div class="compare-drawer__eyebrow">Matchup insights</div>
+            <h2 class="compare-drawer__title">Compare bots</h2>
+          </div>
+          <button type="button" class="compare-drawer__close" aria-label="Close comparison">
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <div class="compare-drawer__body">
+          <div class="compare-drawer__status" data-section="status"></div>
+          <div class="compare-drawer__summary" data-section="summary" hidden></div>
+          <div class="compare-drawer__matches" data-section="matches" hidden>
+            <div class="compare-drawer__section-title">Recent matches</div>
+            <ul class="compare-drawer__match-list"></ul>
+          </div>
+        </div>
+      `;
+      this.titleEl = this.root.querySelector('.compare-drawer__title');
+      this.statusEl = this.root.querySelector('[data-section="status"]');
+      this.summaryEl = this.root.querySelector('[data-section="summary"]');
+      this.matchesEl = this.root.querySelector('[data-section="matches"]');
+      this.matchListEl = this.root.querySelector('.compare-drawer__match-list');
+      this.closeBtn = this.root.querySelector('.compare-drawer__close');
+      if (this.closeBtn) {
+        this.closeBtn.addEventListener('click', () => this.close());
+      }
+    }
+
+    open(message, detail) {
+      this.active = true;
+      this.root.hidden = false;
+      this.root.classList.add('is-open');
+      if (message !== undefined) {
+        this.renderIntro(message, detail);
+      }
+    }
+
+    close(options = {}) {
+      this.active = false;
+      this.currentKey = '';
+      this.root.classList.remove('is-open');
+      this.root.hidden = true;
+      this.statusEl.hidden = false;
+      this.statusEl.innerHTML = '';
+      this.summaryEl.hidden = true;
+      this.summaryEl.innerHTML = '';
+      this.matchesEl.hidden = true;
+      this.matchListEl.innerHTML = '';
+      this.titleEl.textContent = 'Compare bots';
+      if (!options.silent && typeof this.options.onClose === 'function') {
+        this.options.onClose();
+      }
+    }
+
+    renderIntro(message = 'Select two bots to compare.', detail = '') {
+      this.titleEl.textContent = 'Compare bots';
+      const lines = [`<p>${escapeHtml(message)}</p>`];
+      if (detail) lines.push(`<p class="compare-drawer__muted">${escapeHtml(detail)}</p>`);
+      this.statusEl.hidden = false;
+      this.statusEl.innerHTML = lines.join('');
+      this.summaryEl.hidden = true;
+      this.summaryEl.innerHTML = '';
+      this.matchesEl.hidden = true;
+      this.matchListEl.innerHTML = '';
+    }
+
+    showIntro(message = 'Select two bots to compare.', detail = '') {
+      this.open();
+      this.renderIntro(message, detail);
+    }
+
+    showPending(selection = []) {
+      this.open();
+      if (!selection.length) {
+        this.showIntro();
+        return;
+      }
+      const first = selection[0] || {};
+      const name = first.short || first.name || 'First bot';
+      const detail = first.company ? `${first.company} selected` : '';
+      this.titleEl.textContent = 'Select opponent';
+      const body = [`<p>${escapeHtml(name)} selected. Choose another bot to compare.</p>`];
+      if (detail) body.push(`<p class="compare-drawer__muted">${escapeHtml(detail)}</p>`);
+      this.statusEl.hidden = false;
+      this.statusEl.innerHTML = body.join('');
+      this.summaryEl.hidden = true;
+      this.summaryEl.innerHTML = '';
+      this.matchesEl.hidden = true;
+      this.matchListEl.innerHTML = '';
+    }
+
+    showLoading(meta = {}) {
+      const aLabel = meta.aShort || meta.aName || 'Bot A';
+      const bLabel = meta.bShort || meta.bName || 'Bot B';
+      this.open();
+      this.titleEl.textContent = `${aLabel} vs ${bLabel}`;
+      this.statusEl.hidden = false;
+      this.statusEl.innerHTML = `<p>Loading head-to-head results…</p>`;
+      this.summaryEl.hidden = true;
+      this.summaryEl.innerHTML = '';
+      this.matchesEl.hidden = true;
+      this.matchListEl.innerHTML = '';
+    }
+
+    showError(message = 'Comparison data is unavailable right now.') {
+      this.open();
+      this.titleEl.textContent = 'Compare bots';
+      this.statusEl.hidden = false;
+      this.statusEl.innerHTML = `<p>${escapeHtml(message)}</p>`;
+      this.summaryEl.hidden = true;
+      this.summaryEl.innerHTML = '';
+      this.matchesEl.hidden = true;
+      this.matchListEl.innerHTML = '';
+    }
+
+    showMatchup({ aId, bId, meta = {} }) {
+      const a = Number(aId);
+      const b = Number(bId);
+      if (!Number.isFinite(a) || !Number.isFinite(b) || a <= 0 || b <= 0 || a === b) {
+        this.showError('Select two different bots to compare.');
+        return;
+      }
+      this.lastMeta = meta;
+      const key = `${a}|${b}`;
+      this.currentKey = key;
+      this.showLoading(meta);
+      if (this.cache.has(key)) {
+        const cached = this.cache.get(key);
+        this.renderData(cached, meta);
+        return;
+      }
+      const url = `/api/matchup?a=${encodeURIComponent(a)}&b=${encodeURIComponent(b)}`;
+      fetch(url)
+        .then(res => {
+          if (!res.ok) throw new Error('failed');
+          return res.json();
+        })
+        .then(data => {
+          this.cache.set(key, data);
+          if (this.currentKey === key) {
+            this.renderData(data, meta);
+          }
+        })
+        .catch(() => {
+          if (this.currentKey === key) {
+            this.showError('Comparison data is unavailable right now. Please try again soon.');
+          }
+        });
+    }
+
+    renderBotCard(bot = {}) {
+      const name = bot.name || 'Unknown bot';
+      const company = bot.company || '';
+      const elo = Number(bot.elo);
+      const eloDisplay = Number.isFinite(elo) ? Math.round(elo) : '—';
+      return `
+        <div class="compare-drawer__bot-card">
+          <div class="compare-drawer__bot-name">${escapeHtml(name)}</div>
+          ${company ? `<div class="compare-drawer__bot-meta">${escapeHtml(company)}</div>` : ''}
+          <div class="compare-drawer__bot-metric"><span>Elo</span><strong>${escapeHtml(String(eloDisplay))}</strong></div>
+        </div>
+      `;
+    }
+
+    renderWinStat(label, opponent, pct, wins, hands) {
+      const metaLine = Number(hands) > 0
+        ? `${formatNumber(wins)} wins • ${formatNumber(hands)} hands`
+        : 'No completed hands yet';
+      return `
+        <div class="compare-drawer__stat">
+          <div class="compare-drawer__stat-label">${escapeHtml(label)} vs ${escapeHtml(opponent)}</div>
+          <div class="compare-drawer__stat-value">${escapeHtml(pct)}</div>
+          <div class="compare-drawer__stat-meta">${escapeHtml(metaLine)}</div>
+        </div>
+      `;
+    }
+
+    renderHandsStat(hands, matches) {
+      const matchLine = Number(matches) > 0
+        ? `${formatNumber(matches)} total matches`
+        : 'No completed matches yet';
+      return `
+        <div class="compare-drawer__stat compare-drawer__stat--neutral">
+          <div class="compare-drawer__stat-label">Hands played</div>
+          <div class="compare-drawer__stat-value">${escapeHtml(formatNumber(hands))}</div>
+          <div class="compare-drawer__stat-meta">${escapeHtml(matchLine)}</div>
+        </div>
+      `;
+    }
+
+    renderMatch(match, orientation) {
+      const participants = Array.isArray(match.participants) ? match.participants : [];
+      const a = participants.find(p => Number(p.bot_id) === orientation.aId) || {};
+      const b = participants.find(p => Number(p.bot_id) === orientation.bId) || {};
+      const handsText = Number(match.hands) > 0 ? `${formatNumber(match.hands)} hands` : 'Hands pending';
+      const created = formatDateTime(match.created_at);
+      const replayHref = `/web/replay.html?match_id=${encodeURIComponent(match.match_id)}`;
+      const aChips = Number.isFinite(Number(a.net_chips)) ? formatChips(a.net_chips) : '0';
+      const bChips = Number.isFinite(Number(b.net_chips)) ? formatChips(b.net_chips) : '0';
+      return `
+        <li class="compare-drawer__match-item">
+          <a class="compare-drawer__match" href="${escapeHtml(replayHref)}">
+            <div class="compare-drawer__match-head">
+              <span class="compare-drawer__match-date">${escapeHtml(created)}</span>
+              <span class="compare-drawer__match-hands">${escapeHtml(handsText)}</span>
+            </div>
+            <div class="compare-drawer__match-line">
+              <span class="compare-drawer__match-name">${escapeHtml(orientation.aName)}</span>
+              <span class="compare-drawer__chips compare-drawer__chips--${chipClass(a.net_chips)}">${escapeHtml(aChips)}</span>
+            </div>
+            <div class="compare-drawer__match-line">
+              <span class="compare-drawer__match-name">${escapeHtml(orientation.bName)}</span>
+              <span class="compare-drawer__chips compare-drawer__chips--${chipClass(b.net_chips)}">${escapeHtml(bChips)}</span>
+            </div>
+          </a>
+        </li>
+      `;
+    }
+
+    renderData(data = {}, meta = {}) {
+      this.statusEl.hidden = true;
+      this.statusEl.innerHTML = '';
+      const bots = Array.isArray(data.bots) ? data.bots : [];
+      const summary = data.summary || {};
+      const aId = Number(data.a_id ?? meta.aId);
+      const bId = Number(data.b_id ?? meta.bId);
+      const botMap = new Map(bots.map(b => [Number(b.id), b]));
+      const aBot = botMap.get(aId) || botMap.values().next().value || {};
+      const remainingBots = bots.filter(b => Number(b.id) !== Number(aBot.id));
+      const bBot = botMap.get(bId) || remainingBots[0] || {};
+      const aName = meta.aShort || meta.aName || aBot.name || 'Bot A';
+      const bName = meta.bShort || meta.bName || bBot.name || 'Bot B';
+      const aCompany = meta.aCompany || aBot.company || '';
+      const bCompany = meta.bCompany || bBot.company || '';
+
+      this.titleEl.textContent = `${aName} vs ${bName}`;
+
+      const hands = Number(summary.hands || 0);
+      const matches = Number(summary.matches || 0);
+      const aWins = Number(summary.a_wins || 0);
+      const bWins = Number(summary.b_wins || 0);
+      const aPct = formatPercent(aWins, hands);
+      const bPct = formatPercent(bWins, hands);
+
+      this.summaryEl.hidden = false;
+      this.summaryEl.innerHTML = `
+        <div class="compare-drawer__pair">
+          ${this.renderBotCard({ name: aName, company: aCompany, elo: aBot.elo })}
+          <div class="compare-drawer__versus">vs</div>
+          ${this.renderBotCard({ name: bName, company: bCompany, elo: bBot.elo })}
+        </div>
+        <div class="compare-drawer__stat-grid">
+          ${this.renderWinStat(aName, bName, aPct, aWins, hands)}
+          ${this.renderWinStat(bName, aName, bPct, bWins, hands)}
+          ${this.renderHandsStat(hands, matches)}
+        </div>
+      `;
+
+      const orientation = {
+        aId,
+        bId,
+        aName,
+        bName
+      };
+      const matchesList = Array.isArray(data.recent_matches) ? data.recent_matches.slice(0, 10) : [];
+      if (matchesList.length === 0) {
+        this.matchesEl.hidden = false;
+        this.matchListEl.innerHTML = '<li class="compare-drawer__empty">No recent matches recorded for this pairing yet.</li>';
+        return;
+      }
+      this.matchesEl.hidden = false;
+      this.matchListEl.innerHTML = matchesList.map(match => this.renderMatch(match, orientation)).join('');
+    }
+  }
+
+  const ns = ensureNamespace();
+  ns.create = (root, options) => new Drawer(root, options);
+})();

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="/web/app.css?v=8"/>
   <link rel="icon" href="/web/favicon.svg" type="image/svg+xml"/>
   <script src="/web/app.js" defer></script>
+  <script src="/web/compare.js" defer></script>
   <script>
     document.addEventListener('DOMContentLoaded', ()=>{
       document.querySelectorAll('.topnav a').forEach(a=>{
@@ -277,11 +278,18 @@ function rowHTML(i, r, metric){
       const ratingVal = ratingFor(r, metric).toFixed(1);
       const rd = Number(r.glicko_rd ?? r.g_rd);
       const rdText = metric === 'glicko' && Number.isFinite(rd) ? `<span class="sub">±${Math.round(rd)}</span>` : '';
-      return `<tr class="lb-row" data-href="/web/bot.html?id=${r.bot_id}">
+      const fullSafe = escapeHtml(full);
+      const shortSafe = escapeHtml(short);
+      const companySafe = escapeHtml(trim1(r.company) || '');
+      const compareLabel = escapeHtml(`Select ${short || full || 'bot'} for comparison`);
+      return `<tr class="lb-row" data-href="/web/bot.html?id=${r.bot_id}" data-bot-id="${r.bot_id}" data-bot-name="${fullSafe}" data-bot-short="${shortSafe}" data-bot-company="${companySafe}">
         <td class="num">${i+1}</td>
         <td>
           <div class="lb-model">
             ${modelIcon(r.company, r.model)}
+            <button type="button" class="compare-select" data-bot-id="${r.bot_id}" aria-pressed="false" aria-label="${compareLabel}" title="${compareLabel}">
+              <span class="compare-select__icon" aria-hidden="true"></span>
+            </button>
             <a href="/web/bot.html?id=${r.bot_id}" class="name" title="${title}">${short}</a>
           </div>
         </td>
@@ -324,6 +332,120 @@ function rowHTML(i, r, metric){
       let sortKey = 'rating';
       let sortDesc = true;
       let ratingMetric = 'elo';
+
+      const compareState = { enabled: false, selected: [] };
+      const lbCard = document.querySelector('.lb-card');
+      const compareToggle = document.getElementById('compareToggle');
+      const compareDrawerEl = document.getElementById('compareDrawer');
+      let compareDrawer = null;
+
+      function syncSelectionUI(){
+        const rowsInDom = document.querySelectorAll('tr.lb-row');
+        const selectedIds = new Set(compareState.selected.map(item => item.id));
+        const presentIds = new Set();
+        rowsInDom.forEach(row => {
+          const id = Number(row.dataset.botId || '');
+          if (!Number.isFinite(id)) return;
+          presentIds.add(id);
+          const isSelected = selectedIds.has(id);
+          row.classList.toggle('is-selected', compareState.enabled && isSelected);
+          row.classList.toggle('is-selectable', compareState.enabled);
+          const btn = row.querySelector('.compare-select');
+          if (btn){
+            btn.classList.toggle('is-selected', isSelected);
+            btn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
+            btn.disabled = !compareState.enabled;
+          }
+        });
+        if (presentIds.size < compareState.selected.length){
+          compareState.selected = compareState.selected.filter(item => presentIds.has(item.id));
+        }
+      }
+
+      function updateDrawerState(){
+        if (!compareDrawer) return;
+        if (!compareState.enabled){
+          compareDrawer.close({ silent: true });
+          return;
+        }
+        if (compareState.selected.length === 0){
+          compareDrawer.showIntro('Select two bots to compare.', 'Choose any two leaderboard entries to view head-to-head results.');
+          return;
+        }
+        if (compareState.selected.length === 1){
+          compareDrawer.showPending(compareState.selected);
+          return;
+        }
+        const [first, second] = compareState.selected;
+        compareDrawer.showMatchup({
+          aId: first.id,
+          bId: second.id,
+          meta: {
+            aId: first.id,
+            bId: second.id,
+            aName: first.name,
+            bName: second.name,
+            aShort: first.short,
+            bShort: second.short,
+            aCompany: first.company,
+            bCompany: second.company
+          }
+        });
+      }
+
+      function toggleSelection(row){
+        if (!compareState.enabled || !row) return;
+        const id = Number(row.dataset.botId || '');
+        if (!Number.isFinite(id) || id <= 0) return;
+        const existingIdx = compareState.selected.findIndex(item => item.id === id);
+        if (existingIdx >= 0){
+          compareState.selected.splice(existingIdx, 1);
+        } else {
+          const meta = {
+            id,
+            name: row.dataset.botName || row.querySelector('.lb-model .name')?.textContent || '',
+            short: row.dataset.botShort || row.querySelector('.lb-model .name')?.textContent || '',
+            company: row.dataset.botCompany || ''
+          };
+          if (compareState.selected.length >= 2){
+            compareState.selected.shift();
+          }
+          compareState.selected.push(meta);
+        }
+        syncSelectionUI();
+        updateDrawerState();
+      }
+
+      function setCompareMode(on){
+        const next = Boolean(on);
+        if (compareState.enabled === next) return;
+        compareState.enabled = next;
+        if (compareToggle){
+          compareToggle.setAttribute('aria-pressed', next ? 'true' : 'false');
+          compareToggle.classList.toggle('is-active', next);
+        }
+        if (lbCard){
+          lbCard.classList.toggle('is-compare-mode', next);
+        }
+        if (!next){
+          compareState.selected = [];
+        }
+        syncSelectionUI();
+        updateDrawerState();
+      }
+
+      if (compareDrawerEl && window.PokerBench?.CompareDrawer){
+        compareDrawer = window.PokerBench.CompareDrawer.create(compareDrawerEl, {
+          onClose: () => setCompareMode(false)
+        });
+      }
+
+      if (compareToggle){
+        compareToggle.setAttribute('aria-pressed', 'false');
+        compareToggle.addEventListener('click', ()=>{
+          setCompareMode(!compareState.enabled);
+        });
+      }
 
       const ratingLabels = { elo: 'Elo', glicko: 'Glicko-2' };
 
@@ -389,6 +511,8 @@ function rowHTML(i, r, metric){
           });
         } catch {}
         setHeaderIndicators();
+        syncSelectionUI();
+        if (compareState.enabled) updateDrawerState();
       }
 
       async function refreshJudgeAccuracy(){
@@ -457,9 +581,23 @@ function rowHTML(i, r, metric){
 
       const tb = $('#tbody');
       tb.addEventListener('click', (e)=>{
+        const compareBtn = e.target.closest('.compare-select');
+        if (compareBtn){
+          e.preventDefault();
+          e.stopPropagation();
+          toggleSelection(compareBtn.closest('tr.lb-row'));
+          return;
+        }
+        const tr = e.target.closest('tr.lb-row');
+        if (!tr) return;
+        if (compareState.enabled){
+          e.preventDefault();
+          toggleSelection(tr);
+          return;
+        }
         if (e.target.closest('a')) return;
-        const tr = e.target.closest('tr.lb-row'); if (!tr) return;
-        const href = tr.getAttribute('data-href'); if (href) location.href = href;
+        const href = tr.getAttribute('data-href');
+        if (href) location.href = href;
       });
     }
     addEventListener('DOMContentLoaded', load);
@@ -581,14 +719,22 @@ function rowHTML(i, r, metric){
               <button class="inline-tip" type="button" data-tip="PokerBench runs continuous heads-up poker matches between bots, tracks every hand, and updates ratings as results arrive." aria-label="Tip: how PokerBench runs matches">i</button>
             </div>
           </div>
-          <div class="sort-control" role="group" aria-label="Rating metric">
-            <span class="sort-control__label">Rating</span>
-            <button type="button" class="active" data-rating="elo">Elo</button>
-            <button type="button" data-rating="glicko">Glicko-2</button>
+          <div class="lb-card__header-actions">
+            <div class="sort-control" role="group" aria-label="Rating metric">
+              <span class="sort-control__label">Rating</span>
+              <button type="button" class="active" data-rating="elo">Elo</button>
+              <button type="button" data-rating="glicko">Glicko-2</button>
+            </div>
+            <button type="button" class="pill compare-toggle" id="compareToggle" aria-pressed="false">
+              <span class="compare-toggle__icon" aria-hidden="true"></span>
+              <span class="compare-toggle__label">Compare</span>
+            </button>
           </div>
         </div>
         <div class="lb-card__body">
-          <div class="lb-table-wrap">
+          <div class="compare-layout">
+            <div class="compare-layout__main">
+              <div class="lb-table-wrap">
             <table class="lb-table">
             <colgroup>
               <col style="width:56px" />
@@ -617,6 +763,9 @@ function rowHTML(i, r, metric){
             <tbody id="tbody"><tr><td colspan="9">Loading...</td></tr></tbody>
           </table>
         </div>
+            </div>
+            <aside class="compare-drawer" id="compareDrawer" hidden></aside>
+          </div>
         </div>
       </div>
     </div>

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -7,9 +7,28 @@
   <link rel="stylesheet" href="/web/app.css?v=8"/>
   <link rel="icon" href="/web/favicon.svg" type="image/svg+xml"/>
   <script src="/web/app.js" defer></script>
+  <script src="/web/compare.js" defer></script>
   <script>
     document.addEventListener('DOMContentLoaded', ()=>{
       document.querySelectorAll('.topnav__links a').forEach(a=>{ try{ if(location.pathname.endsWith(a.getAttribute('href').split('/').pop())) a.classList.add('active'); }catch(e){} });
+      const drawerEl = document.getElementById('compareDrawer');
+      if (drawerEl && window.PokerBench?.CompareDrawer){
+        compareDrawer = window.PokerBench.CompareDrawer.create(drawerEl, {
+          onClose: ()=>{
+            if (activePinnedCell){
+              activePinnedCell.classList.remove('matrix-cell--active');
+              activePinnedCell.setAttribute('aria-pressed', 'false');
+              activePinnedCell = null;
+            }
+            const detail = document.getElementById('matrixDetails');
+            if (detail){
+              detail.innerHTML = '<div class="matrix-details__empty">Click a matchup to pin detailed stats.</div>';
+              detail.classList.remove('matrix-details--active');
+            }
+          }
+        });
+        compareDrawer.showIntro('Click a matchup to compare bots.', 'Head-to-head insights update as new matches finish.');
+      }
     });
     const $ = s => document.querySelector(s);
     const nf = new Intl.NumberFormat();
@@ -21,6 +40,7 @@
     let tooltipActiveCell = null;
     let tooltipScrollHandlerAttached = false;
     let activePinnedCell = null;
+    let compareDrawer = null;
     function heat(p){
       const x = Math.max(0, Math.min(1, p));
       const hue = 240*(1-x); // blue -> red
@@ -79,8 +99,10 @@
           const q = wins[j][i];
           const oppPct = q==null? '—' : Math.round(100*q)+'%';
           const exp = Math.round(100*eloProb(elo[i], elo[j]))+'%';
-          const aName = bots[i]?.name || '—';
-          const bName = bots[j]?.name || '—';
+          const aBot = bots[i] || {};
+          const bBot = bots[j] || {};
+          const aName = aBot.name || '—';
+          const bName = bBot.name || '—';
           const pairLabel = `${aName} vs ${bName}`;
           const handCount = hands[i][j] || 0;
           const sample = handCount > 0 ? ` (n=${handCount})` : '';
@@ -93,6 +115,12 @@
           const dataAttrs = [
             `data-a="${escapeAttr(aName)}"`,
             `data-b="${escapeAttr(bName)}"`,
+            `data-a-id="${escapeAttr(String(aBot.id || ''))}"`,
+            `data-b-id="${escapeAttr(String(bBot.id || ''))}"`,
+            `data-a-full="${escapeAttr(aName)}"`,
+            `data-b-full="${escapeAttr(bName)}"`,
+            `data-a-company="${escapeAttr(aBot.company || '')}"`,
+            `data-b-company="${escapeAttr(bBot.company || '')}"`,
             `data-pct="${escapeAttr(pct)}"`,
             `data-opp="${escapeAttr(oppPct)}"`,
             `data-hands="${escapeAttr(handCount)}"`,
@@ -238,6 +266,29 @@
         window.addEventListener('resize', hideTooltip, { passive: true });
         tooltipScrollHandlerAttached = true;
       }
+      function handleCellSelection(cell){
+        if (!cell) return;
+        hideTooltip();
+        updateDetailPanel(cell);
+        if (compareDrawer){
+          const aId = Number(cell.dataset.aId || '0');
+          const bId = Number(cell.dataset.bId || '0');
+          if (Number.isFinite(aId) && Number.isFinite(bId) && aId > 0 && bId > 0){
+            const meta = {
+              aId,
+              bId,
+              aName: cell.dataset.aFull || cell.dataset.a || '—',
+              bName: cell.dataset.bFull || cell.dataset.b || '—',
+              aShort: shortName(cell.dataset.aFull || cell.dataset.a || ''),
+              bShort: shortName(cell.dataset.bFull || cell.dataset.b || ''),
+              aCompany: cell.dataset.aCompany || '',
+              bCompany: cell.dataset.bCompany || ''
+            };
+            compareDrawer.showMatchup({ aId, bId, meta });
+          }
+        }
+      }
+
       cells.forEach(cell=>{
         cell.addEventListener('mouseenter', event=>{
           showTooltip(cell, event);
@@ -254,14 +305,12 @@
         cell.addEventListener('blur', hideTooltip);
         cell.addEventListener('click', event=>{
           event.preventDefault();
-          hideTooltip();
-          updateDetailPanel(cell);
+          handleCellSelection(cell);
         });
         cell.addEventListener('keydown', event=>{
           if(event.key === 'Enter' || event.key === ' '){
             event.preventDefault();
-            hideTooltip();
-            updateDetailPanel(cell);
+            handleCellSelection(cell);
           }
         });
       });
@@ -380,11 +429,16 @@
         <div class="muted">Cell = A’s win rate vs B; diagonal blank by design.</div>
       </div>
 
-      <div class="card matrix-card">
-        <div class="matrix-card__body" id="matrix">Loading…</div>
-        <div class="matrix-details" id="matrixDetails" role="status" aria-live="polite">
-          <div class="matrix-details__empty">Click a matchup to pin detailed stats.</div>
+      <div class="compare-layout compare-layout--matrix">
+        <div class="compare-layout__main">
+          <div class="card matrix-card">
+            <div class="matrix-card__body" id="matrix">Loading…</div>
+            <div class="matrix-details" id="matrixDetails" role="status" aria-live="polite">
+              <div class="matrix-details__empty">Click a matchup to pin detailed stats.</div>
+            </div>
+          </div>
         </div>
+        <aside class="compare-drawer" id="compareDrawer" hidden></aside>
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- add a shared compare drawer module that loads head-to-head data via `/api/matchup` and renders bot matchups with caching
- wire the leaderboard page with a compare toggle, selection handling, and drawer layout to display side-by-side comparisons
- embed the same drawer on the matrix page so clicking a matchup populates the detailed comparison alongside the table, with supporting styles

## Testing
- go test ./... *(hangs while waiting for external database connection; aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68d032a488b4832d96194dd8090e3c62