### PR TITLE
Fix dealer indicator and leaderboard compare UI

### DIFF
--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -300,7 +300,7 @@ function rowHTML(i, r, metric){
         <td class="num">${Math.max(0,Math.min(100, Number(r.win_rate_pct||0)))}%<span class="sub">${ciTxt}</span></td>
         <td class="num">${judge.hasData ? judge.display : '—'}</td>
         <td class="num">${fmt(r.net_chips)}</td>
-        <td class="sub">${r.updated_at ? dateFmt(r.updated_at) : 'n/a'}</td>
+        <td><span class="sub">${r.updated_at ? dateFmt(r.updated_at) : 'n/a'}</span></td>
       </tr>`;
     }
 
@@ -356,6 +356,10 @@ function rowHTML(i, r, metric){
             btn.classList.toggle('is-selected', isSelected);
             btn.setAttribute('aria-pressed', isSelected ? 'true' : 'false');
             btn.disabled = !compareState.enabled;
+            btn.hidden = !compareState.enabled;
+            if (!compareState.enabled && document.activeElement === btn) {
+              btn.blur();
+            }
           }
         });
         if (presentIds.size < compareState.selected.length){

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -23,6 +23,7 @@ const ReplayPage = (() => {
     prevHoles: { SB: '', BB: '' },
     prevHandId: null,
     dealerSeat: 'SB',
+    prevDealerSeat: null,
     winnerSeat: null,
     startStacks: { SB: 0, BB: 0 },
     baseEquity: { SB: 0, BB: 0 },
@@ -425,23 +426,40 @@ const ReplayPage = (() => {
   }
 
   function updateDealerIndicator() {
-    const seat = state.dealerSeat;
-    if (els.sbDealer) {
-      const isDealer = seat === 'SB';
-      els.sbDealer.hidden = !isDealer;
-      els.sbDealer.setAttribute('aria-hidden', isDealer ? 'false' : 'true');
-    }
-    if (els.bbDealer) {
-      const isDealer = seat === 'BB';
-      els.bbDealer.hidden = !isDealer;
-      els.bbDealer.setAttribute('aria-hidden', isDealer ? 'false' : 'true');
-    }
+    const seat = state.dealerSeat === 'SB' || state.dealerSeat === 'BB' ? state.dealerSeat : null;
+    const prevSeat = state.prevDealerSeat;
+    const shouldAnimate = seat && seat !== prevSeat;
+
+    const syncDealerChip = (el, isDealer) => {
+      if (!el) return;
+      if (isDealer) {
+        el.hidden = false;
+        el.setAttribute('aria-hidden', 'false');
+        if (shouldAnimate) {
+          el.classList.remove('dealer-move');
+          void el.offsetWidth; // force reflow to restart animation
+          el.classList.add('dealer-move');
+        } else {
+          el.classList.remove('dealer-move');
+        }
+      } else {
+        el.hidden = true;
+        el.setAttribute('aria-hidden', 'true');
+        el.classList.remove('dealer-move');
+      }
+    };
+
+    syncDealerChip(els.sbDealer, seat === 'SB');
+    syncDealerChip(els.bbDealer, seat === 'BB');
+
     if (els.sbZone) {
       els.sbZone.classList.toggle('seat-card--dealer', seat === 'SB');
     }
     if (els.bbZone) {
       els.bbZone.classList.toggle('seat-card--dealer', seat === 'BB');
     }
+
+    state.prevDealerSeat = seat;
   }
 
   function updateWinnerGlow() {
@@ -1025,6 +1043,7 @@ const ReplayPage = (() => {
     state.prevHandId = null;
     state.winnerSeat = null;
     state.dealerSeat = 'SB';
+    state.prevDealerSeat = null;
     state.actionButtons = [];
     updateDealerIndicator();
     updateWinnerGlow();


### PR DESCRIPTION
## Summary
- ensure the dealer chip only appears on the active seat and animate when it moves
- hide leaderboard compare selectors until compare mode is enabled and restore updated column layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d055caf310832da6182731066bff1d