### PR TITLE
Refine Elo filter layout

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -2238,12 +2238,6 @@ ion);
   border-bottom-color: rgba(71, 89, 128, 0.45);
 }
 
-@media (min-width: 960px) {
-  .elo-card__header {
-    grid-template-columns: minmax(0, 1fr) auto;
-    align-items: center;
-  }
-}
 
 .elo-card__heading {
   display: flex;
@@ -2260,13 +2254,28 @@ ion);
 .elo-card__filters {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 14px 20px;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 16px 20px;
 }
 
+.elo-card__filters > * {
+  flex-shrink: 0;
+}
+
+.elo-card__filters #ratingMetricControl,
 .elo-card__filters .sort-control {
+  align-self: flex-start;
+}
+
+.elo-card__filters label.sort-control {
   margin-left: auto;
+}
+
+.elo-card__filters .filter-group {
+  flex: 1 1 100%;
+  width: 100%;
+  min-width: 0;
 }
 
 .page-elo .topnav__links .pill {


### PR DESCRIPTION
## Summary
- stack the Elo card header so the filter controls sit below the intro copy on most viewports
- allow the rating metric, company chips, and sort select to wrap cleanly with the filter group expanding to full width

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d1b90eccc4832d8f8f9824b4d8097c