### PR TITLE
Improve replay board layout and enhance insights

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -4372,9 +4372,9 @@ body.tooltips-disabled .inline-tip {
 
 .seat-card {
   position: relative;
-  display: grid;
-  grid-template-rows: auto auto auto 1fr;
-  gap: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   padding: 24px;
   border-radius: var(--radius-lg);
   border: 1px solid rgba(148, 163, 184, 0.2);
@@ -4523,7 +4523,6 @@ body.tooltips-disabled .inline-tip {
   border-radius: var(--radius-md);
   border: 1px solid rgba(148, 163, 184, 0.18);
   background: rgba(248, 250, 252, 0.82);
-  margin-top: auto;
 }
 
 :root[data-theme='dark'] .seat-card__ev,
@@ -4629,14 +4628,23 @@ body.tooltips-disabled .inline-tip {
 .board-display__cards {
   position: relative;
   z-index: 1;
-  gap: 18px;
-  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, var(--card-w)));
   justify-content: center;
-  flex-wrap: wrap;
-  row-gap: 28px;
-  max-width: calc((var(--card-w) * 3) + (18px * 2));
-  margin: 0 auto;
+  justify-items: center;
   align-content: center;
+  column-gap: 18px;
+  row-gap: 24px;
+  width: min(100%, calc((var(--card-w) * 3) + (18px * 2)));
+  margin: 0 auto;
+}
+
+.board-display__cards > *:nth-child(4) {
+  grid-column: 2;
+}
+
+.board-display__cards > *:nth-child(5) {
+  grid-column: 3;
 }
 
 .board-display__label {
@@ -4689,9 +4697,9 @@ body.tooltips-disabled .inline-tip {
   }
 
   .board-display__cards {
-    gap: 14px;
+    column-gap: 14px;
     row-gap: 20px;
-    max-width: calc((var(--card-w) * 3) + (14px * 2));
+    width: min(100%, calc((var(--card-w) * 3) + (14px * 2)));
   }
 }
 
@@ -4813,11 +4821,18 @@ body.tooltips-disabled .inline-tip {
 }
 
 .insight__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-size: var(--fs-0);
   text-transform: uppercase;
   letter-spacing: 0.14em;
   color: var(--muted);
   font-weight: 600;
+}
+
+.insight__label .inline-tip {
+  margin-left: 0;
 }
 
 .insight__value {

--- a/server/web/replay.html
+++ b/server/web/replay.html
@@ -288,27 +288,39 @@
 
           <div class="stage-insights" id="insightGrid">
             <div class="insight" id="insightPotOdds">
-              <span class="insight__label">Pot odds</span>
+              <span class="insight__label">Pot odds
+                <button class="inline-tip" type="button" data-tip="Share of the final pot you must invest to call. Compare it against your equity before calling." aria-label="Tip: pot odds definition">i</button>
+              </span>
               <span class="insight__value" id="potOdds">—</span>
             </div>
             <div class="insight" id="insightRequiredEq">
-              <span class="insight__label">Required equity</span>
+              <span class="insight__label">Required equity
+                <button class="inline-tip" type="button" data-tip="Minimum equity needed to break even on a call with the current pot odds." aria-label="Tip: required equity definition">i</button>
+              </span>
               <span class="insight__value" id="requiredEq">—</span>
             </div>
             <div class="insight" id="insightToCall">
-              <span class="insight__label">To call</span>
+              <span class="insight__label">To call
+                <button class="inline-tip" type="button" data-tip="Chip amount you must invest to match the current bet." aria-label="Tip: to call definition">i</button>
+              </span>
               <span class="insight__value" id="toCall">—</span>
             </div>
             <div class="insight" id="insightMinRaise">
-              <span class="insight__label">Min raise</span>
+              <span class="insight__label">Min raise
+                <button class="inline-tip" type="button" data-tip="Smallest legal raise-to amount available for this action." aria-label="Tip: minimum raise definition">i</button>
+              </span>
               <span class="insight__value" id="minRaise">—</span>
             </div>
             <div class="insight" id="insightRaiseWindow">
-              <span class="insight__label">Raise window</span>
+              <span class="insight__label">Raise window
+                <button class="inline-tip" type="button" data-tip="Legal range for raise-to amounts on this street, combining the minimum and maximum if available." aria-label="Tip: raise window definition">i</button>
+              </span>
               <span class="insight__value" id="raiseWindow">—</span>
             </div>
             <div class="insight insight--solver" id="insightSolver">
-              <span class="insight__label">Solver guidance</span>
+              <span class="insight__label">Solver guidance
+                <button class="inline-tip" type="button" data-tip="Shows solver recommendations, best action, and confidence when evaluation data is available." aria-label="Tip: solver guidance definition">i</button>
+              </span>
               <span class="insight__value" id="solverText">—</span>
             </div>
           </div>

--- a/server/web/replay.js
+++ b/server/web/replay.js
@@ -396,18 +396,36 @@ const ReplayPage = (() => {
     return { equity, share, delta };
   }
 
-  function updateDeltaElement(el, value, { zeroLabel = '±0', precision } = {}) {
+  function updateDeltaElement(el, value, { zeroLabel = '±0', precision, label } = {}) {
     if (!el) return;
     const num = Number(value);
     if (!Number.isFinite(num) || Math.abs(num) < 1e-6) {
       el.textContent = zeroLabel;
       el.classList.remove('positive', 'negative');
+      if (label) {
+        const desc = `${label}: no change`;
+        el.setAttribute('title', desc);
+        el.setAttribute('aria-label', desc);
+      } else {
+        el.removeAttribute('title');
+        el.removeAttribute('aria-label');
+      }
       return;
     }
     const positive = num >= 0;
     el.textContent = fmtSigned(num, zeroLabel, precision);
     el.classList.toggle('positive', positive);
     el.classList.toggle('negative', !positive);
+    if (label) {
+      const amountText = fmtChips(Math.abs(num));
+      const direction = positive ? 'up' : 'down';
+      const desc = `${label}: ${direction} ${amountText}`;
+      el.setAttribute('title', desc);
+      el.setAttribute('aria-label', desc);
+    } else {
+      el.removeAttribute('title');
+      el.removeAttribute('aria-label');
+    }
   }
 
   function updateStatus(mode) {
@@ -504,6 +522,7 @@ const ReplayPage = (() => {
     const evDeltaEl = isSB ? els.sbEvDelta : els.bbEvDelta;
     const evMeter = isSB ? els.sbEvMeter : els.bbEvMeter;
     const evFill = isSB ? els.sbEvFill : els.bbEvFill;
+    const seatLabel = isSB ? 'Small blind' : 'Big blind';
 
     const cards = isSB ? row?.sb_hole : row?.bb_hole;
     const key = (Array.isArray(cards) ? cards : []).join(',');
@@ -547,12 +566,20 @@ const ReplayPage = (() => {
 
     const eq = computeEquity(row, seatKey);
     if (evAmountEl) {
-      evAmountEl.textContent = fmtChips(eq.equity);
+      const equityText = fmtChips(eq.equity);
+      evAmountEl.textContent = equityText;
+      const amountLabel = `${seatLabel} chip equity ${equityText}`;
+      evAmountEl.setAttribute('title', amountLabel);
+      evAmountEl.setAttribute('aria-label', amountLabel);
     }
     if (evShareEl) {
-      evShareEl.textContent = `${(eq.share * 100).toFixed(1)}%`;
+      const sharePct = `${(eq.share * 100).toFixed(1)}%`;
+      evShareEl.textContent = sharePct;
+      const shareLabel = `${seatLabel} equity share ${sharePct}`;
+      evShareEl.setAttribute('title', shareLabel);
+      evShareEl.setAttribute('aria-label', shareLabel);
     }
-    updateDeltaElement(evDeltaEl, eq.delta, { precision: 1 });
+    updateDeltaElement(evDeltaEl, eq.delta, { precision: 1, label: `${seatLabel} equity change` });
     if (evMeter) {
       evMeter.style.setProperty('--ev-pct', `${Math.max(0, Math.min(100, eq.share * 100))}%`);
     }
@@ -570,39 +597,91 @@ const ReplayPage = (() => {
     const reqEqValue = computeRequiredEquityValue(row);
     const reqEq = formatPercent(reqEqValue);
     const toCall = Number(row?.to_call);
+    const pot = Number(row?.pot);
     const minRaise = Number(row?.min_raise_to);
     const maxRaise = Number(row?.max_raise_to);
+    const hasPotContext = Number.isFinite(toCall) && Number.isFinite(pot);
+    const totalAfterCall = hasPotContext ? pot + toCall : null;
 
     if (els.potOdds) {
-      els.potOdds.textContent = potOdds ?? '—';
-      els.potOdds.parentElement?.classList.toggle('is-empty', !potOdds);
+      const hasPotOdds = typeof potOdds === 'string';
+      els.potOdds.textContent = hasPotOdds ? potOdds : '—';
+      els.potOdds.parentElement?.classList.toggle('is-empty', !hasPotOdds);
+      if (hasPotOdds) {
+        const tooltip = hasPotContext && Number.isFinite(totalAfterCall)
+          ? `Call ${fmtChips(toCall)} to win ${fmtChips(totalAfterCall)} (${potOdds}).`
+          : `Pot odds ${potOdds}.`;
+        els.potOdds.setAttribute('title', tooltip);
+        els.potOdds.setAttribute('aria-label', tooltip);
+      } else {
+        els.potOdds.removeAttribute('title');
+        els.potOdds.removeAttribute('aria-label');
+      }
     }
     if (els.requiredEq) {
-      els.requiredEq.textContent = reqEq ?? '—';
-      els.requiredEq.parentElement?.classList.toggle('is-empty', !reqEq);
+      const hasReqEq = typeof reqEq === 'string';
+      els.requiredEq.textContent = hasReqEq ? reqEq : '—';
+      els.requiredEq.parentElement?.classList.toggle('is-empty', !hasReqEq);
+      if (hasReqEq) {
+        const tooltip = `Break-even call equity: ${reqEq}.`;
+        els.requiredEq.setAttribute('title', tooltip);
+        els.requiredEq.setAttribute('aria-label', tooltip);
+      } else {
+        els.requiredEq.removeAttribute('title');
+        els.requiredEq.removeAttribute('aria-label');
+      }
     }
     if (els.toCall) {
-      const text = Number.isFinite(toCall) ? fmtChips(toCall) : '—';
+      const hasToCall = Number.isFinite(toCall);
+      const text = hasToCall ? fmtChips(toCall) : '—';
       els.toCall.textContent = text;
-      els.toCall.parentElement?.classList.toggle('is-empty', !Number.isFinite(toCall));
+      els.toCall.parentElement?.classList.toggle('is-empty', !hasToCall);
+      if (hasToCall) {
+        const tooltip = `Call amount: ${text}`;
+        els.toCall.setAttribute('title', tooltip);
+        els.toCall.setAttribute('aria-label', tooltip);
+      } else {
+        els.toCall.removeAttribute('title');
+        els.toCall.removeAttribute('aria-label');
+      }
     }
     if (els.minRaise) {
-      const text = Number.isFinite(minRaise) ? fmtChips(minRaise) : '—';
+      const hasMinRaise = Number.isFinite(minRaise);
+      const text = hasMinRaise ? fmtChips(minRaise) : '—';
       els.minRaise.textContent = text;
-      els.minRaise.parentElement?.classList.toggle('is-empty', !Number.isFinite(minRaise));
+      els.minRaise.parentElement?.classList.toggle('is-empty', !hasMinRaise);
+      if (hasMinRaise) {
+        const tooltip = `Minimum raise-to: ${text}`;
+        els.minRaise.setAttribute('title', tooltip);
+        els.minRaise.setAttribute('aria-label', tooltip);
+      } else {
+        els.minRaise.removeAttribute('title');
+        els.minRaise.removeAttribute('aria-label');
+      }
     }
     if (els.raiseWindow) {
       let text = '—';
+      let hasValue = false;
       if (Number.isFinite(minRaise) && Number.isFinite(maxRaise)) {
         text = `${fmtChips(minRaise)} – ${fmtChips(maxRaise)}`;
+        hasValue = true;
       } else if (Number.isFinite(minRaise)) {
         text = `≥ ${fmtChips(minRaise)}`;
+        hasValue = true;
       } else if (Number.isFinite(maxRaise)) {
         text = `≤ ${fmtChips(maxRaise)}`;
+        hasValue = true;
       }
       els.raiseWindow.textContent = text;
-      const hasValue = Number.isFinite(minRaise) || Number.isFinite(maxRaise);
       els.raiseWindow.parentElement?.classList.toggle('is-empty', !hasValue);
+      if (hasValue) {
+        const tooltip = `Raise window: ${text}`;
+        els.raiseWindow.setAttribute('title', tooltip);
+        els.raiseWindow.setAttribute('aria-label', tooltip);
+      } else {
+        els.raiseWindow.removeAttribute('title');
+        els.raiseWindow.removeAttribute('aria-label');
+      }
     }
 
     if (els.solverText) {
@@ -632,6 +711,14 @@ const ReplayPage = (() => {
       const text = parts.join(' • ');
       els.solverText.textContent = text || '—';
       els.solverText.parentElement?.classList.toggle('is-empty', !text);
+      if (text) {
+        const tooltip = `Solver guidance: ${text}`;
+        els.solverText.setAttribute('title', tooltip);
+        els.solverText.setAttribute('aria-label', tooltip);
+      } else {
+        els.solverText.removeAttribute('title');
+        els.solverText.removeAttribute('aria-label');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- rework the board display into a two-row grid and tighten seat card spacing for the blinds
- add inline tips to the replay insights panel for pot odds, equity, and solver guidance
- surface contextual aria/tooltip text for chip equity and insight values to improve clarity

## Testing
- go test ./... *(terminated early; command appeared to hang waiting for external services)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b80a47c4832d85158a09ae06812f