### PR TITLE
Address lint issues in LLM client and server code

### DIFF
--- a/server/llm/client.go
+++ b/server/llm/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/textproto"
 	"os"
@@ -96,9 +97,13 @@ func PingTextWithOpts(ctx context.Context, model, system, user string, opts Ping
 		}
 
 		var buf bytes.Buffer
-		_, _ = buf.ReadFrom(resp.Body)
+		if _, err := buf.ReadFrom(resp.Body); err != nil {
+			return "", fmt.Errorf("read chat response: %w", err)
+		}
 		body := buf.Bytes()
-		resp.Body.Close()
+		if cerr := resp.Body.Close(); cerr != nil {
+			log.Printf("llm: closing response body: %v", cerr)
+		}
 
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			var cc struct {

--- a/server/llm/client_test.go
+++ b/server/llm/client_test.go
@@ -7,12 +7,23 @@ import (
 
 func TestSetHeaderPreserveCase(t *testing.T) {
 	hdr := http.Header{}
-	setHeaderPreserveCase(hdr, "HTTP-Referer", "https://example.com/app")
-	if vals := hdr["HTTP-Referer"]; len(vals) != 1 || vals[0] != "https://example.com/app" {
-		t.Fatalf("expected HTTP-Referer slice to be preserved, got %+v", vals)
+	const rawKey = "X-HTTP-Referer"
+	setHeaderPreserveCase(hdr, rawKey, "https://example.com/app")
+	canonical := http.CanonicalHeaderKey(rawKey)
+	found := false
+	for k, vals := range hdr {
+		if k == rawKey {
+			found = true
+			if len(vals) != 1 || vals[0] != "https://example.com/app" {
+				t.Fatalf("expected %s slice to be preserved, got %+v", rawKey, vals)
+			}
+		}
+		if canonical != rawKey && k == canonical {
+			t.Fatalf("unexpected canonical header variant present: %+v", hdr)
+		}
 	}
-	if _, exists := hdr["Http-Referer"]; exists {
-		t.Fatalf("unexpected canonical header variant present: %+v", hdr)
+	if !found {
+		t.Fatalf("expected to find %s key in header map", rawKey)
 	}
 
 	setHeaderPreserveCase(hdr, "Referer", "https://example.com/app")

--- a/server/main.go
+++ b/server/main.go
@@ -108,7 +108,10 @@ func loadAPIKeyFromSecret() {
 		if raw == "" {
 			return false
 		}
-		os.Setenv(envKey, raw)
+		if err := os.Setenv(envKey, raw); err != nil {
+			log.Printf("failed to set %s: %v", envKey, err)
+			return false
+		}
 		if len(defaults) >= 2 {
 			baseEnv, fallback := defaults[0], defaults[1]
 			skip := false
@@ -119,7 +122,9 @@ func loadAPIKeyFromSecret() {
 				}
 			}
 			if !skip && strings.TrimSpace(os.Getenv(baseEnv)) == "" {
-				os.Setenv(baseEnv, fallback)
+				if err := os.Setenv(baseEnv, fallback); err != nil {
+					log.Printf("failed to set %s: %v", baseEnv, err)
+				}
 			}
 		}
 		return true
@@ -462,9 +467,11 @@ Rules:
 			maxTok = &n
 		}
 	}
-	useToolsEnv := strings.TrimSpace(os.Getenv("USE_TOOLS"))
 	useTools := true
-	if useToolsEnv != "" && !(useToolsEnv == "1" || strings.EqualFold(useToolsEnv, "true") || strings.EqualFold(useToolsEnv, "yes")) {
+	if useToolsEnv := strings.TrimSpace(os.Getenv("USE_TOOLS")); useToolsEnv != "" &&
+		useToolsEnv != "1" &&
+		!strings.EqualFold(useToolsEnv, "true") &&
+		!strings.EqualFold(useToolsEnv, "yes") {
 		useTools = false
 	}
 	if useTools {
@@ -1457,15 +1464,16 @@ PAYOUT:
 	}
 
 	// exact chip flow (incl. split)
-	if winner == engine.SB {
+	switch winner {
+	case engine.SB:
 		sbP.Bank += pot - sbC.total
 		bbP.Bank -= bbC.total
 		sbP.Wins++
-	} else if winner == engine.BB {
+	case engine.BB:
 		bbP.Bank += pot - bbC.total
 		sbP.Bank -= sbC.total
 		bbP.Wins++
-	} else {
+	default:
 		half := pot / 2
 		rem := pot % 2
 		sbP.Bank += half + rem - sbC.total
@@ -1563,9 +1571,7 @@ func extractJSONObject(s string) string {
 			s = s[i+1:]
 		}
 	}
-	if strings.HasSuffix(s, "```") {
-		s = strings.TrimSuffix(s, "```")
-	}
+	s = strings.TrimSuffix(s, "```")
 	// Find first '{' and matching last '}'
 	start := strings.IndexByte(s, '{')
 	if start < 0 {
@@ -2283,8 +2289,14 @@ func runDuelMatrix(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 			a := parts[i]
 			b := parts[j]
 			log.Printf("Matrix duel: A=%s vs B=%s", a, b)
-			os.Setenv("OPENROUTER_MODEL_A", a)
-			os.Setenv("OPENROUTER_MODEL_B", b)
+			if err := os.Setenv("OPENROUTER_MODEL_A", a); err != nil {
+				log.Printf("failed to set OPENROUTER_MODEL_A: %v", err)
+				return
+			}
+			if err := os.Setenv("OPENROUTER_MODEL_B", b); err != nil {
+				log.Printf("failed to set OPENROUTER_MODEL_B: %v", err)
+				return
+			}
 			runDuel(checkStop, gracefulOnly, db)
 		}
 	}
@@ -2333,12 +2345,6 @@ func seatLabel(s engine.Seat) string {
 		return "BB"
 	}
 	return ""
-}
-func stackOf(h *engine.Hand, seat engine.Seat) int {
-	if seat == engine.SB {
-		return h.SB.Stack
-	}
-	return h.BB.Stack
 }
 func handScore(w engine.Seat, aWasSB bool) (sa, sb float64) {
 	switch w {

--- a/server/router.go
+++ b/server/router.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"log"
 	"net/http"
 	"sort"
 	"strconv"
@@ -570,8 +571,6 @@ func Router(db *store.DB) http.Handler {
 			style = "FISH"
 		case raisePct >= 22 && callPct <= 35 && foldPct <= 50:
 			style = "TAG"
-		default:
-			style = "TAG"
 		}
 
 		writeJSON(w, map[string]any{
@@ -647,14 +646,27 @@ func Router(db *store.DB) http.Handler {
 		}
 
 		enc := json.NewEncoder(w)
-		send := func(rows []Row) {
+		send := func(rows []Row) bool {
 			for _, r := range rows {
-				w.Write([]byte("event: action\n"))
-				w.Write([]byte("data: "))
-				_ = enc.Encode(r)
-				w.Write([]byte("\n"))
+				if _, err := w.Write([]byte("event: action\n")); err != nil {
+					log.Printf("sse write event: %v", err)
+					return false
+				}
+				if _, err := w.Write([]byte("data: ")); err != nil {
+					log.Printf("sse write data prefix: %v", err)
+					return false
+				}
+				if err := enc.Encode(r); err != nil {
+					log.Printf("sse encode row: %v", err)
+					return false
+				}
+				if _, err := w.Write([]byte("\n")); err != nil {
+					log.Printf("sse write newline: %v", err)
+					return false
+				}
 			}
 			flusher.Flush()
+			return true
 		}
 
 		// tail loop
@@ -694,7 +706,9 @@ func Router(db *store.DB) http.Handler {
 				}
 				rows.Close()
 				if len(batch) > 0 {
-					send(batch)
+					if !send(batch) {
+						return
+					}
 				}
 			}
 		}

--- a/server/stats_extra_test.go
+++ b/server/stats_extra_test.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"math"
-	mrand "math/rand"
 	"testing"
 )
 
 func TestPairedBootstrapCI(t *testing.T) {
 	deltas := []float64{-5, -2.5, 0, 2.5, 5}
-	mrand.Seed(123)
 	mean, lo, hi := PairedBootstrapCI(deltas, 2000, 0.05)
 	if math.Abs(mean-0) > 1e-9 {
 		t.Fatalf("expected mean 0, got %f", mean)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"errors"
+	"log"
 	"sort"
 	"strings"
 
@@ -364,7 +365,11 @@ func (db *DB) InsertParticipantsAndTallies(
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback(ctx) // safe if already committed
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil && !errors.Is(err, pgx.ErrTxClosed) {
+			log.Printf("tx rollback: %v", err)
+		}
+	}()
 
 	// participants
 	var reAParam any


### PR DESCRIPTION
## Summary
- handle response body errors in the LLM client and tighten header tests
- check env var writes, simplify payout logic, and abort duel matrix runs when env setup fails
- report SSE write failures, include style labels in bot stats, and log failed rollbacks

## Testing
- golangci-lint run ./...
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0795e1f28832d853cf87a3eb4d890