### PR TITLE
Fix compare drawer close button visibility

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -1144,6 +1144,10 @@ p {
   gap: 18px;
 }
 
+.compare-drawer[hidden] {
+  display: none !important;
+}
+
 .compare-drawer__header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- ensure the matrix insights drawer honors the hidden attribute by forcing it to `display: none`
- fixes the "×" close button so closing the drawer actually removes it from view

## Testing
- no automated tests were run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1c020a160832d8c5acc3bbf3873e5