### PR TITLE
Adjust replay insights grid to two rows

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -4672,7 +4672,19 @@ body.tooltips-disabled .inline-tip {
 .stage-insights {
   display: grid;
   gap: 16px;
-  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 1024px) {
+  .stage-insights {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .stage-insights {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .insight {


### PR DESCRIPTION
## Summary
- update the replay insights grid to use three columns on large screens so the cards form two rows
- add responsive breakpoints to gracefully collapse the grid to two or one columns on smaller viewports

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0abce64c0832d8049ef80f2099143