### PR TITLE
Make mirror Elo weighting optional

### DIFF
--- a/server/elo_v2.go
+++ b/server/elo_v2.go
@@ -4,14 +4,17 @@ import "math"
 
 // Elo holds ratings for model A and B (per *mirrored pair*).
 type Elo struct {
-	A, B  float64 // ratings
-	K     float64 // base K
-	Games int     // mirrored pairs processed (pair-mode only)
-	AccA  float64 // historical judge accuracy [0,1]
-	AccB  float64 // historical judge accuracy [0,1]
+	A, B          float64 // ratings
+	K             float64 // base K
+	WeightMirrors bool    // scale mirrored pairs by pot?
+	Games         int     // mirrored pairs processed (pair-mode only)
+	AccA          float64 // historical judge accuracy [0,1]
+	AccB          float64 // historical judge accuracy [0,1]
 }
 
-func NewElo(start, k float64) Elo { return Elo{A: start, B: start, K: k, AccA: 0.5, AccB: 0.5} }
+func NewElo(start, k float64, weightMirrors bool) Elo {
+	return Elo{A: start, B: start, K: k, WeightMirrors: weightMirrors, AccA: 0.5, AccB: 0.5}
+}
 
 func (e Elo) expect() (ea, eb float64) {
 	ea = 1.0 / (1.0 + math.Pow(10, (e.B-e.A)/400.0))
@@ -75,7 +78,10 @@ func (e *Elo) UpdateFromMirror(
 
 	avgAcc := (e.AccA + e.AccB) * 0.5
 	volAdj := clamp(0.85+0.3*avgAcc, 0.75, 1.15)
-	kEff := e.K * mirrorWeight(potSum, bb) * volAdj * decay(e.Games)
+	kEff := e.K * volAdj * decay(e.Games)
+	if e.WeightMirrors {
+		kEff *= mirrorWeight(potSum, bb)
+	}
 
 	dA = kEff * (sA - ea)
 	dB = kEff * (sB - eb)

--- a/server/elo_v2_test.go
+++ b/server/elo_v2_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"math"
+	"testing"
+)
+
+func TestUpdateFromMirrorWeightToggle(t *testing.T) {
+	potSum := 1000
+	bb := 100
+	chipsA := 220
+	winsA, winsB := 1.4, 0.6
+	foldA, foldB := 0.3, -0.1
+
+	weighted := NewElo(1500, 32, true)
+	unweighted := NewElo(1500, 32, false)
+
+	dAWeighted, _ := weighted.UpdateFromMirror(chipsA, potSum, bb, winsA, winsB, foldA, foldB)
+	dAUnweighted, _ := unweighted.UpdateFromMirror(chipsA, potSum, bb, winsA, winsB, foldA, foldB)
+
+	if dAUnweighted == 0 {
+		t.Fatalf("expected non-zero unweighted delta")
+	}
+
+	gotRatio := dAWeighted / dAUnweighted
+	wantRatio := mirrorWeight(potSum, bb)
+
+	if math.Abs(gotRatio-wantRatio) > 1e-9 {
+		t.Fatalf("ratio mismatch: got %.6f want %.6f", gotRatio, wantRatio)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -1840,7 +1840,7 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 	}
 	eloPerHand := false
 	eloWeightPot := asBool(os.Getenv("ELO_WEIGHT_BY_POT"))
-	elo := NewElo(eloStart, eloK)
+	elo := NewElo(eloStart, eloK, eloWeightPot)
 
 	gA := NewGlicko2()
 	gB := NewGlicko2()


### PR DESCRIPTION
## Summary
- add a configuration flag to the Elo tracker so pair updates optionally apply mirror pot weighting
- wire the existing ELO_WEIGHT_BY_POT environment variable through the server bootstrap to control the new toggle
- add unit coverage to verify the weighted and unweighted mirror update paths diverge as expected

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1be2f96f4832d85b457ef1acb2245