### PR TITLE
Improve leaderboard compare layout and matrix presentation

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -191,14 +191,14 @@ p {
 
 .wrap,
 .wrap--wide {
-  width: min(1200px, calc(100vw - 48px));
+  width: min(1280px, calc(100vw - 48px));
   margin: 0 auto;
   display: grid;
   gap: var(--gutter);
 }
 
 .wrap--wide {
-  width: min(1340px, calc(100vw - 56px));
+  width: min(1480px, calc(100vw - 56px));
 }
 
 .row {
@@ -926,8 +926,13 @@ p {
 
 @media (min-width: 1120px) {
   .compare-layout {
-    grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
     align-items: start;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lb-card.is-compare-mode .compare-layout,
+  .compare-layout--matrix {
+    grid-template-columns: minmax(0, 1fr) minmax(320px, 400px);
   }
 }
 
@@ -1638,7 +1643,8 @@ p {
   background: linear-gradient(90deg, var(--accent) 0%, rgba(17, 17, 17, 0.4) 100%);
 }
 
-.table-wrap {
+.table-wrap,
+.lb-table-wrap {
   width: 100%;
   overflow-x: auto;
 }
@@ -1726,82 +1732,6 @@ p {
   color: var(--muted);
 }
 
-.matrix-details {
-  padding: 22px 24px;
-  border-radius: var(--radius-md);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-sm);
-  display: grid;
-  gap: 16px;
-  transition: border-color var(--transition), box-shadow var(--transition);
-}
-
-.matrix-details__empty {
-  color: var(--muted);
-  font-size: var(--fs-1);
-}
-
-.matrix-details--active {
-  border-color: var(--border-strong);
-  box-shadow: var(--shadow-md);
-}
-
-.matrix-details__matchup {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  font-weight: 600;
-  font-size: var(--fs-3);
-}
-
-.matrix-details__model {
-  white-space: nowrap;
-}
-
-.matrix-details__versus {
-  font-size: var(--fs-1);
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-}
-
-.matrix-details__stat-line {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
-}
-
-.matrix-details__stat {
-  flex: 1 1 200px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 14px 16px;
-  border-radius: var(--radius-sm);
-  background: var(--surface-alt);
-  border: 1px solid var(--border);
-}
-
-.matrix-details__label {
-  font-weight: 500;
-  color: var(--muted);
-}
-
-.matrix-details__value {
-  font-weight: 600;
-  font-variant-numeric: tabular-nums;
-}
-
-.matrix-details__meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 24px;
-  color: var(--muted);
-  font-size: var(--fs-1);
-}
-
 @media (max-width: 720px) {
   .matrix-tooltip {
     min-width: 200px;
@@ -1812,16 +1742,11 @@ p {
     flex-wrap: wrap;
     gap: 6px;
   }
-
-  .matrix-details__stat {
-    flex: 1 1 140px;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .matrix-cell,
-  .matrix-tooltip,
-  .matrix-details {
+  .matrix-tooltip {
     transition: none !important;
     transform: none !important;
   }
@@ -2523,7 +2448,6 @@ n);
   justify-content: flex-end;
 }
 
-
 .cardx {
   --corner-pad: 12px;
   --rank-size: 26px;
@@ -2604,7 +2528,6 @@ n);
   --tilt: 180deg;
 }
 
-
 .cardx .num-box {
   position: absolute;
   font-size: var(--rank-size);
@@ -2632,7 +2555,6 @@ n);
   content: var(--card-glyph, '');
 }
 
-
 .cardx .suit {
   font-size: var(--glyph-size);
   color: currentColor;
@@ -2655,7 +2577,6 @@ n);
 .club {
   color: #15803d;
 }
-
 
 .cardx.spade {
   --card-front-bg: linear-gradient(180deg, #ffffff 0%, #e2e8f0 100%);
@@ -3820,7 +3741,6 @@ body.tooltips-disabled .inline-tip {
   min-height: 1.5em;
 }
 
-
 .stage-table {
   display: grid;
   gap: 28px;
@@ -3902,7 +3822,6 @@ body.tooltips-disabled .inline-tip {
   font-size: var(--fs-1);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18), 0 12px 24px rgba(15, 23, 42, 0.22);
 }
-
 
 .seat-card__cards {
   order: 1;

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -20,11 +20,6 @@
               activePinnedCell.setAttribute('aria-pressed', 'false');
               activePinnedCell = null;
             }
-            const detail = document.getElementById('matrixDetails');
-            if (detail){
-              detail.innerHTML = '<div class="matrix-details__empty">Click a matchup to pin detailed stats.</div>';
-              detail.classList.remove('matrix-details--active');
-            }
           }
         });
         compareDrawer.showIntro('Click a matchup to compare bots.', 'Head-to-head insights update as new matches finish.');
@@ -215,41 +210,8 @@
       positionTooltip(event, cell);
     }
     function updateDetailPanel(cell){
-      const detail = $('#matrixDetails');
-      if(!detail || !cell) return;
-      const a = cell.dataset.a || '—';
-      const b = cell.dataset.b || '—';
-      const pct = cell.dataset.pct || '—';
-      const opp = cell.dataset.opp || '—';
-      const exp = cell.dataset.exp || '—';
-      const handCount = Number(cell.dataset.hands || '0');
-      const hasData = cell.dataset.hasData === 'true';
-      const sample = hasData && handCount > 0
-        ? `${formatNumber(handCount)} hands played`
-        : 'No completed hands yet';
-      detail.innerHTML = `
-        <div class="matrix-details__matchup">
-          <span class="matrix-details__model">${escapeAttr(a)}</span>
-          <span class="matrix-details__versus">vs</span>
-          <span class="matrix-details__model">${escapeAttr(b)}</span>
-        </div>
-        <div class="matrix-details__stat-line">
-          <div class="matrix-details__stat">
-            <span class="matrix-details__label">${escapeAttr(a)}</span>
-            <span class="matrix-details__value">${escapeAttr(hasData ? pct : '—')}</span>
-          </div>
-          <div class="matrix-details__stat">
-            <span class="matrix-details__label">${escapeAttr(b)}</span>
-            <span class="matrix-details__value">${escapeAttr(hasData ? opp : '—')}</span>
-          </div>
-        </div>
-        <div class="matrix-details__meta">
-          <span>${escapeAttr(sample)}</span>
-          <span>Elo expectation: ${escapeAttr(exp)}</span>
-        </div>
-      `;
-      detail.classList.add('matrix-details--active');
-      if(activePinnedCell){
+      if(!cell) return;
+      if(activePinnedCell && activePinnedCell !== cell){
         activePinnedCell.classList.remove('matrix-cell--active');
         activePinnedCell.setAttribute('aria-pressed', 'false');
       }
@@ -433,9 +395,6 @@
         <div class="compare-layout__main">
           <div class="card matrix-card">
             <div class="matrix-card__body" id="matrix">Loading…</div>
-            <div class="matrix-details" id="matrixDetails" role="status" aria-live="polite">
-              <div class="matrix-details__empty">Click a matchup to pin detailed stats.</div>
-            </div>
           </div>
         </div>
         <aside class="compare-drawer" id="compareDrawer" hidden></aside>


### PR DESCRIPTION
## Summary
- widen the shared page wrap and adjust the leaderboard compare layout so the compare drawer only consumes space when active
- allow the leaderboard table wrapper to scroll horizontally and enlarge the compare drawer column to avoid overlap with matchup insights
- remove the redundant matrix detail panel beneath the table and keep selection highlighting while relying on the compare drawer

## Testing
- not run (front-end only)


------
https://chatgpt.com/codex/tasks/task_e_68d03ba55398832d98578792deb57aed