### PR TITLE
Improve dark mode presentation across navigation and cards

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -23,6 +23,13 @@
   --shadow-sm: 0 10px 24px rgba(15, 23, 42, 0.06);
   --shadow-md: 0 28px 46px rgba(15, 23, 42, 0.09);
   --shadow-lg: 0 48px 96px rgba(15, 23, 42, 0.12);
+  --header-bg: rgba(255, 255, 255, 0.94);
+  --header-bg-solid: rgba(255, 255, 255, 0.96);
+  --header-border: transparent;
+  --header-border-strong: var(--border);
+  --header-shadow: 0 18px 34px rgba(15, 23, 42, 0.08);
+  --footer-bg: rgba(255, 255, 255, 0.92);
+  --footer-border: var(--border);
   --font-sans: 'Inter', 'Helvetica Neue', Arial, sans-serif;
   --font-display: 'Space Grotesk', 'Inter', 'Helvetica Neue', Arial, sans-serif;
   --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, Consolas, monospace;
@@ -101,6 +108,13 @@
   --shadow-sm: 0 10px 30px rgba(2, 6, 16, 0.55);
   --shadow-md: 0 28px 58px rgba(2, 6, 16, 0.58);
   --shadow-lg: 0 48px 112px rgba(2, 6, 16, 0.6);
+  --header-bg: rgba(8, 13, 23, 0.9);
+  --header-bg-solid: rgba(11, 18, 32, 0.94);
+  --header-border: rgba(36, 49, 76, 0.65);
+  --header-border-strong: rgba(49, 63, 97, 0.85);
+  --header-shadow: 0 18px 34px rgba(2, 6, 16, 0.65);
+  --footer-bg: rgba(8, 13, 23, 0.88);
+  --footer-border: rgba(49, 63, 97, 0.75);
   --bg: var(--page-bg);
   --bg-2: var(--surface);
   --surface-2: var(--surface-alt);
@@ -353,18 +367,18 @@ p {
   position: sticky;
   top: 0;
   z-index: 20;
-  background: rgba(255, 255, 255, 0.94);
+  background: var(--header-bg);
   backdrop-filter: blur(16px);
-  border-bottom: 1px solid transparent;
+  border-bottom: 1px solid var(--header-border);
   opacity: 1;
   transition: transform 220ms ease, opacity 220ms ease, box-shadow 220ms ease, background-color 220ms ease,
     border-color 220ms ease;
 }
 
 .site-header--shadow {
-  background: rgba(255, 255, 255, 0.96);
-  border-color: var(--border);
-  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.08);
+  background: var(--header-bg-solid);
+  border-color: var(--header-border-strong);
+  box-shadow: var(--header-shadow);
 }
 
 .site-header--hidden {
@@ -556,6 +570,11 @@ p {
   height: auto;
 }
 
+:root[data-theme='dark'] .logo-badge img[src$="pokerBenchlogo.svg"],
+:root.theme-dark .logo-badge img[src$="pokerBenchlogo.svg"] {
+  filter: brightness(0) invert(1);
+}
+
 .brand:hover .logo-badge {
   transform: scale(1.04);
 }
@@ -567,6 +586,18 @@ p {
 
 .topnav__links .pill .nav-link__label {
   font-size: var(--fs-1);
+}
+
+.topnav__links .nav-link,
+.topnav__actions .nav-link {
+  color: var(--muted);
+}
+
+.topnav__links .nav-link:hover,
+.topnav__links .nav-link:focus-visible,
+.topnav__actions .nav-link:hover,
+.topnav__actions .nav-link:focus-visible {
+  color: var(--accent);
 }
 
 .logo-badge--sm {
@@ -1449,6 +1480,13 @@ p {
   border: 1px solid var(--border);
 }
 
+:root[data-theme='dark'] .sort-control,
+:root.theme-dark .sort-control {
+  background: rgba(13, 20, 33, 0.85);
+  border: 1px solid rgba(71, 89, 128, 0.55);
+  box-shadow: 0 12px 28px rgba(2, 6, 16, 0.55);
+}
+
 .sort-control__label {
   font-size: var(--fs-1);
   font-weight: 500;
@@ -1485,11 +1523,25 @@ p {
   box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
 }
 
+:root[data-theme='dark'] .sort-control button.active,
+:root.theme-dark .sort-control button.active {
+  background: rgba(33, 51, 82, 0.9);
+  color: var(--accent);
+  box-shadow: 0 4px 12px rgba(2, 6, 16, 0.45);
+}
+
 .page-elo .sort-control {
   background: rgba(255, 255, 255, 0.7);
   border: 1px solid rgba(15, 23, 42, 0.08);
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
   backdrop-filter: blur(6px);
+}
+
+:root[data-theme='dark'] .page-elo .sort-control,
+:root.theme-dark .page-elo .sort-control {
+  background: rgba(13, 20, 33, 0.88);
+  border: 1px solid rgba(71, 89, 128, 0.6);
+  box-shadow: 0 12px 28px rgba(2, 6, 16, 0.55);
 }
 
 .page-elo .sort-control select {
@@ -1500,8 +1552,21 @@ p {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.35);
 }
 
+:root[data-theme='dark'] .page-elo .sort-control select,
+:root.theme-dark .page-elo .sort-control select {
+  background: rgba(13, 20, 33, 0.95);
+  border: 1px solid rgba(71, 89, 128, 0.6);
+  box-shadow: inset 0 0 0 1px rgba(141, 183, 255, 0.12);
+  color: var(--accent);
+}
+
 .page-elo .sort-control select:hover {
   border-color: rgba(59, 130, 246, 0.45);
+}
+
+:root[data-theme='dark'] .page-elo .sort-control select:hover,
+:root.theme-dark .page-elo .sort-control select:hover {
+  border-color: rgba(141, 183, 255, 0.55);
 }
 
 .table,
@@ -1860,6 +1925,14 @@ p {
   backdrop-filter: blur(18px);
 }
 
+:root[data-theme='dark'] .matrix-tooltip,
+:root.theme-dark .matrix-tooltip {
+  background: rgba(11, 18, 32, 0.92);
+  border: 1px solid rgba(71, 89, 128, 0.55);
+  box-shadow: 0 20px 40px rgba(2, 6, 16, 0.58);
+  color: var(--text);
+}
+
 .matrix-tooltip.visible {
   opacity: 1;
   transform: translate3d(0, 0, 0) scale(1);
@@ -1972,8 +2045,8 @@ p {
 .site-footer {
   margin-top: auto;
   padding: 32px 0;
-  border-top: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.92);
+  border-top: 1px solid var(--footer-border);
+  background: var(--footer-bg);
   backdrop-filter: blur(12px);
 }
 
@@ -2071,6 +2144,28 @@ ion);
   color: var(--muted);
 }
 
+:root[data-theme='dark'] .site-footer__brand .logo-badge,
+:root.theme-dark .site-footer__brand .logo-badge {
+  background: rgba(21, 31, 51, 0.85);
+  border-color: rgba(71, 89, 128, 0.5);
+  box-shadow: 0 6px 18px rgba(2, 6, 16, 0.45);
+}
+
+:root[data-theme='dark'] .site-footer__social,
+:root.theme-dark .site-footer__social {
+  background: rgba(15, 23, 42, 0.82);
+  border-color: rgba(71, 89, 128, 0.55);
+  color: var(--text);
+  box-shadow: 0 12px 26px rgba(2, 6, 16, 0.5);
+}
+
+:root[data-theme='dark'] .site-footer__social:hover,
+:root.theme-dark .site-footer__social:hover {
+  border-color: rgba(141, 183, 255, 0.5);
+  color: var(--accent);
+  box-shadow: 0 12px 26px rgba(2, 6, 16, 0.6);
+}
+
 /* ---------- Elo page ------------------------------------------------ */
 
 .page-elo .card.elo-card {
@@ -2102,6 +2197,23 @@ ion);
   pointer-events: none;
 }
 
+:root[data-theme='dark'] .page-elo .card.elo-card,
+:root.theme-dark .page-elo .card.elo-card {
+  background: linear-gradient(150deg, rgba(13, 21, 38, 0.96) 0%, rgba(6, 12, 24, 0.98) 100%);
+  border: 1px solid rgba(71, 89, 128, 0.6);
+  box-shadow: 0 34px 72px rgba(2, 6, 16, 0.58);
+}
+
+:root[data-theme='dark'] .page-elo .card.elo-card::before,
+:root.theme-dark .page-elo .card.elo-card::before {
+  background: radial-gradient(circle at top right, rgba(59, 130, 246, 0.22), transparent 58%);
+}
+
+:root[data-theme='dark'] .page-elo .card.elo-card::after,
+:root.theme-dark .page-elo .card.elo-card::after {
+  background: radial-gradient(circle, rgba(59, 130, 246, 0.35) 0%, rgba(59, 130, 246, 0) 70%);
+}
+
 @media (max-width: 720px) {
   .page-elo .card.elo-card {
     padding: 26px;
@@ -2118,6 +2230,11 @@ ion);
   gap: 24px;
   padding-bottom: 22px;
   border-bottom: 1px solid rgba(15, 23, 42, 0.1);
+}
+
+:root[data-theme='dark'] .elo-card__header,
+:root.theme-dark .elo-card__header {
+  border-bottom-color: rgba(71, 89, 128, 0.45);
 }
 
 @media (min-width: 960px) {
@@ -2184,6 +2301,13 @@ ion);
   backdrop-filter: blur(6px);
 }
 
+:root[data-theme='dark'] .filter-group,
+:root.theme-dark .filter-group {
+  background: rgba(11, 18, 32, 0.85);
+  border: 1px solid rgba(71, 89, 128, 0.55);
+  box-shadow: inset 0 1px 0 rgba(141, 183, 255, 0.12);
+}
+
 .filter-group__label {
   display: inline-flex;
   align-items: center;
@@ -2235,10 +2359,24 @@ n);
   box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
 }
 
+:root[data-theme='dark'] .filter-chip:hover,
+:root.theme-dark .filter-chip:hover {
+  border-color: rgba(141, 183, 255, 0.5);
+  box-shadow: 0 12px 26px rgba(2, 6, 16, 0.5);
+  color: var(--accent);
+}
+
 .filter-chip:focus-visible {
   outline: none;
   border-color: rgba(59, 130, 246, 0.48);
   box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.18), 0 12px 26px rgba(15, 23, 42, 0.08);
+  color: var(--accent);
+}
+
+:root[data-theme='dark'] .filter-chip:focus-visible,
+:root.theme-dark .filter-chip:focus-visible {
+  border-color: rgba(141, 183, 255, 0.6);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.35), 0 12px 26px rgba(2, 6, 16, 0.55);
   color: var(--accent);
 }
 
@@ -2247,6 +2385,14 @@ n);
   color: var(--accent);
   border-color: rgba(59, 130, 246, 0.4);
   box-shadow: 0 16px 34px rgba(59, 130, 246, 0.16);
+}
+
+:root[data-theme='dark'] .filter-chip.active,
+:root.theme-dark .filter-chip.active {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.32) 0%, rgba(30, 64, 175, 0.68) 100%);
+  color: #e0f2fe;
+  border-color: rgba(59, 130, 246, 0.55);
+  box-shadow: 0 16px 34px rgba(2, 6, 16, 0.6);
 }
 
 .filter-chip__content {
@@ -2273,6 +2419,14 @@ n);
   box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
 }
 
+:root[data-theme='dark'] .filter-chip img,
+:root.theme-dark .filter-chip img,
+:root[data-theme='dark'] .filter-chip .org-icon,
+:root.theme-dark .filter-chip .org-icon {
+  background: rgba(21, 31, 51, 0.85);
+  box-shadow: inset 0 0 0 1px rgba(71, 89, 128, 0.45);
+}
+
 .filter-chip__text {
   white-space: nowrap;
 }
@@ -2292,6 +2446,13 @@ n);
   backdrop-filter: blur(6px);
 }
 
+:root[data-theme='dark'] .filter-indicator,
+:root.theme-dark .filter-indicator {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(71, 89, 128, 0.5);
+  color: var(--muted);
+}
+
 .filter-indicator::before {
   content: '';
   width: 10px;
@@ -2299,6 +2460,12 @@ n);
   border-radius: 999px;
   background: currentColor;
   opacity: 0.45;
+}
+
+:root[data-theme='dark'] .filter-indicator::before,
+:root.theme-dark .filter-indicator::before {
+  background: var(--accent);
+  opacity: 0.8;
 }
 
 .filter-indicator.is-active {
@@ -3322,11 +3489,34 @@ body.tooltips-disabled .inline-tip {
   transition: background var(--transition), color var(--transition), border-color var(--transition), box-shadow var(--transition);
 }
 
+:root[data-theme='dark'] .playstyle-card__badge,
+:root.theme-dark .playstyle-card__badge {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(71, 89, 128, 0.5);
+  color: var(--muted);
+  box-shadow: 0 12px 30px rgba(2, 6, 16, 0.45);
+}
+
+:root[data-theme='dark'] .filter-chip,
+:root.theme-dark .filter-chip {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(71, 89, 128, 0.5);
+  color: var(--muted);
+}
+
 .playstyle-card[data-style='LAG'] .playstyle-card__badge {
   background: rgba(56, 189, 248, 0.16);
   color: #0f172a;
   border-color: rgba(56, 189, 248, 0.45);
   box-shadow: 0 12px 30px rgba(56, 189, 248, 0.18);
+}
+
+:root[data-theme='dark'] .playstyle-card[data-style='LAG'] .playstyle-card__badge,
+:root.theme-dark .playstyle-card[data-style='LAG'] .playstyle-card__badge {
+  background: rgba(56, 189, 248, 0.24);
+  color: #e0f2fe;
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 12px 30px rgba(13, 94, 160, 0.48);
 }
 
 .playstyle-card[data-style='TAG'] .playstyle-card__badge {
@@ -3336,11 +3526,27 @@ body.tooltips-disabled .inline-tip {
   box-shadow: 0 12px 30px rgba(168, 85, 247, 0.18);
 }
 
+:root[data-theme='dark'] .playstyle-card[data-style='TAG'] .playstyle-card__badge,
+:root.theme-dark .playstyle-card[data-style='TAG'] .playstyle-card__badge {
+  background: rgba(168, 85, 247, 0.26);
+  color: #f3e8ff;
+  border-color: rgba(168, 85, 247, 0.55);
+  box-shadow: 0 12px 30px rgba(88, 28, 135, 0.48);
+}
+
 .playstyle-card[data-style='FISH'] .playstyle-card__badge {
   background: rgba(249, 115, 22, 0.16);
   color: #7c2d12;
   border-color: rgba(249, 115, 22, 0.45);
   box-shadow: 0 12px 30px rgba(249, 115, 22, 0.18);
+}
+
+:root[data-theme='dark'] .playstyle-card[data-style='FISH'] .playstyle-card__badge,
+:root.theme-dark .playstyle-card[data-style='FISH'] .playstyle-card__badge {
+  background: rgba(249, 115, 22, 0.24);
+  color: #ffedd5;
+  border-color: rgba(249, 115, 22, 0.55);
+  box-shadow: 0 12px 30px rgba(124, 45, 18, 0.45);
 }
 
 .playstyle-card[data-style='NIT'] .playstyle-card__badge {
@@ -3350,11 +3556,26 @@ body.tooltips-disabled .inline-tip {
   box-shadow: 0 12px 30px rgba(34, 197, 94, 0.18);
 }
 
+:root[data-theme='dark'] .playstyle-card[data-style='NIT'] .playstyle-card__badge,
+:root.theme-dark .playstyle-card[data-style='NIT'] .playstyle-card__badge {
+  background: rgba(34, 197, 94, 0.24);
+  color: #bbf7d0;
+  border-color: rgba(34, 197, 94, 0.55);
+  box-shadow: 0 12px 30px rgba(14, 116, 67, 0.45);
+}
+
 .playstyle-card[data-style='N/A'] .playstyle-card__badge {
   background: var(--surface-alt);
   color: var(--muted);
   border-color: var(--border);
   box-shadow: none;
+}
+
+:root[data-theme='dark'] .playstyle-card[data-style='N/A'] .playstyle-card__badge,
+:root.theme-dark .playstyle-card[data-style='N/A'] .playstyle-card__badge {
+  background: rgba(21, 31, 51, 0.78);
+  border-color: rgba(71, 89, 128, 0.5);
+  color: var(--muted);
 }
 
 .playstyle-card__grid {
@@ -3398,8 +3619,21 @@ body.tooltips-disabled .inline-tip {
   transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
 }
 
+:root[data-theme='dark'] .playstyle-grid__cell,
+:root.theme-dark .playstyle-grid__cell {
+  background: rgba(15, 23, 42, 0.78);
+  border-color: rgba(71, 89, 128, 0.5);
+  color: var(--muted);
+}
+
 .playstyle-grid__cell:hover {
   transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+  color: var(--text);
+}
+
+:root[data-theme='dark'] .playstyle-grid__cell:hover,
+:root.theme-dark .playstyle-grid__cell:hover {
   box-shadow: var(--shadow-sm);
   color: var(--text);
 }
@@ -3414,10 +3648,24 @@ body.tooltips-disabled .inline-tip {
   --ps-accent: #0f172a;
 }
 
+:root[data-theme='dark'] .playstyle-grid__cell[data-style='LAG'],
+:root.theme-dark .playstyle-grid__cell[data-style='LAG'] {
+  --ps-color: rgba(56, 189, 248, 0.32);
+  --ps-border: rgba(56, 189, 248, 0.55);
+  --ps-accent: #e0f2fe;
+}
+
 .playstyle-grid__cell[data-style='TAG'] {
   --ps-color: rgba(168, 85, 247, 0.2);
   --ps-border: rgba(168, 85, 247, 0.5);
   --ps-accent: #3b0764;
+}
+
+:root[data-theme='dark'] .playstyle-grid__cell[data-style='TAG'],
+:root.theme-dark .playstyle-grid__cell[data-style='TAG'] {
+  --ps-color: rgba(168, 85, 247, 0.32);
+  --ps-border: rgba(168, 85, 247, 0.55);
+  --ps-accent: #f3e8ff;
 }
 
 .playstyle-grid__cell[data-style='FISH'] {
@@ -3426,10 +3674,24 @@ body.tooltips-disabled .inline-tip {
   --ps-accent: #7c2d12;
 }
 
+:root[data-theme='dark'] .playstyle-grid__cell[data-style='FISH'],
+:root.theme-dark .playstyle-grid__cell[data-style='FISH'] {
+  --ps-color: rgba(249, 115, 22, 0.3);
+  --ps-border: rgba(249, 115, 22, 0.52);
+  --ps-accent: #ffedd5;
+}
+
 .playstyle-grid__cell[data-style='NIT'] {
   --ps-color: rgba(34, 197, 94, 0.2);
   --ps-border: rgba(34, 197, 94, 0.5);
   --ps-accent: #065f46;
+}
+
+:root[data-theme='dark'] .playstyle-grid__cell[data-style='NIT'],
+:root.theme-dark .playstyle-grid__cell[data-style='NIT'] {
+  --ps-color: rgba(34, 197, 94, 0.32);
+  --ps-border: rgba(34, 197, 94, 0.55);
+  --ps-accent: #bbf7d0;
 }
 
 .playstyle-grid__cell.is-active {
@@ -3437,6 +3699,14 @@ body.tooltips-disabled .inline-tip {
   background: linear-gradient(135deg, var(--ps-color, rgba(15, 23, 42, 0.06)) 0%, rgba(255, 255, 255, 0.92) 70%);
   box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
   color: var(--ps-accent, var(--text));
+}
+
+:root[data-theme='dark'] .playstyle-grid__cell.is-active,
+:root.theme-dark .playstyle-grid__cell.is-active {
+  background: linear-gradient(135deg, var(--ps-color, rgba(31, 45, 76, 0.45)) 0%, rgba(9, 14, 24, 0.92) 70%);
+  border-color: var(--ps-border, rgba(141, 183, 255, 0.5));
+  box-shadow: 0 18px 36px rgba(2, 6, 16, 0.55);
+  color: var(--ps-accent, var(--accent));
 }
 
 .playstyle-grid__cell.is-active .playstyle-grid__abbr {
@@ -3447,6 +3717,11 @@ body.tooltips-disabled .inline-tip {
   color: rgba(15, 23, 42, 0.7);
 }
 
+:root[data-theme='dark'] .playstyle-grid__cell.is-active .playstyle-grid__text,
+:root.theme-dark .playstyle-grid__cell.is-active .playstyle-grid__text {
+  color: rgba(226, 232, 255, 0.82);
+}
+
 .playstyle-grid__abbr {
   font-family: var(--font-display);
   font-size: 1.15rem;
@@ -3454,6 +3729,11 @@ body.tooltips-disabled .inline-tip {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text);
+}
+
+:root[data-theme='dark'] .playstyle-grid__cell.is-active .playstyle-grid__abbr,
+:root.theme-dark .playstyle-grid__cell.is-active .playstyle-grid__abbr {
+  color: var(--ps-accent, var(--accent));
 }
 
 .playstyle-grid__text {
@@ -3892,6 +4172,13 @@ body.tooltips-disabled .inline-tip {
   backdrop-filter: blur(6px);
 }
 
+:root[data-theme='dark'] .stage-controls,
+:root.theme-dark .stage-controls {
+  background: rgba(13, 20, 33, 0.88);
+  border: 1px solid rgba(71, 89, 128, 0.55);
+  box-shadow: 0 16px 34px rgba(2, 6, 16, 0.55);
+}
+
 @media (min-width: 720px) {
   .stage-controls {
     padding: 24px 28px;
@@ -3940,6 +4227,13 @@ body.tooltips-disabled .inline-tip {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
 }
 
+:root[data-theme='dark'] .stage-control,
+:root.theme-dark .stage-control {
+  background: rgba(15, 23, 42, 0.88);
+  border: 1px solid rgba(71, 89, 128, 0.5);
+  box-shadow: inset 0 1px 0 rgba(141, 183, 255, 0.08);
+}
+
 .stage-control--timeline {
   grid-column: 1 / -1;
   padding: 20px 22px;
@@ -3959,6 +4253,13 @@ body.tooltips-disabled .inline-tip {
   border: 1px solid rgba(148, 163, 184, 0.2);
   background: rgba(248, 250, 252, 0.72);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+:root[data-theme='dark'] .stage-summary,
+:root.theme-dark .stage-summary {
+  background: rgba(13, 20, 33, 0.85);
+  border: 1px solid rgba(71, 89, 128, 0.5);
+  box-shadow: inset 0 1px 0 rgba(141, 183, 255, 0.1);
 }
 
 .stage-summary__item {
@@ -4020,6 +4321,13 @@ body.tooltips-disabled .inline-tip {
   background: rgba(255, 255, 255, 0.96);
   box-shadow: 0 22px 44px rgba(15, 23, 42, 0.12);
   transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+:root[data-theme='dark'] .seat-card,
+:root.theme-dark .seat-card {
+  background: rgba(13, 20, 33, 0.92);
+  border: 1px solid rgba(71, 89, 128, 0.55);
+  box-shadow: 0 22px 44px rgba(2, 6, 16, 0.6);
 }
 
 .seat-card--active {
@@ -4343,6 +4651,12 @@ body.tooltips-disabled .inline-tip {
   min-height: 80px;
 }
 
+:root[data-theme='dark'] .insight,
+:root.theme-dark .insight {
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(71, 89, 128, 0.5);
+}
+
 .insight.is-empty {
   opacity: 0.65;
 }
@@ -4424,6 +4738,11 @@ body.tooltips-disabled .inline-tip {
   box-shadow: 0 14px 28px rgba(15, 23, 42, 0.18);
 }
 
+:root[data-theme='dark'] .replay-control-btn.is-pressing,
+:root.theme-dark .replay-control-btn.is-pressing {
+  box-shadow: 0 14px 28px rgba(2, 6, 16, 0.55);
+}
+
 .replay-control-btn.did-press::after {
   opacity: 0.55;
   transform: scale(1.25);
@@ -4458,6 +4777,13 @@ body.tooltips-disabled .inline-tip {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
+:root[data-theme='dark'] .replay-control,
+:root.theme-dark .replay-control {
+  background: rgba(13, 20, 33, 0.88);
+  border: 1px solid rgba(71, 89, 128, 0.5);
+  box-shadow: inset 0 1px 0 rgba(141, 183, 255, 0.08);
+}
+
 .replay-control__label {
   display: flex;
   justify-content: space-between;
@@ -4479,6 +4805,12 @@ body.tooltips-disabled .inline-tip {
   background: linear-gradient(90deg, #16a34a 0%, #16a34a calc(var(--progress) * 100%), rgba(148, 163, 184, 0.32) calc(var(--progress) * 100%), rgba(148, 163, 184, 0.32) 100%);
   outline: none;
   accent-color: #16a34a;
+}
+
+:root[data-theme='dark'] .replay-control__range,
+:root.theme-dark .replay-control__range {
+  background: linear-gradient(90deg, #4ade80 0%, #4ade80 calc(var(--progress) * 100%), rgba(71, 89, 128, 0.5) calc(var(--progress) * 100%), rgba(71, 89, 128, 0.5) 100%);
+  accent-color: #4ade80;
 }
 
 .replay-control__range::-webkit-slider-runnable-track {


### PR DESCRIPTION
## Summary
- darken the sticky header, footer, and navigation links in dark mode while keeping the PokerBench badge visible
- restyle the Elo dashboard card, filters, and company sort controls for a cohesive dark palette
- refresh bot playstyle badges, grid cells, and replay/stage panels with richer dark mode surfaces

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d056d39468832d81cf6a8f74315f84