### PR TITLE
Remove OpenAI configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,9 @@ printf 'or-key-...' > secrets/openrouter_api_key.txt
 docker compose up --build
 ```
 
-`docker compose` binds `./secrets` into every container. Supplying either
-`OPENROUTER_API_KEY`/`secrets/openrouter_api_key.txt` or
-`OPENAI_API_KEY`/`secrets/openai_api_key.txt` is enough for both the server and
-the duel runner.
+`docker compose` binds `./secrets` into every container. Supplying
+`OPENROUTER_API_KEY` or `secrets/openrouter_api_key.txt` is enough for both the
+server and the duel runner.
 
 The server becomes available at [http://localhost:8080/web/leaderboard.html](http://localhost:8080/web/leaderboard.html).
 `docker compose` also spins up:
@@ -96,15 +95,13 @@ The server becomes available at [http://localhost:8080/web/leaderboard.html](htt
 
 ### Option B — Local Go
 
-Requirements: Go 1.21+, PostgreSQL 15+, and either an OpenRouter or OpenAI API
-key.
+Requirements: Go 1.21+, PostgreSQL 15+, and an OpenRouter API key.
 
 ```bash
 # 1) install dependencies
 go mod download
 
 # 2) set environment (either export or place in a local .env)
-# (OPENROUTER_API_KEY shown; OPENAI_API_KEY also works.)
 export OPENROUTER_API_KEY=or-key-...
 export DATABASE_URL="postgres://poker:poker@localhost:5432/thunderdome?sslmode=disable"
 export OPENROUTER_MODEL_A="meta-llama/llama-3.1-70b-instruct"
@@ -319,7 +316,7 @@ Use the leaderboard’s **Acc** column as a regression check whenever you tweak 
   git config core.autocrlf false
   git add --renormalize .
   ```
-- **Secret file missing:** Ensure `./secrets/openai_api_key.txt` or `./secrets/openrouter_api_key.txt` exists (one line with your key) or export the env var directly.
+- **Secret file missing:** Ensure `./secrets/openrouter_api_key.txt` exists (one line with your key) or export the env var directly.
 
 ---
 

--- a/server/llm/openrouter.go
+++ b/server/llm/openrouter.go
@@ -23,21 +23,17 @@ func resolveAPIConfig(model string) (apiConfig, error) {
 	if trimmedModel == "" {
 		trimmedModel = firstNonEmpty(
 			os.Getenv("OPENROUTER_MODEL"),
-			os.Getenv("OPENAI_MODEL"),
 		)
 	}
 	if trimmedModel == "" {
-		return apiConfig{}, errors.New("model missing: set OPENROUTER_MODEL/OPENAI_MODEL or pass a value")
+		return apiConfig{}, errors.New("model missing: set OPENROUTER_MODEL or pass a value")
 	}
 
 	if key := strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")); key != "" {
 		return resolveOpenRouterConfig(trimmedModel, key)
 	}
-	if key := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); key != "" {
-		return resolveOpenAIConfig(trimmedModel, key)
-	}
 
-	return apiConfig{}, errors.New("API key missing: set OPENROUTER_API_KEY or OPENAI_API_KEY (or provide the secrets file)")
+	return apiConfig{}, errors.New("API key missing: set OPENROUTER_API_KEY (or provide the secrets file)")
 }
 
 func resolveOpenRouterConfig(model, key string) (apiConfig, error) {
@@ -89,28 +85,6 @@ func resolveOpenRouterConfig(model, key string) (apiConfig, error) {
 	if title != "" {
 		cfg.ExtraHeaders["X-Title"] = title
 	}
-
-	return cfg, nil
-}
-
-func resolveOpenAIConfig(model, key string) (apiConfig, error) {
-	cfg := apiConfig{
-		APIKey:       key,
-		Model:        model,
-		HeaderName:   "Authorization",
-		HeaderPrefix: "Bearer ",
-		ExtraHeaders: map[string]string{},
-	}
-
-	base := firstNonEmpty(
-		os.Getenv("OPENAI_API_BASE"),
-		os.Getenv("OPENAI_BASE_URL"),
-	)
-	base = strings.TrimSpace(base)
-	if base == "" {
-		base = "https://api.openai.com/v1"
-	}
-	cfg.BaseURL = strings.TrimRight(base, "/")
 
 	return cfg, nil
 }

--- a/server/llm/openrouter_test.go
+++ b/server/llm/openrouter_test.go
@@ -1,6 +1,9 @@
 package llm
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestResolveAPIConfigDefaults(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
@@ -84,30 +87,24 @@ func TestResolveAPIConfigSiteURLLocalhost(t *testing.T) {
 	}
 }
 
-func TestResolveAPIConfigOpenAI(t *testing.T) {
+func TestResolveAPIConfigMissingKey(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "")
-	t.Setenv("OPENROUTER_MODEL", "")
-	t.Setenv("OPENAI_API_KEY", "openai-test-key")
-	t.Setenv("OPENAI_API_BASE", "https://api.example.com/v42")
-	t.Setenv("OPENAI_MODEL", "gpt-4o-mini")
+	t.Setenv("OPENROUTER_MODEL", "meta-llama/llama-3.1-70b-instruct")
 
-	cfg, err := resolveAPIConfig("")
-	if err != nil {
-		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	if _, err := resolveAPIConfig(""); err == nil {
+		t.Fatalf("expected error when OPENROUTER_API_KEY is missing")
+	} else if !strings.Contains(err.Error(), "OPENROUTER_API_KEY") {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Model != "gpt-4o-mini" {
-		t.Fatalf("unexpected model: %q", cfg.Model)
-	}
-	if cfg.BaseURL != "https://api.example.com/v42" {
-		t.Fatalf("unexpected OpenAI base URL: %q", cfg.BaseURL)
-	}
-	if cfg.HeaderName != "Authorization" {
-		t.Fatalf("unexpected header name: %q", cfg.HeaderName)
-	}
-	if cfg.HeaderPrefix != "Bearer " {
-		t.Fatalf("unexpected header prefix: %q", cfg.HeaderPrefix)
-	}
-	if len(cfg.ExtraHeaders) != 0 {
-		t.Fatalf("OpenAI config should not include extra headers: %+v", cfg.ExtraHeaders)
+}
+
+func TestResolveAPIConfigMissingModel(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("OPENROUTER_MODEL", "")
+
+	if _, err := resolveAPIConfig(""); err == nil {
+		t.Fatalf("expected error when OPENROUTER_MODEL is missing")
+	} else if !strings.Contains(err.Error(), "OPENROUTER_MODEL") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -101,7 +101,7 @@ func sub(title string)      { fmt.Printf("%s %s\n", dim("•"), bold(title)) }
 //
 
 // The loader looks for pre-exported env vars first, then falls back to common
-// file hints. Both OpenRouter and OpenAI secrets are supported.
+// file hints for OpenRouter secrets.
 func loadAPIKeyFromSecret() {
 	setKey := func(envKey, raw string, defaults ...string) bool {
 		raw = strings.TrimSpace(raw)
@@ -132,9 +132,6 @@ func loadAPIKeyFromSecret() {
 
 	if key := os.Getenv("OPENROUTER_API_KEY"); key != "" {
 		setKey("OPENROUTER_API_KEY", key, "OPENROUTER_API_BASE", "https://openrouter.ai/api/v1", "OPENROUTER_BASE_URL")
-	}
-	if key := os.Getenv("OPENAI_API_KEY"); key != "" {
-		setKey("OPENAI_API_KEY", key, "OPENAI_API_BASE", "https://api.openai.com/v1", "OPENAI_BASE_URL")
 	}
 
 	tryPaths := func(paths []string, setter func(string) bool) bool {
@@ -167,26 +164,6 @@ func loadAPIKeyFromSecret() {
 			return setKey("OPENROUTER_API_KEY", raw, "OPENROUTER_API_BASE", "https://openrouter.ai/api/v1", "OPENROUTER_BASE_URL")
 		})
 	}
-
-	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
-		var openaiPaths []string
-		if p := strings.TrimSpace(os.Getenv("OPENAI_API_KEY_FILE")); p != "" {
-			openaiPaths = append(openaiPaths, p)
-		}
-		openaiPaths = append(openaiPaths,
-			"./secrets/openai_api_key.txt",
-			"server/openai_api_key.txt",
-			"./server/openai_api_key.txt",
-			"./openai_api_key.txt",
-			"/app/secrets/openai_api_key.txt",
-			"/app/server/openai_api_key.txt",
-			"/run/secrets/openai_api_key",
-		)
-
-		tryPaths(openaiPaths, func(raw string) bool {
-			return setKey("OPENAI_API_KEY", raw, "OPENAI_API_BASE", "https://api.openai.com/v1", "OPENAI_BASE_URL")
-		})
-	}
 }
 
 func mustEnv(keys ...string) {
@@ -201,10 +178,7 @@ func mustHaveAPIKey() {
 	if strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY")) != "" {
 		return
 	}
-	if strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) != "" {
-		return
-	}
-	log.Fatal("Missing required API key. Set OPENROUTER_API_KEY or OPENAI_API_KEY (or place the secret file).")
+	log.Fatal("Missing required API key. Set OPENROUTER_API_KEY (or place the secret file).")
 }
 func getenv(k, def string) string {
 	if v := os.Getenv(k); v != "" {


### PR DESCRIPTION
## Summary
- drop the OPENAI secret detection and fatal messaging from the server bootstrap
- simplify the OpenRouter API resolver and update tests to cover missing key/model errors
- refresh the README so setup instructions only reference OpenRouter credentials

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0a722b650832da3f7f0ae7c8fb22b