### PR TITLE
Center replay board bottom row

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -4642,10 +4642,10 @@ body.tooltips-disabled .inline-tip {
 .board-display__cards {
   position: relative;
   z-index: 1;
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, var(--card-w)));
+  display: flex;
+  flex-wrap: wrap;
   justify-content: center;
-  justify-items: center;
+  align-items: center;
   align-content: center;
   column-gap: 18px;
   row-gap: 24px;
@@ -4654,10 +4654,7 @@ body.tooltips-disabled .inline-tip {
 }
 
 .board-display__cards::after {
-  content: '';
-  display: block;
-  grid-column: 1;
-  grid-row: 2;
+  content: none;
 }
 
 .board-display__label {


### PR DESCRIPTION
## Summary
- update the replay board layout to use flexbox so the second row of cards centers beneath the flop
- remove the grid-only pseudo element that previously forced the placeholders to the right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d35d8aa524832daf661163edc3c728