### PR TITLE
Center second row of replay board cards

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -4640,12 +4640,11 @@ body.tooltips-disabled .inline-tip {
   margin: 0 auto;
 }
 
-.board-display__cards > *:nth-child(4) {
-  grid-column: 2;
-}
-
-.board-display__cards > *:nth-child(5) {
-  grid-column: 3;
+.board-display__cards::after {
+  content: '';
+  display: block;
+  grid-column: 1;
+  grid-row: 2;
 }
 
 .board-display__label {


### PR DESCRIPTION
## Summary
- ensure the replay board keeps a fixed three-column grid
- add a grid placeholder to center the turn and river cards on the second row

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d1bf32961c832daa1b1f38f630c7f7