### PR TITLE
Log banks in action logs and replay

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -1225,6 +1225,7 @@ func playHandMatch(
 				}
 				sbStack, bbStack := h.SB.Stack, h.BB.Stack
 				sbCom, bbCom := h.SB.Committed, h.BB.Committed
+				sbBank, bbBank := sbP.Bank, bbP.Bank
 				sbHole := []string{}
 				bbHole := []string{}
 				if len(h.SB.Hole) == 2 {
@@ -1239,7 +1240,7 @@ func playHandMatch(
 					potOdds = float64(toCall) / float64(denom)
 				}
 				_ = db.InsertActionLog(context.Background(), matchID, pairIndex, h.ID, s, curLabel, action, amount,
-					h.Pot, h.CurBet, toCall, minTo, maxTo, sbStack, bbStack, sbCom, bbCom, boardNow, sbHole, bbHole, potOdds, potOdds)
+					h.Pot, h.CurBet, toCall, minTo, maxTo, sbStack, bbStack, sbCom, bbCom, sbBank, bbBank, boardNow, sbHole, bbHole, potOdds, potOdds)
 			}
 
 			// logging adornments
@@ -1497,6 +1498,30 @@ PAYOUT:
 		fmt.Printf("%s %s %s | %s\n", good("Winner by fold →"), seatTag(winner), good(fmt.Sprintf("(%s)", winModel)), potTag(pot))
 	}
 	fmt.Printf("%s %s:%d  %s:%d\n\n", bold("Seat banks →"), cyan("SB"), sbP.Bank, warn("BB"), bbP.Bank)
+
+	if db != nil && matchID != 0 {
+		boardNow := make([]string, 0, len(h.Board))
+		for _, c := range h.Board {
+			if s := c.String(); s != "" {
+				boardNow = append(boardNow, s)
+			}
+		}
+		sbHole := []string{}
+		bbHole := []string{}
+		if len(h.SB.Hole) == 2 {
+			sbHole = []string{h.SB.Hole[0].String(), h.SB.Hole[1].String()}
+		}
+		if len(h.BB.Hole) == 2 {
+			bbHole = []string{h.BB.Hole[0].String(), h.BB.Hole[1].String()}
+		}
+		actorLabel := sbP.Label
+		if winner == engine.BB {
+			actorLabel = bbP.Label
+		}
+		_ = db.InsertActionLog(context.Background(), matchID, pairIndex, h.ID, "summary", actorLabel, "hand_complete", nil,
+			pot, 0, 0, 0, 0, h.SB.Stack, h.BB.Stack, 0, 0, sbP.Bank, bbP.Bank,
+			boardNow, sbHole, bbHole, 0, 0)
+	}
 
 	// deltas (this is what your callers use)
 	deltaSB := sbP.Bank - startSB

--- a/server/router.go
+++ b/server/router.go
@@ -637,6 +637,8 @@ func Router(db *store.DB) http.Handler {
 			BBStack     int       `json:"bb_stack"`
 			SBCommitted int       `json:"sb_committed"`
 			BBCommitted int       `json:"bb_committed"`
+			SBBank      int       `json:"sb_bank"`
+			BBBank      int       `json:"bb_bank"`
 			Board       []string  `json:"board"`
 			SBHole      []string  `json:"sb_hole"`
 			BBHole      []string  `json:"bb_hole"`
@@ -1172,6 +1174,8 @@ func Router(db *store.DB) http.Handler {
 			BBStack     int       `json:"bb_stack"`
 			SBCommitted int       `json:"sb_committed"`
 			BBCommitted int       `json:"bb_committed"`
+			SBBank      int       `json:"sb_bank"`
+			BBBank      int       `json:"bb_bank"`
 			Board       []string  `json:"board"`
 			SBHole      []string  `json:"sb_hole"`
 			BBHole      []string  `json:"bb_hole"`
@@ -1193,6 +1197,7 @@ func Router(db *store.DB) http.Handler {
             SELECT a.id, a.pair_index, a.hand_id, a.street, a.actor_label, a.action, a.amount,
                    a.pot, a.cur_bet, a.to_call, a.min_raise_to, a.max_raise_to,
                    a.sb_stack, a.bb_stack, a.sb_committed, a.bb_committed,
+                   a.sb_bank, a.bb_bank,
                    a.board, a.sb_hole, a.bb_hole, a.pot_odds, a.required_equity, a.created_at,
                    e.solver, e.solver_version, e.best_action, e.best_amount_to, e.ev_gap_bb, e.correctness_prob, e.is_top_action
               FROM action_logs a
@@ -1211,6 +1216,7 @@ func Router(db *store.DB) http.Handler {
 			if err := rows.Scan(&r.ID, &r.PairIndex, &r.HandID, &r.Street, &r.ActorLabel, &r.Action, &r.Amount,
 				&r.Pot, &r.CurBet, &r.ToCall, &r.MinRaiseTo, &r.MaxRaiseTo,
 				&r.SBStack, &r.BBStack, &r.SBCommitted, &r.BBCommitted,
+				&r.SBBank, &r.BBBank,
 				&r.Board, &r.SBHole, &r.BBHole, &r.PotOdds, &r.RequiredEq, &r.CreatedAt,
 				&r.Solver, &r.SolverVersion, &r.EvalBestAction, &r.EvalBestTo, &r.EvalGapBB, &r.EvalCorrectProb, &r.EvalIsTop); err != nil {
 				http.Error(w, err.Error(), 500)
@@ -1278,36 +1284,61 @@ func Router(db *store.DB) http.Handler {
 			}
 			return nil
 		}
+		winnerFromFold := func(r Row) *string {
+			if !strings.EqualFold(r.Action, "fold") || r.ActorLabel == "" {
+				return nil
+			}
+			actor := strings.ToUpper(r.ActorLabel)
+			aIsSB := strings.HasSuffix(strings.ToUpper(r.HandID), "A")
+			var seat string
+			switch actor {
+			case "A":
+				if aIsSB {
+					seat = "BB"
+				} else {
+					seat = "SB"
+				}
+			case "B":
+				if aIsSB {
+					seat = "SB"
+				} else {
+					seat = "BB"
+				}
+			case "SB":
+				seat = "BB"
+			case "BB":
+				seat = "SB"
+			}
+			if seat == "" {
+				return nil
+			}
+			return &seat
+		}
 		for idx := range out {
 			isLast := idx == len(out)-1
 			boundary := isLast || out[idx+1].HandID != out[idx].HandID
 			if !boundary {
 				continue
 			}
-			// Prefer showdown if available
+			// Prefer showdown from the final row
 			if ws := computeShowdown(out[idx]); ws != nil {
 				out[idx].WinnerSeat = ws
 				continue
 			}
-			// Fold fallback: last action was a fold -> winner is other label mapped by hand suffix
-			r := out[idx]
-			if strings.EqualFold(r.Action, "fold") && r.ActorLabel != "" {
-				aIsSB := strings.HasSuffix(strings.ToUpper(r.HandID), "A")
-				var seat string
-				if r.ActorLabel == "A" { // A folded -> B wins
-					if aIsSB {
-						seat = "BB"
-					} else {
-						seat = "SB"
-					}
-				} else { // B folded -> A wins
-					if aIsSB {
-						seat = "SB"
-					} else {
-						seat = "BB"
-					}
+			// Try to infer from previous action in the same hand (for summaries)
+			if idx > 0 && out[idx-1].HandID == out[idx].HandID {
+				prev := out[idx-1]
+				if ws := computeShowdown(prev); ws != nil {
+					out[idx].WinnerSeat = ws
+					continue
 				}
-				out[idx].WinnerSeat = &seat
+				if ws := winnerFromFold(prev); ws != nil {
+					out[idx].WinnerSeat = ws
+					continue
+				}
+			}
+			if ws := winnerFromFold(out[idx]); ws != nil {
+				out[idx].WinnerSeat = ws
 			}
 		}
 		writeJSON(w, map[string]any{"rows": out})

--- a/server/store/schema.sql
+++ b/server/store/schema.sql
@@ -202,6 +202,8 @@ CREATE TABLE IF NOT EXISTS action_logs (
   bb_stack       INT NOT NULL,
   sb_committed   INT NOT NULL,
   bb_committed   INT NOT NULL,
+  sb_bank        INT NOT NULL DEFAULT 0,
+  bb_bank        INT NOT NULL DEFAULT 0,
   board          TEXT[] NOT NULL DEFAULT '{}',
   sb_hole        TEXT[] NOT NULL DEFAULT '{}',
   bb_hole        TEXT[] NOT NULL DEFAULT '{}',
@@ -222,6 +224,10 @@ ALTER TABLE action_logs
   ADD COLUMN IF NOT EXISTS pot_odds REAL NOT NULL DEFAULT 0;
 ALTER TABLE action_logs
   ADD COLUMN IF NOT EXISTS required_equity REAL NOT NULL DEFAULT 0;
+ALTER TABLE action_logs
+  ADD COLUMN IF NOT EXISTS sb_bank INT NOT NULL DEFAULT 0;
+ALTER TABLE action_logs
+  ADD COLUMN IF NOT EXISTS bb_bank INT NOT NULL DEFAULT 0;
 
 -- =========================
 -- MATCH PAIR DELTAS (bb/100 per mirrored pair)

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -560,6 +560,7 @@ func (db *DB) InsertActionLog(
 	amount *int,
 	pot, curBet, toCall, minTo, maxTo int,
 	sbStack, bbStack, sbCommitted, bbCommitted int,
+	sbBank, bbBank int,
 	board []string,
 	sbHole []string,
 	bbHole []string,
@@ -576,6 +577,7 @@ func (db *DB) InsertActionLog(
             actor_label, action, amount,
             pot, cur_bet, to_call, min_raise_to, max_raise_to,
             sb_stack, bb_stack, sb_committed, bb_committed,
+            sb_bank, bb_bank,
             board, sb_hole, bb_hole,
             pot_odds, required_equity
         ) VALUES (
@@ -583,14 +585,16 @@ func (db *DB) InsertActionLog(
             $5,$6,$7,
             $8,$9,$10,$11,$12,
             $13,$14,$15,$16,
-            $17,$18,$19,
-            $20,$21
+            $17,$18,
+            $19,$20,$21,
+            $22,$23
         )
     `,
 		matchID, pairIndex, handID, street,
 		actorLabel, action, amt,
 		pot, curBet, toCall, minTo, maxTo,
 		sbStack, bbStack, sbCommitted, bbCommitted,
+		sbBank, bbBank,
 		board, sbHole, bbHole,
 		potOdds, requiredEquity,
 	)

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -26,6 +26,7 @@ const ReplayPage = (() => {
     prevDealerSeat: null,
     winnerSeat: null,
     startStacks: { SB: 0, BB: 0 },
+    startBanks: { SB: Number.NaN, BB: Number.NaN },
     baseEquity: { SB: 0, BB: 0 },
     actionButtons: [],
   };
@@ -343,6 +344,8 @@ const ReplayPage = (() => {
 
   function describeActor(row) {
     if (!row) return '';
+    const actionName = String(row.action || '').toLowerCase();
+    if (actionName === 'hand_complete') return '';
     const seat = seatForLabel(row.actor_label, row);
     const name = labelName(row.actor_label);
     if (!name) return '';
@@ -351,6 +354,14 @@ const ReplayPage = (() => {
 
   function fmtAction(row) {
     if (!row) return '—';
+    const actionName = String(row.action || '').toLowerCase();
+    if (actionName === 'hand_complete') {
+      const winner = String(row?.winner_seat || '').toUpperCase();
+      if (winner === 'SB' || winner === 'BB') {
+        return `Hand complete — ${winner} wins`;
+      }
+      return 'Hand complete';
+    }
     const parts = [];
     const actor = describeActor(row);
     if (actor) parts.push(actor);
@@ -514,8 +525,25 @@ const ReplayPage = (() => {
     if (stackEl) {
       stackEl.textContent = fmtChips(Number.isFinite(stack) ? stack : 0);
     }
-    const base = state.startStacks[seatKey] ?? stack;
-    updateDeltaElement(deltaEl, Number.isFinite(stack) ? stack - base : 0, { precision: 0 });
+    const bank = Number(isSB ? row?.sb_bank : row?.bb_bank);
+    let baseBank = state.startBanks[seatKey];
+    const hasBank = Number.isFinite(bank);
+    if (!Number.isFinite(baseBank) && hasBank) {
+      baseBank = bank;
+      state.startBanks[seatKey] = bank;
+    }
+    if (deltaEl) {
+      if (hasBank && Number.isFinite(baseBank)) {
+        const delta = bank - baseBank;
+        const deltaText = fmtSigned(delta, '±0', 0);
+        deltaEl.textContent = `Bank ${fmtChips(bank)} (${deltaText})`;
+        deltaEl.classList.toggle('positive', delta > 0);
+        deltaEl.classList.toggle('negative', delta < 0);
+      } else {
+        deltaEl.textContent = 'Bank —';
+        deltaEl.classList.remove('positive', 'negative');
+      }
+    }
 
     const eq = computeEquity(row, seatKey);
     if (evAmountEl) {
@@ -689,7 +717,8 @@ const ReplayPage = (() => {
 
     updateInsights(row);
 
-    const actorSeat = seatForLabel(row.actor_label, row);
+    const actionName = String(row?.action || '').toLowerCase();
+    const actorSeat = actionName === 'hand_complete' ? null : seatForLabel(row.actor_label, row);
     updateSeatFocus(actorSeat);
   }
 
@@ -1046,6 +1075,9 @@ const ReplayPage = (() => {
     state.dealerSeat = 'SB';
     state.prevDealerSeat = null;
     state.actionButtons = [];
+    state.startStacks = { SB: 0, BB: 0 };
+    state.startBanks = { SB: Number.NaN, BB: Number.NaN };
+    state.baseEquity = { SB: 0, BB: 0 };
     updateDealerIndicator();
     updateWinnerGlow();
     renderEmptyActionList('Loading actions…');
@@ -1075,8 +1107,14 @@ const ReplayPage = (() => {
       return;
     }
     const first = state.rows[0];
-    state.startStacks.SB = Number(first?.sb_stack ?? 0);
-    state.startStacks.BB = Number(first?.bb_stack ?? 0);
+    const firstSbStack = Number(first?.sb_stack ?? 0);
+    const firstBbStack = Number(first?.bb_stack ?? 0);
+    state.startStacks.SB = Number.isFinite(firstSbStack) ? firstSbStack : 0;
+    state.startStacks.BB = Number.isFinite(firstBbStack) ? firstBbStack : 0;
+    const firstSbBank = Number(first?.sb_bank ?? firstSbStack);
+    const firstBbBank = Number(first?.bb_bank ?? firstBbStack);
+    state.startBanks.SB = Number.isFinite(firstSbBank) ? firstSbBank : state.startStacks.SB;
+    state.startBanks.BB = Number.isFinite(firstBbBank) ? firstBbBank : state.startStacks.BB;
     const startPot = Number(first?.pot ?? 0) / 2;
     state.baseEquity.SB = state.startStacks.SB + startPot;
     state.baseEquity.BB = state.startStacks.BB + startPot;


### PR DESCRIPTION
## Summary
- extend the action_logs schema to store SB/BB bank snapshots and persist them from InsertActionLog
- record a summary action after each hand so bankroll totals update alongside payouts
- expose the new bank fields through /api/match-logs and surface them in the replay UI as cumulative bank totals

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d09eb34230832daaac6a068883f50c