### PR TITLE
Remove hero logos and improve history status contrast

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -4046,6 +4046,12 @@ body.tooltips-disabled .inline-tip {
   color: #1f2937;
 }
 
+:root[data-theme='dark'] .history-status--done,
+:root.theme-dark .history-status--done {
+  background: rgba(148, 163, 184, 0.22);
+  color: #e2e8f0;
+}
+
 .history-table__actions {
   text-align: right;
 }

--- a/server/web/elo.html
+++ b/server/web/elo.html
@@ -1198,9 +1198,6 @@
       <div class="elo-card__header">
         <div class="elo-card__intro">
           <div class="elo-card__brand">
-            <span class="elo-card__logo logo-badge logo-badge--md">
-              <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
-            </span>
             <div class="elo-card__heading">
               <h1>Elo Over Time</h1>
               <div class="muted">End-of-match Elo per bot across all duels.</div>

--- a/server/web/history.html
+++ b/server/web/history.html
@@ -306,9 +306,6 @@
   <main class="page-content">
     <div class="wrap wrap--wide">
       <div class="history-hero">
-        <a class="history-hero__logo" href="/web/replay.html" aria-label="PokerBench latest match">
-          <img src="/web/img/pokerBenchlogo.svg" alt="PokerBench logo"/>
-        </a>
         <div class="history-hero__body">
           <h1>Match History</h1>
           <div class="muted">Select a match to watch its replay.</div>


### PR DESCRIPTION
## Summary
- remove the PokerBench badge from the match history hero and Elo overview header
- adjust the completed status pill colors so it remains legible in dark mode

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d060fb9f08832dbe7cb3e8636d307e