### PR TITLE
Adjust board layout and simplify Elo page legend

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -2065,6 +2065,18 @@ ion);
   margin-left: auto;
 }
 
+.page-elo .topnav__links .pill {
+  padding-left: 1.35rem;
+  padding-right: 1.35rem;
+}
+
+.page-elo .filter-chip {
+  min-width: 120px;
+  justify-content: center;
+  padding-left: 1.1rem;
+  padding-right: 1.1rem;
+}
+
 @media (max-width: 720px) {
   .elo-card__filters {
     justify-content: flex-start;
@@ -2248,54 +2260,48 @@ n);
   z-index: 2;
 }
 
-.chart-legend {
+.elo-bars {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 20px;
-  margin-top: 18px;
+  gap: 18px;
+  margin-top: 22px;
 }
 
-.chart-legend__item {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  padding: 18px 20px;
+.elo-bars__item {
+  position: relative;
+  display: grid;
+  gap: 12px;
+  padding: 18px 20px 20px;
   border-radius: var(--radius-md);
   border: 1px solid rgba(15, 23, 42, 0.08);
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(240, 244, 255, 0.94) 100%);
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
-  transition: transform var(--transition), box-shadow var(--transition);
 }
 
-.chart-legend__item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 22px 46px rgba(15, 23, 42, 0.16);
+.elo-bars__item::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.26);
 }
 
-.chart-legend__header {
+.elo-bars__header {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 16px;
 }
 
-.chart-legend__swatch {
-  width: 14px;
-  height: 14px;
-  border-radius: 999px;
-  background: var(--legend-color, var(--accent));
-  box-shadow: 0 0 0 5px rgba(15, 23, 42, 0.05);
-}
-
-.chart-legend__label {
+.elo-bars__label {
   display: flex;
   align-items: center;
   gap: 12px;
   min-width: 0;
-  font-size: var(--fs-1);
 }
 
-.chart-legend__label .org-icon,
-.chart-legend__label img {
+.elo-bars__label .org-icon,
+.elo-bars__label img {
   width: 38px;
   height: 38px;
   border-radius: 14px;
@@ -2304,78 +2310,91 @@ n);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
 }
 
-.chart-legend__text {
+.elo-bars__text {
   display: grid;
   gap: 2px;
   min-width: 0;
 }
 
-.chart-legend__text span {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.chart-legend__model {
+.elo-bars__model {
   font-weight: 600;
   color: var(--text);
 }
 
-.chart-legend__company {
+.elo-bars__company {
   font-size: var(--fs-0);
   color: var(--muted);
 }
 
-.chart-legend__metrics {
-  display: grid;
+.elo-bars__meta {
+  display: flex;
+  align-items: baseline;
   gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
 }
 
-@media (min-width: 960px) {
-  .chart-legend__item {
-    flex-direction: row;
-    align-items: center;
-  }
-
-  .chart-legend__metrics {
-    margin-left: auto;
-    grid-auto-flow: column;
-    grid-auto-columns: minmax(108px, auto);
-    justify-items: end;
-  }
-}
-
-.chart-legend__metric {
-  display: grid;
-  gap: 2px;
-  text-align: left;
-}
-
-.chart-legend__metric-value {
+.elo-bars__value {
+  font-family: var(--font-mono);
   font-weight: 600;
   font-size: var(--fs-2);
   color: var(--text);
 }
 
-.chart-legend__metric-label {
+.elo-bars__delta {
+  font-family: var(--font-mono);
   font-size: var(--fs-0);
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  color: var(--muted);
 }
 
-.chart-legend__metric.is-positive .chart-legend__metric-value {
+.elo-bars__delta.is-positive {
   color: var(--ok);
 }
 
-.chart-legend__metric.is-negative .chart-legend__metric-value {
+.elo-bars__delta.is-negative {
   color: var(--bad);
 }
 
-.chart-legend__metric.is-neutral .chart-legend__metric-value {
+.elo-bars__delta.is-neutral {
   color: var(--muted);
 }
+
+.elo-bars__matches {
+  font-size: var(--fs-0);
+  color: var(--muted);
+}
+
+.elo-bars__bar {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.22);
+  overflow: hidden;
+}
+
+.elo-bars__fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.18) 0%, rgba(59, 130, 246, 0.45) 55%, rgba(59, 130, 246, 0.85) 100%);
+}
+
+.elo-bars__item[role='listitem'] {
+  list-style: none;
+}
+
+@media (max-width: 720px) {
+  .elo-bars__header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .elo-bars__meta {
+    align-self: stretch;
+  }
+}
+
 
 .chart-crosshair {
   stroke: rgba(15, 23, 42, 0.24);
@@ -4070,7 +4089,7 @@ body.tooltips-disabled .inline-tip {
   border: 1px solid rgba(148, 163, 184, 0.22);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.95) 0%, rgba(243, 246, 252, 0.92) 100%);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 26px 52px rgba(15, 23, 42, 0.18);
-  min-height: calc(var(--card-h) + 72px);
+  min-height: calc((var(--card-h) * 2) + 110px);
 }
 
 .board-display__cards {
@@ -4079,7 +4098,11 @@ body.tooltips-disabled .inline-tip {
   gap: 18px;
   width: 100%;
   justify-content: center;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
+  row-gap: 28px;
+  max-width: calc((var(--card-w) * 3) + (18px * 2));
+  margin: 0 auto;
+  align-content: center;
 }
 
 .board-display__label {

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -684,75 +684,77 @@
 
       if (!plots.length) return;
 
-      const createMetric = (labelText, valueText, modifier) => {
-        const metric = document.createElement('div');
-        metric.className = 'chart-legend__metric';
-        if (modifier && modifier !== 'neutral') {
-          metric.classList.add(`is-${modifier}`);
-        } else if (modifier === 'neutral') {
-          metric.classList.add('is-neutral');
-        }
-        const valueEl = document.createElement('span');
-        valueEl.className = 'chart-legend__metric-value';
-        valueEl.textContent = valueText;
-        const labelEl = document.createElement('span');
-        labelEl.className = 'chart-legend__metric-label';
-        labelEl.textContent = labelText;
-        metric.appendChild(valueEl);
-        metric.appendChild(labelEl);
-        return metric;
-      };
+      const latestValues = plots
+        .map(plot => (Number.isFinite(plot.stats?.latestElo) ? plot.stats.latestElo : null))
+        .filter(value => value != null);
+      const maxLatest = latestValues.length ? Math.max(...latestValues) : 0;
 
       plots.forEach(plot => {
+        const stats = plot.stats || {};
         const item = document.createElement('div');
-        item.className = 'chart-legend__item';
-        item.style.setProperty('--legend-color', plot.color);
+        item.className = 'elo-bars__item';
+        item.setAttribute('role', 'listitem');
 
         const header = document.createElement('div');
-        header.className = 'chart-legend__header';
-
-        const swatch = document.createElement('span');
-        swatch.className = 'chart-legend__swatch';
-        header.appendChild(swatch);
+        header.className = 'elo-bars__header';
 
         const label = document.createElement('div');
-        label.className = 'chart-legend__label';
+        label.className = 'elo-bars__label';
         const iconEl = createIconElement(plot.meta.iconMarkup);
         if (iconEl) label.appendChild(iconEl);
 
         const textWrap = document.createElement('div');
-        textWrap.className = 'chart-legend__text';
+        textWrap.className = 'elo-bars__text';
         const modelEl = document.createElement('span');
-        modelEl.className = 'chart-legend__model';
+        modelEl.className = 'elo-bars__model';
         modelEl.textContent = plot.meta.model || 'Unknown';
         modelEl.style.color = plot.color;
         const companyEl = document.createElement('span');
-        companyEl.className = 'chart-legend__company';
+        companyEl.className = 'elo-bars__company';
         companyEl.textContent = plot.meta.company || 'Unknown';
         companyEl.style.color = colorWithAlpha(plot.color, 0.7);
         textWrap.appendChild(modelEl);
         textWrap.appendChild(companyEl);
-
         label.appendChild(textWrap);
-        header.appendChild(label);
-        item.appendChild(header);
 
-        const metrics = document.createElement('div');
-        metrics.className = 'chart-legend__metrics';
-        const stats = plot.stats || {};
+        const metaWrap = document.createElement('div');
+        metaWrap.className = 'elo-bars__meta';
 
-        metrics.appendChild(createMetric('Latest Elo', formatEloValue(stats.latestElo)));
-        const deltaMetric = createMetric('Δ overall', formatDeltaValue(stats.deltaFromFirst), deltaModifier(stats.deltaFromFirst));
-        metrics.appendChild(deltaMetric);
-        const matchesValue = Number.isFinite(stats.matches) ? String(stats.matches) : '–';
-        metrics.appendChild(createMetric('Matches', matchesValue));
+        const valueEl = document.createElement('span');
+        valueEl.className = 'elo-bars__value';
+        valueEl.textContent = formatEloValue(stats.latestElo);
+        metaWrap.appendChild(valueEl);
 
-        if (stats.lastUpdated instanceof Date) {
-          const updatedLabel = shortDate.format(stats.lastUpdated);
-          metrics.appendChild(createMetric('Last duel', updatedLabel));
+        const deltaValue = formatDeltaValue(stats.deltaFromFirst);
+        const deltaClass = deltaModifier(stats.deltaFromFirst) || 'neutral';
+        const deltaEl = document.createElement('span');
+        deltaEl.className = `elo-bars__delta is-${deltaClass}`;
+        deltaEl.textContent = deltaValue;
+        metaWrap.appendChild(deltaEl);
+
+        if (Number.isFinite(stats.matches)) {
+          const matchesEl = document.createElement('span');
+          matchesEl.className = 'elo-bars__matches';
+          const count = stats.matches;
+          matchesEl.textContent = count === 1 ? '1 match' : `${count} matches`;
+          metaWrap.appendChild(matchesEl);
         }
 
-        item.appendChild(metrics);
+        header.appendChild(label);
+        header.appendChild(metaWrap);
+        item.appendChild(header);
+
+        const bar = document.createElement('div');
+        bar.className = 'elo-bars__bar';
+        const fill = document.createElement('div');
+        fill.className = 'elo-bars__fill';
+        const latest = Number.isFinite(stats.latestElo) ? stats.latestElo : 0;
+        const pct = maxLatest > 0 ? Math.max(0, Math.min(1, latest / maxLatest)) : 0;
+        fill.style.width = `${(pct * 100).toFixed(2)}%`;
+        fill.style.background = `linear-gradient(135deg, ${colorWithAlpha(plot.color, 0.25)} 0%, ${colorWithAlpha(plot.color, 0.6)} 50%, ${plot.color} 100%)`;
+        bar.appendChild(fill);
+        item.appendChild(bar);
+
         legend.appendChild(item);
       });
 
@@ -1283,7 +1285,7 @@
             <div class="chart-tooltip__series"></div>
           </div>
         </div>
-        <div id="legend" class="chart-legend"></div>
+        <div id="legend" class="elo-bars" role="list"></div>
       </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update the board display styling so community cards wrap into two rows and clear the blind cards
- widen the Elo page pills and replace the card-style legend with a horizontal bar graph list

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d03b2758bc832da2ad97eba74a1600