### PR TITLE
Add OpenAI API key support alongside OpenRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ docker compose up --build
 ```
 
 `docker compose` binds `./secrets` into every container. Supplying either
-`OPENROUTER_API_KEY` or `secrets/openrouter_api_key.txt` is enough for both the
-server and the duel runner.
+`OPENROUTER_API_KEY`/`secrets/openrouter_api_key.txt` or
+`OPENAI_API_KEY`/`secrets/openai_api_key.txt` is enough for both the server and
+the duel runner.
 
 The server becomes available at [http://localhost:8080/web/leaderboard.html](http://localhost:8080/web/leaderboard.html).
 `docker compose` also spins up:
@@ -95,13 +96,15 @@ The server becomes available at [http://localhost:8080/web/leaderboard.html](htt
 
 ### Option B — Local Go
 
-Requirements: Go 1.21+, PostgreSQL 15+, and an OpenRouter API key.
+Requirements: Go 1.21+, PostgreSQL 15+, and either an OpenRouter or OpenAI API
+key.
 
 ```bash
 # 1) install dependencies
 go mod download
 
 # 2) set environment (either export or place in a local .env)
+# (OPENROUTER_API_KEY shown; OPENAI_API_KEY also works.)
 export OPENROUTER_API_KEY=or-key-...
 export DATABASE_URL="postgres://poker:poker@localhost:5432/thunderdome?sslmode=disable"
 export OPENROUTER_MODEL_A="meta-llama/llama-3.1-70b-instruct"

--- a/server/llm/openrouter.go
+++ b/server/llm/openrouter.go
@@ -19,21 +19,34 @@ type apiConfig struct {
 }
 
 func resolveAPIConfig(model string) (apiConfig, error) {
+	trimmedModel := strings.TrimSpace(model)
+	if trimmedModel == "" {
+		trimmedModel = firstNonEmpty(
+			os.Getenv("OPENROUTER_MODEL"),
+			os.Getenv("OPENAI_MODEL"),
+		)
+	}
+	if trimmedModel == "" {
+		return apiConfig{}, errors.New("model missing: set OPENROUTER_MODEL/OPENAI_MODEL or pass a value")
+	}
+
+	if key := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")); key != "" {
+		return resolveOpenRouterConfig(trimmedModel, key)
+	}
+	if key := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); key != "" {
+		return resolveOpenAIConfig(trimmedModel, key)
+	}
+
+	return apiConfig{}, errors.New("API key missing: set OPENROUTER_API_KEY or OPENAI_API_KEY (or provide the secrets file)")
+}
+
+func resolveOpenRouterConfig(model, key string) (apiConfig, error) {
 	cfg := apiConfig{
-		Model:        strings.TrimSpace(model),
+		APIKey:       key,
+		Model:        model,
+		HeaderName:   "Authorization",
+		HeaderPrefix: "Bearer ",
 		ExtraHeaders: map[string]string{},
-	}
-
-	if cfg.Model == "" {
-		cfg.Model = strings.TrimSpace(os.Getenv("OPENROUTER_MODEL"))
-	}
-	if cfg.Model == "" {
-		return apiConfig{}, errors.New("model missing: set OPENROUTER_MODEL or pass a value")
-	}
-
-	cfg.APIKey = strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY"))
-	if cfg.APIKey == "" {
-		return apiConfig{}, errors.New("API key missing: set OPENROUTER_API_KEY or provide secrets/openrouter_api_key.txt")
 	}
 
 	base := firstNonEmpty(
@@ -47,15 +60,14 @@ func resolveAPIConfig(model string) (apiConfig, error) {
 	cfg.BaseURL = strings.TrimRight(base, "/")
 
 	headerName := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY_HEADER"))
-	if headerName == "" {
-		headerName = "Authorization"
+	if headerName != "" {
+		cfg.HeaderName = headerName
 	}
-	prefix := os.Getenv("OPENROUTER_API_KEY_PREFIX")
-	if headerName == "Authorization" && strings.TrimSpace(prefix) == "" {
-		prefix = "Bearer "
+	if prefix := os.Getenv("OPENROUTER_API_KEY_PREFIX"); prefix != "" {
+		cfg.HeaderPrefix = prefix
+	} else if cfg.HeaderName != "Authorization" {
+		cfg.HeaderPrefix = ""
 	}
-	cfg.HeaderName = headerName
-	cfg.HeaderPrefix = prefix
 
 	siteURL, err := resolveOpenRouterSiteURL()
 	if err != nil {
@@ -77,6 +89,28 @@ func resolveAPIConfig(model string) (apiConfig, error) {
 	if title != "" {
 		cfg.ExtraHeaders["X-Title"] = title
 	}
+
+	return cfg, nil
+}
+
+func resolveOpenAIConfig(model, key string) (apiConfig, error) {
+	cfg := apiConfig{
+		APIKey:       key,
+		Model:        model,
+		HeaderName:   "Authorization",
+		HeaderPrefix: "Bearer ",
+		ExtraHeaders: map[string]string{},
+	}
+
+	base := firstNonEmpty(
+		os.Getenv("OPENAI_API_BASE"),
+		os.Getenv("OPENAI_BASE_URL"),
+	)
+	base = strings.TrimSpace(base)
+	if base == "" {
+		base = "https://api.openai.com/v1"
+	}
+	cfg.BaseURL = strings.TrimRight(base, "/")
 
 	return cfg, nil
 }

--- a/server/llm/openrouter_test.go
+++ b/server/llm/openrouter_test.go
@@ -83,3 +83,31 @@ func TestResolveAPIConfigSiteURLLocalhost(t *testing.T) {
 		t.Fatalf("unexpected Referer: %q", got)
 	}
 }
+
+func TestResolveAPIConfigOpenAI(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("OPENROUTER_MODEL", "")
+	t.Setenv("OPENAI_API_KEY", "openai-test-key")
+	t.Setenv("OPENAI_API_BASE", "https://api.example.com/v42")
+	t.Setenv("OPENAI_MODEL", "gpt-4o-mini")
+
+	cfg, err := resolveAPIConfig("")
+	if err != nil {
+		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	if cfg.Model != "gpt-4o-mini" {
+		t.Fatalf("unexpected model: %q", cfg.Model)
+	}
+	if cfg.BaseURL != "https://api.example.com/v42" {
+		t.Fatalf("unexpected OpenAI base URL: %q", cfg.BaseURL)
+	}
+	if cfg.HeaderName != "Authorization" {
+		t.Fatalf("unexpected header name: %q", cfg.HeaderName)
+	}
+	if cfg.HeaderPrefix != "Bearer " {
+		t.Fatalf("unexpected header prefix: %q", cfg.HeaderPrefix)
+	}
+	if len(cfg.ExtraHeaders) != 0 {
+		t.Fatalf("OpenAI config should not include extra headers: %+v", cfg.ExtraHeaders)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -101,29 +101,41 @@ func sub(title string)      { fmt.Printf("%s %s\n", dim("•"), bold(title)) }
 //
 
 // The loader looks for pre-exported env vars first, then falls back to common
-// file hints. Only OpenRouter credentials are considered.
+// file hints. Both OpenRouter and OpenAI secrets are supported.
 func loadAPIKeyFromSecret() {
-	setOpenRouter := func(raw string) bool {
+	setKey := func(envKey, raw string, defaults ...string) bool {
 		raw = strings.TrimSpace(raw)
 		if raw == "" {
 			return false
 		}
-		os.Setenv("OPENROUTER_API_KEY", raw)
-		if strings.TrimSpace(os.Getenv("OPENROUTER_API_BASE")) == "" &&
-			strings.TrimSpace(os.Getenv("OPENROUTER_BASE_URL")) == "" {
-			os.Setenv("OPENROUTER_API_BASE", "https://openrouter.ai/api/v1")
+		os.Setenv(envKey, raw)
+		if len(defaults) >= 2 {
+			baseEnv, fallback := defaults[0], defaults[1]
+			skip := false
+			for _, alt := range defaults[2:] {
+				if strings.TrimSpace(os.Getenv(alt)) != "" {
+					skip = true
+					break
+				}
+			}
+			if !skip && strings.TrimSpace(os.Getenv(baseEnv)) == "" {
+				os.Setenv(baseEnv, fallback)
+			}
 		}
 		return true
 	}
 
-	if setOpenRouter(os.Getenv("OPENROUTER_API_KEY")) {
-		return
+	if key := os.Getenv("OPENROUTER_API_KEY"); key != "" {
+		setKey("OPENROUTER_API_KEY", key, "OPENROUTER_API_BASE", "https://openrouter.ai/api/v1", "OPENROUTER_BASE_URL")
+	}
+	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
+		setKey("OPENAI_API_KEY", key, "OPENAI_API_BASE", "https://api.openai.com/v1", "OPENAI_BASE_URL")
 	}
 
-	tryPaths := func(paths []string) bool {
+	tryPaths := func(paths []string, setter func(string) bool) bool {
 		for _, path := range paths {
 			if b, err := os.ReadFile(path); err == nil {
-				if setOpenRouter(string(b)) {
+				if setter(string(b)) {
 					return true
 				}
 			}
@@ -131,24 +143,45 @@ func loadAPIKeyFromSecret() {
 		return false
 	}
 
-	var openrouterPaths []string
-	if p := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY_FILE")); p != "" {
-		openrouterPaths = append(openrouterPaths, p)
-	}
-	openrouterPaths = append(openrouterPaths,
-		"./secrets/openrouter_api_key.txt",
-		"server/openrouter_api_key.txt",
-		"./server/openrouter_api_key.txt",
-		"./openrouter_api_key.txt",
-		"/app/secrets/openrouter_api_key.txt",
-		"/app/server/openrouter_api_key.txt",
-		"/run/secrets/openrouter_api_key",
-	)
+	if strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")) == "" {
+		var openrouterPaths []string
+		if p := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY_FILE")); p != "" {
+			openrouterPaths = append(openrouterPaths, p)
+		}
+		openrouterPaths = append(openrouterPaths,
+			"./secrets/openrouter_api_key.txt",
+			"server/openrouter_api_key.txt",
+			"./server/openrouter_api_key.txt",
+			"./openrouter_api_key.txt",
+			"/app/secrets/openrouter_api_key.txt",
+			"/app/server/openrouter_api_key.txt",
+			"/run/secrets/openrouter_api_key",
+		)
 
-	if tryPaths(openrouterPaths) {
-		return
+		tryPaths(openrouterPaths, func(raw string) bool {
+			return setKey("OPENROUTER_API_KEY", raw, "OPENROUTER_API_BASE", "https://openrouter.ai/api/v1", "OPENROUTER_BASE_URL")
+		})
 	}
 
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
+		var openaiPaths []string
+		if p := strings.TrimSpace(os.Getenv("OPENAI_API_KEY_FILE")); p != "" {
+			openaiPaths = append(openaiPaths, p)
+		}
+		openaiPaths = append(openaiPaths,
+			"./secrets/openai_api_key.txt",
+			"server/openai_api_key.txt",
+			"./server/openai_api_key.txt",
+			"./openai_api_key.txt",
+			"/app/secrets/openai_api_key.txt",
+			"/app/server/openai_api_key.txt",
+			"/run/secrets/openai_api_key",
+		)
+
+		tryPaths(openaiPaths, func(raw string) bool {
+			return setKey("OPENAI_API_KEY", raw, "OPENAI_API_BASE", "https://api.openai.com/v1", "OPENAI_BASE_URL")
+		})
+	}
 }
 
 func mustEnv(keys ...string) {
@@ -157,6 +190,16 @@ func mustEnv(keys ...string) {
 			log.Fatalf("Missing required env var %s. Put it in .env (dev) or set it on the host (prod).", k)
 		}
 	}
+}
+
+func mustHaveAPIKey() {
+	if strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")) != "" {
+		return
+	}
+	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != "" {
+		return
+	}
+	log.Fatal("Missing required API key. Set OPENROUTER_API_KEY or OPENAI_API_KEY (or place the secret file).")
 }
 func getenv(k, def string) string {
 	if v := os.Getenv(k); v != "" {
@@ -210,7 +253,7 @@ func main() {
 
 	// Only require the key when not doing a pure DB migrate
 	if !migrate {
-		mustEnv("OPENROUTER_API_KEY")
+		mustHaveAPIKey()
 	}
 
 	gracefulOnly := !asBool(os.Getenv("STOP_IMMEDIATE"))


### PR DESCRIPTION
## Summary
- allow the LLM client to resolve configuration from either OpenRouter or OpenAI API keys and models
- teach the bootstrap loader to pull OpenAI secrets from standard files and relax the runtime API-key requirement accordingly
- document the new OpenAI option and add unit coverage for the OpenAI configuration path

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d06de45b0c832d86168e2cab8c6575