### PR TITLE
Aggregate bot playstyle across all matches

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -4,6 +4,7 @@ package main
 import (
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -12,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"ai-thunderdome/server/engine"
 	"ai-thunderdome/server/store"
@@ -516,8 +519,13 @@ func Router(db *store.DB) http.Handler {
 		writeJSON(w, map[string]any{"career": career, "matches": list})
 	})
 
-	// Aggregated action mix for a bot across all matches (for playstyle badges)
-	mux.HandleFunc("/api/bot-style", func(w http.ResponseWriter, r *http.Request) {
+        // Aggregated action mix for a bot across all matches.
+        //
+        // This powers the playstyle card on server/web/bot.html (and the
+        // static export that mirrors that page). No other surfaces depend on
+        // the response payload, so updating the aggregation only affects that
+        // visualization.
+        mux.HandleFunc("/api/bot-style", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		idStr := r.URL.Query().Get("id")
 		if idStr == "" {
@@ -530,20 +538,35 @@ func Router(db *store.DB) http.Handler {
 			return
 		}
 
-		// Sum action tallies across all matches for this bot
+		// Sum action tallies across all matches for this bot (career-wide)
 		var checkCT, callCT, raiseCT, foldCT int
 		err := db.QueryRow(ctx, `
-            SELECT COALESCE(SUM(t.check_ct),0) AS check_ct,
-                   COALESCE(SUM(t.call_ct),0)  AS call_ct,
-                   COALESCE(SUM(t.raise_ct),0) AS raise_ct,
-                   COALESCE(SUM(t.fold_ct),0)  AS fold_ct
-              FROM action_tallies t
-              JOIN match_participants p ON p.match_id = t.match_id AND p.label = t.label
-             WHERE p.bot_id = $1
+            SELECT COALESCE(check_ct, 0) AS check_ct,
+                   COALESCE(call_ct, 0)  AS call_ct,
+                   COALESCE(raise_ct, 0) AS raise_ct,
+                   COALESCE(fold_ct, 0)  AS fold_ct
+              FROM v_bot_action_mix
+             WHERE bot_id = $1
         `, botID).Scan(&checkCT, &callCT, &raiseCT, &foldCT)
 		if err != nil {
-			http.Error(w, err.Error(), 500)
-			return
+			if errors.Is(err, pgx.ErrNoRows) {
+				checkCT, callCT, raiseCT, foldCT = 0, 0, 0, 0
+			} else {
+				// Fall back to the direct aggregation to remain compatible with pre-migration databases.
+				err = db.QueryRow(ctx, `
+                SELECT COALESCE(SUM(t.check_ct),0) AS check_ct,
+                       COALESCE(SUM(t.call_ct),0)  AS call_ct,
+                       COALESCE(SUM(t.raise_ct),0) AS raise_ct,
+                       COALESCE(SUM(t.fold_ct),0)  AS fold_ct
+                  FROM action_tallies t
+                  JOIN match_participants p ON p.match_id = t.match_id AND p.label = t.label
+                 WHERE p.bot_id = $1
+            `, botID).Scan(&checkCT, &callCT, &raiseCT, &foldCT)
+				if err != nil {
+					http.Error(w, err.Error(), 500)
+					return
+				}
+			}
 		}
 		total := checkCT + callCT + raiseCT + foldCT
 		// Guard against division by zero for display percentages.

--- a/server/store/schema.sql
+++ b/server/store/schema.sql
@@ -140,6 +140,18 @@ FROM matches m
 JOIN match_participants p ON p.match_id = m.id
 JOIN action_tallies t     ON t.match_id = m.id AND t.label = p.label;
 
+CREATE OR REPLACE VIEW v_bot_action_mix AS
+SELECT
+  p.bot_id,
+  SUM(t.check_ct) AS check_ct,
+  SUM(t.call_ct)  AS call_ct,
+  SUM(t.raise_ct) AS raise_ct,
+  SUM(t.fold_ct)  AS fold_ct,
+  SUM(t.check_ct + t.call_ct + t.raise_ct + t.fold_ct) AS total_actions
+FROM match_participants p
+JOIN action_tallies t ON t.match_id = p.match_id AND t.label = p.label
+GROUP BY p.bot_id;
+
 -- Recreate to allow column order/name changes safely during upgrades
 DROP VIEW IF EXISTS v_bot_summary;
 CREATE VIEW v_bot_summary AS


### PR DESCRIPTION
## Summary
- add a reusable `v_bot_action_mix` view that aggregates action tallies across a bot's full history
- serve `/api/bot-style` data from the career-wide view with a fallback to the legacy aggregation for pre-migration databases
- document that the `/api/bot-style` response only feeds the bot detail playstyle visualization

## Testing
- go test ./... *(hangs locally, aborted after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68d34cbaf634832dbed7b74d473afeec