### PR TITLE
Polish replay UI and refresh Elo chart styling

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -133,6 +133,18 @@ button {
   cursor: pointer;
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 :focus-visible {
   outline: 3px solid var(--focus-ring);
   outline-offset: 3px;
@@ -1157,11 +1169,17 @@ p {
 
 .compare-drawer__match-head {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
-  gap: 10px;
+  gap: 12px;
   font-size: var(--fs-1);
   color: var(--muted);
+}
+
+.compare-drawer__match-date,
+.compare-drawer__match-hands {
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
 }
 
 .compare-drawer__match-line {
@@ -2165,10 +2183,10 @@ n);
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(155deg, rgba(255, 255, 255, 0.98) 0%, rgba(235, 242, 255, 0.9) 100%);
-  border: 1px solid rgba(15, 23, 42, 0.06);
-  box-shadow: 0 32px 64px rgba(15, 23, 42, 0.14);
-  backdrop-filter: blur(10px);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: none;
   pointer-events: none;
 }
 
@@ -2197,9 +2215,9 @@ n);
   gap: 12px;
   padding: 18px 20px 20px;
   border-radius: var(--radius-md);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98) 0%, rgba(240, 244, 255, 0.94) 100%);
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
 }
 
 .elo-bars__item::after {
@@ -3996,7 +4014,7 @@ body.tooltips-disabled .inline-tip {
 
 .board-display {
   display: grid;
-  gap: 18px;
+  gap: 12px;
   justify-items: center;
 }
 
@@ -4030,6 +4048,54 @@ body.tooltips-disabled .inline-tip {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
+}
+
+@media (max-width: 1200px) {
+  .card--stage {
+    width: 100%;
+    padding: 28px 24px;
+    gap: 28px;
+  }
+
+  .stage-table {
+    gap: 24px;
+  }
+
+  .stage-table__center {
+    padding: 0;
+  }
+
+  .board-display__surface {
+    padding: 24px 26px;
+    min-height: calc((var(--card-h) * 2) + 90px);
+  }
+}
+
+@media (max-width: 900px) {
+  .replay-layout {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .card--stage {
+    width: 100%;
+    padding: 24px 20px;
+    gap: 24px;
+  }
+
+  .stage-table {
+    gap: 20px;
+  }
+
+  .board-display__surface {
+    padding: 20px 18px;
+  }
+
+  .board-display__cards {
+    gap: 14px;
+    row-gap: 20px;
+    max-width: calc((var(--card-w) * 3) + (14px * 2));
+  }
 }
 
 .stage-table__caption {

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -417,8 +417,8 @@
       tooltip.classList.remove('visible');
 
       const rect = chartWrap.getBoundingClientRect();
-      const width = Math.max(720, rect.width || state.dims.width);
-      const height = Math.max(420, Math.min(width * 0.56, (window.innerHeight || 900) * 0.7));
+      const width = Math.max(420, rect.width || state.dims.width || 420);
+      const height = Math.max(280, Math.min(width * 0.56, (window.innerHeight || 900) * 0.7));
       state.dims.width = width;
       state.dims.height = height;
 
@@ -477,28 +477,7 @@
         return xForIndex(idx == null ? 0 : idx);
       };
       const y = (val) => height - pad.bottom - ((val - yMin) * (height - pad.top - pad.bottom)) / (yMax - yMin);
-      const baselineY = y(yMin);
-
-      const defs = mk('defs');
-      const bgGrad = mk('linearGradient');
-      bgGrad.setAttribute('id', 'chart-bg');
-      bgGrad.setAttribute('x1', '0');
-      bgGrad.setAttribute('x2', '0');
-      bgGrad.setAttribute('y1', '0');
-      bgGrad.setAttribute('y2', '1');
-      const bgStop1 = mk('stop'); bgStop1.setAttribute('offset', '0%'); bgStop1.setAttribute('stop-color', 'rgba(248,250,255,0.98)');
-      const bgStop2 = mk('stop'); bgStop2.setAttribute('offset', '100%'); bgStop2.setAttribute('stop-color', 'rgba(228,238,255,0.94)');
-      bgGrad.appendChild(bgStop1); bgGrad.appendChild(bgStop2);
-      defs.appendChild(bgGrad);
-      svg.appendChild(defs);
-
-      const bg = mk('rect');
-      bg.setAttribute('x', '0');
-      bg.setAttribute('y', '0');
-      bg.setAttribute('width', String(width));
-      bg.setAttribute('height', String(height));
-      bg.setAttribute('fill', 'url(#chart-bg)');
-      svg.appendChild(bg);
+      svg.style.background = 'var(--surface)';
 
       const grid = mk('g');
       grid.setAttribute('stroke', 'rgba(15, 23, 42, 0.1)');
@@ -620,27 +599,6 @@
 
         const pathData = pts.map((pt, idx) => `${idx === 0 ? 'M' : 'L'} ${pt.x} ${pt.y}`).join(' ');
 
-        if (pts.length) {
-          const areaCommands = [`M ${pts[0].x} ${baselineY}`];
-          pts.forEach(pt => areaCommands.push(`L ${pt.x} ${pt.y}`));
-          areaCommands.push(`L ${pts[pts.length - 1].x} ${baselineY}`);
-          areaCommands.push('Z');
-          const area = mk('path');
-          area.setAttribute('d', areaCommands.join(' '));
-          area.setAttribute('fill', colorWithAlpha(stroke, 0.12));
-          area.setAttribute('stroke', 'none');
-          group.appendChild(area);
-        }
-
-        const glow = mk('path');
-        glow.setAttribute('d', pathData);
-        glow.setAttribute('fill', 'none');
-        glow.setAttribute('stroke', colorWithAlpha(stroke, 0.35));
-        glow.setAttribute('stroke-width', '7');
-        glow.setAttribute('stroke-linecap', 'round');
-        glow.setAttribute('stroke-linejoin', 'round');
-        glow.setAttribute('opacity', '1');
-
         const line = mk('path');
         line.setAttribute('d', pathData);
         line.setAttribute('fill', 'none');
@@ -649,7 +607,6 @@
         line.setAttribute('stroke-linecap', 'round');
         line.setAttribute('stroke-linejoin', 'round');
 
-        group.appendChild(glow);
         group.appendChild(line);
 
         pts.forEach(pt => {

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -22,7 +22,6 @@
             }
           }
         });
-        compareDrawer.showIntro('Click a matchup to compare bots.', 'Head-to-head insights update as new matches finish.');
       }
     });
     const $ = s => document.querySelector(s);

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -211,7 +211,7 @@
               </header>
               <div class="seat-card__cards">
                 <div class="cards cards--hole" id="sb_hole" aria-label="Small blind hole cards"></div>
-                <div class="seat-card__cards-text" id="sbHoleText">Hidden</div>
+                <div class="seat-card__cards-text visually-hidden" id="sbHoleText">Hidden</div>
               </div>
               <div class="seat-card__stacks">
                 <span class="muted">Stack</span>
@@ -241,7 +241,7 @@
                 <div class="board-display__surface">
                   <div class="cards board-display__cards" id="board" aria-label="Community cards" data-card-slots="5"></div>
                 </div>
-                <div class="board-display__label" id="boardText">Board: —</div>
+                <div class="board-display__label visually-hidden" id="boardText">Board: —</div>
               </div>
               <div id="caption" class="stage-table__caption" aria-live="polite">Waiting for first hand…</div>
             </div>
@@ -256,7 +256,7 @@
               </header>
               <div class="seat-card__cards">
                 <div class="cards cards--hole" id="bb_hole" aria-label="Big blind hole cards"></div>
-                <div class="seat-card__cards-text" id="bbHoleText">Hidden</div>
+                <div class="seat-card__cards-text visually-hidden" id="bbHoleText">Hidden</div>
               </div>
               <div class="seat-card__stacks">
                 <span class="muted">Stack</span>

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -669,7 +669,10 @@ const ReplayPage = (() => {
       state.prevHandId = row.hand_id;
       state.winnerSeat = null;
       updateWinnerGlow();
-      state.dealerSeat = state.dealerSeat === 'SB' ? 'BB' : 'SB';
+      const nextDealer = isAOnSB(row.hand_id) ? 'SB' : 'BB';
+      if (nextDealer === 'SB' || nextDealer === 'BB') {
+        state.dealerSeat = nextDealer;
+      }
       updateDealerIndicator();
       if (els.handBanner) {
         els.handBanner.textContent = '';


### PR DESCRIPTION
## Summary
- hide duplicate hole card and board text in the replay view and derive the dealer indicator from each hand id
- keep the compare drawer hidden on the matrix page until a matchup is chosen and tighten its "created" metadata alignment
- refresh the Elo chart with a neutral background, pure line rendering, and responsive spacing improvements that also benefit the replay layout

## Testing
- go test ./... *(hangs locally, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d050b36f5c832d9df14a6bf07ed5e7