### PR TITLE
Track LLM provider in API errors

### DIFF
--- a/server/llm/client.go
+++ b/server/llm/client.go
@@ -126,7 +126,14 @@ func PingTextWithOpts(ctx context.Context, model, system, user string, opts Ping
 			continue
 		}
 
-		return "", fmt.Errorf("openrouter http %d: %s", resp.StatusCode, truncate(string(body), 800))
+		provider := strings.TrimSpace(cfg.Provider)
+		if provider == "" {
+			provider = strings.TrimSpace(cfg.BaseURL)
+			if provider == "" {
+				provider = "llm provider"
+			}
+		}
+		return "", fmt.Errorf("%s http %d: %s", provider, resp.StatusCode, truncate(string(body), 800))
 	}
 
 	return "", errors.New("exhausted chat completion retries")

--- a/server/llm/client_test.go
+++ b/server/llm/client_test.go
@@ -1,7 +1,10 @@
 package llm
 
 import (
+	"context"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -73,5 +76,45 @@ func TestAdjustOpenRouterPayloadForRetryReasoning(t *testing.T) {
 	}
 	if adjustOpenRouterPayloadForRetry(payload, body, removed) {
 		t.Fatalf("second adjustment attempt should not trigger once removed")
+	}
+}
+
+func TestPingTextWithOptsErrorIncludesProviderOpenRouter(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("OPENAI_API_KEY", "")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("OPENROUTER_API_BASE", srv.URL)
+
+	_, err := PingTextWithOpts(context.Background(), "meta-llama/llama-3.1-70b-instruct", "", "", PingOptions{})
+	if err == nil {
+		t.Fatalf("expected error from ping")
+	}
+	if !strings.Contains(err.Error(), "openrouter http 500") {
+		t.Fatalf("expected error to mention openrouter provider, got %q", err)
+	}
+}
+
+func TestPingTextWithOptsErrorIncludesProviderOpenAI(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("OPENROUTER_MODEL", "")
+	t.Setenv("OPENAI_API_KEY", "openai-key")
+	t.Setenv("OPENAI_MODEL", "gpt-4o-mini")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("OPENAI_API_BASE", srv.URL)
+
+	_, err := PingTextWithOpts(context.Background(), "", "", "", PingOptions{})
+	if err == nil {
+		t.Fatalf("expected error from ping")
+	}
+	if !strings.Contains(err.Error(), "openai http 500") {
+		t.Fatalf("expected error to mention openai provider, got %q", err)
 	}
 }

--- a/server/llm/openrouter.go
+++ b/server/llm/openrouter.go
@@ -10,6 +10,7 @@ import (
 )
 
 type apiConfig struct {
+	Provider     string
 	APIKey       string
 	Model        string
 	BaseURL      string
@@ -42,6 +43,7 @@ func resolveAPIConfig(model string) (apiConfig, error) {
 
 func resolveOpenRouterConfig(model, key string) (apiConfig, error) {
 	cfg := apiConfig{
+		Provider:     "openrouter",
 		APIKey:       key,
 		Model:        model,
 		HeaderName:   "Authorization",
@@ -95,6 +97,7 @@ func resolveOpenRouterConfig(model, key string) (apiConfig, error) {
 
 func resolveOpenAIConfig(model, key string) (apiConfig, error) {
 	cfg := apiConfig{
+		Provider:     "openai",
 		APIKey:       key,
 		Model:        model,
 		HeaderName:   "Authorization",

--- a/server/llm/openrouter_test.go
+++ b/server/llm/openrouter_test.go
@@ -8,6 +8,9 @@ func TestResolveAPIConfigDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAPIConfig returned error: %v", err)
 	}
+	if cfg.Provider != "openrouter" {
+		t.Fatalf("unexpected provider: %q", cfg.Provider)
+	}
 	if cfg.BaseURL != "https://openrouter.ai/api/v1" {
 		t.Fatalf("unexpected default base URL: %q", cfg.BaseURL)
 	}
@@ -30,6 +33,9 @@ func TestResolveAPIConfigOverrides(t *testing.T) {
 	cfg, err := resolveAPIConfig("meta-llama/llama-3.1-70b-instruct")
 	if err != nil {
 		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	if cfg.Provider != "openrouter" {
+		t.Fatalf("unexpected provider: %q", cfg.Provider)
 	}
 	if cfg.BaseURL != "https://router.example.com/v1" {
 		t.Fatalf("unexpected base URL: %q", cfg.BaseURL)
@@ -60,6 +66,9 @@ func TestResolveAPIConfigSiteURLNormalization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveAPIConfig returned error: %v", err)
 	}
+	if cfg.Provider != "openrouter" {
+		t.Fatalf("unexpected provider: %q", cfg.Provider)
+	}
 	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != "https://app.example.com/bench" {
 		t.Fatalf("unexpected HTTP-Referer: %q", got)
 	}
@@ -74,6 +83,9 @@ func TestResolveAPIConfigSiteURLLocalhost(t *testing.T) {
 	cfg, err := resolveAPIConfig("meta-llama/llama-3.1-70b-instruct")
 	if err != nil {
 		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	if cfg.Provider != "openrouter" {
+		t.Fatalf("unexpected provider: %q", cfg.Provider)
 	}
 	want := "http://localhost:3000/ui"
 	if got := cfg.ExtraHeaders["HTTP-Referer"]; got != want {
@@ -94,6 +106,9 @@ func TestResolveAPIConfigOpenAI(t *testing.T) {
 	cfg, err := resolveAPIConfig("")
 	if err != nil {
 		t.Fatalf("resolveAPIConfig returned error: %v", err)
+	}
+	if cfg.Provider != "openai" {
+		t.Fatalf("unexpected provider: %q", cfg.Provider)
 	}
 	if cfg.Model != "gpt-4o-mini" {
 		t.Fatalf("unexpected model: %q", cfg.Model)


### PR DESCRIPTION
## Summary
- capture the selected provider in the LLM API configuration
- emit the provider name in PingText error messages
- cover provider labelling in resolver and PingText error unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d0a7262ce0832db7c415032eb39b99