### PR TITLE
Fix dealer chip duplication in replay

### DIFF
--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -212,7 +212,7 @@
                   <span class="seat-card__role">Small blind</span>
                   <span class="seat-card__name" id="sbName">SB</span>
                 </div>
-                <span class="seat-card__dealer" id="sbDealer" aria-hidden="true" hidden>D</span>
+                <span class="seat-card__dealer" id="dealerChip" aria-hidden="true" hidden>D</span>
               </header>
               <div class="seat-card__cards">
                 <div class="cards cards--hole" id="sb_hole" aria-label="Small blind hole cards"></div>
@@ -257,7 +257,6 @@
                   <span class="seat-card__role">Big blind</span>
                   <span class="seat-card__name" id="bbName">BB</span>
                 </div>
-                <span class="seat-card__dealer" id="bbDealer" aria-hidden="true" hidden>D</span>
               </header>
               <div class="seat-card__cards">
                 <div class="cards cards--hole" id="bb_hole" aria-label="Big blind hole cards"></div>

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -430,27 +430,28 @@ const ReplayPage = (() => {
     const prevSeat = state.prevDealerSeat;
     const shouldAnimate = seat && seat !== prevSeat;
 
-    const syncDealerChip = (el, isDealer) => {
-      if (!el) return;
-      if (isDealer) {
-        el.hidden = false;
-        el.setAttribute('aria-hidden', 'false');
+    const chip = els.dealerChip;
+    if (chip) {
+      if (seat) {
+        const targetHeader = seat === 'SB' ? els.sbHeader : els.bbHeader;
+        if (targetHeader && chip.parentElement !== targetHeader) {
+          targetHeader.appendChild(chip);
+        }
+        chip.hidden = false;
+        chip.setAttribute('aria-hidden', 'false');
         if (shouldAnimate) {
-          el.classList.remove('dealer-move');
-          void el.offsetWidth; // force reflow to restart animation
-          el.classList.add('dealer-move');
+          chip.classList.remove('dealer-move');
+          void chip.offsetWidth; // force reflow to restart animation
+          chip.classList.add('dealer-move');
         } else {
-          el.classList.remove('dealer-move');
+          chip.classList.remove('dealer-move');
         }
       } else {
-        el.hidden = true;
-        el.setAttribute('aria-hidden', 'true');
-        el.classList.remove('dealer-move');
+        chip.hidden = true;
+        chip.setAttribute('aria-hidden', 'true');
+        chip.classList.remove('dealer-move');
       }
-    };
-
-    syncDealerChip(els.sbDealer, seat === 'SB');
-    syncDealerChip(els.bbDealer, seat === 'BB');
+    }
 
     if (els.sbZone) {
       els.sbZone.classList.toggle('seat-card--dealer', seat === 'SB');
@@ -1102,8 +1103,9 @@ const ReplayPage = (() => {
     els.bbDelta = $('#bb_delta');
     els.sbName = $('#sbName');
     els.bbName = $('#bbName');
-    els.sbDealer = $('#sbDealer');
-    els.bbDealer = $('#bbDealer');
+    els.sbHeader = $('#sbZone .seat-card__header');
+    els.bbHeader = $('#bbZone .seat-card__header');
+    els.dealerChip = $('#dealerChip');
     els.sbEvAmount = $('#sb_ev_amount');
     els.bbEvAmount = $('#bb_ev_amount');
     els.sbEvValue = $('#sb_ev_value');


### PR DESCRIPTION
## Summary
- replace the replay layout's duplicate dealer chip markup with a single shared element
- update the replay script to reparent the dealer chip to the active seat header and preserve animation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d06f5f38b0832d8ece6f5423986a03