### PR TITLE
Document seed orchestration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ PORT=8080 AUTO_MIGRATE=1 ./ai-thunderdome
 
 Open [http://localhost:8080/web/leaderboard.html](http://localhost:8080/web/leaderboard.html) once the binary is running.
 
+### Seed orchestration
+
+The duel loop decides which mirrored deck to deal before every pair, letting you script deterministic blocks when benchmarking agents.
+
+1. **Pin the pseudo-random stream.** Export a numeric `DECK_SEED` (alongside `DUEL_SEEDS`) so successive runs replay the same mirrored sequence using the `seedStream` generator before each pair.
+2. **Load curated packs.** Set `SEEDPACK_PATH=/path/to/pack.json` (or `SEEDPACK` for the same path) to feed a JSON file such as `{"name":"stage-1","version":"1.0","seeds":[...numbers...]}`. The loader validates the file, computes its hash, and the duel loop iterates through each listed seed in order.
+3. **Chain stages.** Split a large evaluation into multiple pack files (`stage-1.json`, `stage-2.json`, …) or regenerate the pack between runs. Each block is consumed sequentially, so swapping in the next pack continues from the following seed block without rerunning prior pairs.
+
 ---
 
 ## Running Modes
@@ -195,6 +203,7 @@ Fine-tune duel behavior using environment variables:
 | --- | --- |
 | `SB`, `BB`, `START_STACK` | Configure blind sizes and initial stack depth. |
 | `DUEL_SEEDS` | Number of mirrored pairs per duel. (`DUEL_HANDS` can also be supplied; it is converted to seeds.) |
+| `DECK_SEED`, `SEEDPACK`, `SEEDPACK_PATH` | Fix the mirrored deck stream (`DECK_SEED`) or load a JSON file of explicit seeds (`SEEDPACK_PATH` / `SEEDPACK`) for reproducible or staged runs. |
 | `ELO_START`, `ELO_K`, `ELO_PER_HAND`, `ELO_WEIGHT_BY_POT` | Control Elo initialization and update cadence. |
 | `RAISE_ZERO_CALL_PROB` | Probability of probing when `to_call == 0` to reduce auto-check loops. |
 | `RAISE_FIRST_ZERO_CALL` | Force a raise on the first zero-to-call spot (0 disables). |
@@ -202,6 +211,8 @@ Fine-tune duel behavior using environment variables:
 | `USE_TOOLS` | Toggle tool usage in multi-turn chat completions. |
 | `MAX_SECONDS`, `STOP_FILE`, `STOP_IMMEDIATE` | Graceful shutdown controls for long-running benchmarks. |
 | `NO_COLOR`, `USE_COLOR`, `DEBUG` | CLI output formatting and verbose state dumps. |
+
+Set `DECK_SEED` when you need mirrored decks to replay exactly; point `SEEDPACK_PATH` (or `SEEDPACK`) at a JSON list of seeds to walk a curated set. The duel loop consumes each entry sequentially—replaying the same seed for both halves of a mirrored pair—so you can split long campaigns into predictable stages without repeating earlier cards.
 
 ---
 

--- a/compose.env.example
+++ b/compose.env.example
@@ -29,6 +29,10 @@ SB=50
 BB=100
 START_STACK=10000
 DUEL_SEEDS=5                   # mirrored pairs (1 pair = 2 hands)
+# Deterministic seed controls (optional)
+# DECK_SEED=123456789           # base for mirrored deck stream (falls back to crypto RNG)
+# SEEDPACK=./seedpacks/stage-1.json      # path to JSON list of explicit seeds (alias of SEEDPACK_PATH)
+# SEEDPACK_PATH=./seedpacks/stage-1.json # same as above; SEEDPACK_PATH takes precedence when both are set
 ELO_PER_HAND=1                 # 1=true, 0=false
 ELO_WEIGHT_BY_POT=1            # 1=true, 0=false
 


### PR DESCRIPTION
## Summary
- document `DECK_SEED`, `SEEDPACK`, and `SEEDPACK_PATH` in the configuration docs and explain how they support staged runs
- add a Quick Start subsection that walks through fixing deck seeds, loading seed packs, and chaining stages
- surface deterministic seed placeholders in `compose.env.example` for Docker setups

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d1b86a3dc8832d8c13b4f8c0d99cd0