### PR TITLE
Refactor MCJudge evaluation database usage

### DIFF
--- a/server/judge/mc.go
+++ b/server/judge/mc.go
@@ -2,6 +2,7 @@ package judge
 
 import (
 	"context"
+	"errors"
 	"math"
 	"os"
 	"strings"
@@ -9,48 +10,134 @@ import (
 
 	"ai-thunderdome/server/engine"
 	"ai-thunderdome/server/store"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	poker "github.com/paulhankin/poker"
 )
+
+type mcDBRunner struct {
+	primary  *store.DB
+	fallback *store.DB
+}
+
+func newMCDBRunner(primary *store.DB) *mcDBRunner {
+	return &mcDBRunner{primary: primary}
+}
+
+func (r *mcDBRunner) Close(ctx context.Context) {
+	if r.fallback != nil {
+		r.fallback.Close(ctx)
+		r.fallback = nil
+	}
+}
+
+func (r *mcDBRunner) ensureFallback(ctx context.Context) error {
+	if r.fallback != nil {
+		return nil
+	}
+	dsn := strings.TrimSpace(os.Getenv("DATABASE_URL"))
+	if dsn == "" {
+		dsn = "postgres://poker:poker@localhost:5432/thunderdome?sslmode=disable"
+	}
+	fresh, err := store.Open(dsn)
+	if err != nil {
+		return err
+	}
+	r.fallback = fresh
+	return nil
+}
+
+func (r *mcDBRunner) use(ctx context.Context, fn func(*store.DB) error) error {
+	if r.primary != nil {
+		if err := fn(r.primary); err != nil {
+			if isConnBusy(err) {
+				r.primary = nil
+			} else {
+				return err
+			}
+		} else {
+			return nil
+		}
+	}
+	if err := r.ensureFallback(ctx); err != nil {
+		return err
+	}
+	return fn(r.fallback)
+}
+
+func (r *mcDBRunner) QueryRow(ctx context.Context, query string, args []any, dest ...any) error {
+	return r.use(ctx, func(db *store.DB) error {
+		return db.QueryRow(ctx, query, args...).Scan(dest...)
+	})
+}
+
+func (r *mcDBRunner) QueryRows(ctx context.Context, query string, args []any, handler func(pgx.Rows) error) error {
+	return r.use(ctx, func(db *store.DB) error {
+		rows, err := db.Query(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		if err := handler(rows); err != nil {
+			return err
+		}
+		return rows.Err()
+	})
+}
+
+func (r *mcDBRunner) ExecBatch(ctx context.Context, query string, args [][]any) error {
+	if len(args) == 0 {
+		return nil
+	}
+	return r.use(ctx, func(db *store.DB) error {
+		batch := &pgx.Batch{}
+		for _, a := range args {
+			batch.Queue(query, a...)
+		}
+		br := db.SendBatch(ctx, batch)
+		for range args {
+			if _, err := br.Exec(); err != nil {
+				br.Close()
+				return err
+			}
+		}
+		return br.Close()
+	})
+}
+
+func isConnBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	var lock interface {
+		error
+		SafeToRetry() bool
+	}
+	if errors.As(err, &lock) {
+		if strings.Contains(strings.ToLower(lock.Error()), "conn busy") {
+			return true
+		}
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "conn busy")
+}
 
 // EvaluateMatchMC computes river (exact) EV comparisons for each river decision
 // and writes rows into action_eval with solver='MCJudge'.
 // Minimal scope: only facing-bet decisions (to_call>0) on river; compares Call vs Fold.
 func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
-	// Acquire a dedicated connection so work continues even if the pool closes soon after.
-	conn, err := db.Acquire(ctx)
-	if err != nil {
-		// Fallback: if pool is closed, open a fresh one just for judging.
-		dsn := strings.TrimSpace(os.Getenv("DATABASE_URL"))
-		if dsn == "" {
-			dsn = "postgres://poker:poker@localhost:5432/thunderdome?sslmode=disable"
-		}
-		fresh, e2 := store.Open(dsn)
-		if e2 != nil {
-			return err
-		}
-		defer fresh.Close(ctx)
-		conn2, e3 := fresh.Acquire(ctx)
-		if e3 != nil {
-			return err
-		}
-		defer conn2.Release()
-		conn = conn2
-	} else {
-		defer conn.Release()
-	}
+	runner := newMCDBRunner(db)
+	defer runner.Close(ctx)
 
-	// Fetch big blind size for epsilon scaling
 	var bb int
-	if err := conn.QueryRow(ctx, `SELECT bb FROM matches WHERE id = $1`, matchID).Scan(&bb); err != nil {
+	if err := runner.QueryRow(ctx, `SELECT bb FROM matches WHERE id = $1`, []any{matchID}, &bb); err != nil {
 		return err
 	}
 	if bb <= 0 {
 		bb = 100
 	}
-	eps := 0.15 * float64(bb) // epsilon in chips
+	eps := 0.15 * float64(bb)
 
-	type Row struct {
+	type actionRow struct {
 		ID         int64
 		HandID     string
 		ActorLabel string
@@ -62,6 +149,94 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 		Action     string
 		Amount     pgtype.Int4
 	}
+
+	rawRows := make([]actionRow, 0, 32)
+	if err := runner.QueryRows(ctx, `
+        SELECT id, hand_id, actor_label, pot, to_call, board, sb_hole, bb_hole, LOWER(action), amount
+          FROM action_logs
+         WHERE match_id = $1 AND street = 'river'
+         ORDER BY id
+    `, []any{matchID}, func(rows pgx.Rows) error {
+		temp := make([]actionRow, 0, 32)
+		for rows.Next() {
+			var r actionRow
+			if err := rows.Scan(&r.ID, &r.HandID, &r.ActorLabel, &r.Pot, &r.ToCall, &r.Board, &r.SBHole, &r.BBHole, &r.Action, &r.Amount); err != nil {
+				return err
+			}
+			temp = append(temp, r)
+		}
+		rawRows = temp
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if len(rawRows) == 0 {
+		return nil
+	}
+
+	suits := []byte{'c', 'd', 'h', 's'}
+	fullDeck := make([]engine.Card, 0, 52)
+	for _, su := range suits {
+		for rnk := 2; rnk <= 14; rnk++ {
+			fullDeck = append(fullDeck, engine.Card{Rank: rnk, Suit: su})
+		}
+	}
+
+	toPoker := func(c engine.Card) poker.Card {
+		var s poker.Suit
+		switch c.Suit {
+		case 'c':
+			s = poker.Club
+		case 'd':
+			s = poker.Diamond
+		case 'h':
+			s = poker.Heart
+		default:
+			s = poker.Spade
+		}
+		var rnk poker.Rank
+		if c.Rank == 14 {
+			rnk = poker.Rank(1)
+		} else {
+			rnk = poker.Rank(c.Rank)
+		}
+		card, _ := poker.MakeCard(s, rnk)
+		return card
+	}
+
+	parseCard := func(s string) (engine.Card, bool) {
+		if len(s) < 2 {
+			return engine.Card{}, false
+		}
+		rnk := s[0]
+		suit := s[1]
+		var rank int
+		switch rnk {
+		case 'A':
+			rank = 14
+		case 'K':
+			rank = 13
+		case 'Q':
+			rank = 12
+		case 'J':
+			rank = 11
+		case 'T':
+			rank = 10
+		default:
+			if rnk >= '2' && rnk <= '9' {
+				rank = int(rnk - '0')
+			}
+		}
+		if rank == 0 {
+			return engine.Card{}, false
+		}
+		if suit != 'c' && suit != 'd' && suit != 'h' && suit != 's' {
+			return engine.Card{}, false
+		}
+		return engine.Card{Rank: rank, Suit: suit}, true
+	}
+
 	const insertActionEvalSQL = `
                INSERT INTO action_eval(
                    action_log_id, solver, solver_version, abstraction,
@@ -96,47 +271,27 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
                    compute_ms = EXCLUDED.compute_ms
        `
 
-	rows, err := conn.Query(ctx, `
-        SELECT id, hand_id, actor_label, pot, to_call, board, sb_hole, bb_hole, LOWER(action), amount
-          FROM action_logs
-         WHERE match_id = $1 AND street = 'river'
-         ORDER BY id
-    `, matchID)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if rows != nil {
-			rows.Close()
-		}
-	}()
+	inserts := make([][]any, 0, len(rawRows))
 
-	var inserts [][]any
-
-	for rows.Next() {
-		var r Row
-		if err := rows.Scan(&r.ID, &r.HandID, &r.ActorLabel, &r.Pot, &r.ToCall, &r.Board, &r.SBHole, &r.BBHole, &r.Action, &r.Amount); err != nil {
-			return err
-		}
+	for _, r := range rawRows {
 		if len(r.Board) < 5 || len(r.SBHole) != 2 || len(r.BBHole) != 2 {
 			continue
 		}
 
-		// Map actor label to seat for this hand id
 		aIsSB := strings.HasSuffix(strings.ToUpper(r.HandID), "A")
 		heroSeat := engine.SB
 		if r.ActorLabel == "A" {
 			if !aIsSB {
 				heroSeat = engine.BB
 			}
-		} else { // label B
+		} else {
 			if aIsSB {
 				heroSeat = engine.BB
 			} else {
 				heroSeat = engine.SB
 			}
 		}
-		// Hero/villain holes
+
 		var heroHole []string
 		if heroSeat == engine.SB {
 			heroHole = r.SBHole
@@ -144,125 +299,64 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			heroHole = r.BBHole
 		}
 
-		// Parse board + hero hole
-		parse := func(s string) (engine.Card, bool) {
-			if len(s) < 2 {
-				return engine.Card{}, false
-			}
-			rnk := s[0]
-			suit := s[1]
-			var rank int
-			switch rnk {
-			case 'A':
-				rank = 14
-			case 'K':
-				rank = 13
-			case 'Q':
-				rank = 12
-			case 'J':
-				rank = 11
-			case 'T':
-				rank = 10
-			default:
-				if rnk >= '2' && rnk <= '9' {
-					rank = int(rnk - '0')
-				}
-			}
-			if rank == 0 {
-				return engine.Card{}, false
-			}
-			if suit != 'c' && suit != 'd' && suit != 'h' && suit != 's' {
-				return engine.Card{}, false
-			}
-			return engine.Card{Rank: rank, Suit: suit}, true
-		}
 		board := make([]engine.Card, 0, 5)
-		for i := 0; i < 5; i++ {
-			if c, ok := parse(r.Board[i]); ok {
+		for i := 0; i < 5 && i < len(r.Board); i++ {
+			if c, ok := parseCard(r.Board[i]); ok {
 				board = append(board, c)
 			}
 		}
-		h1 := make([]engine.Card, 0, 2)
+		if len(board) != 5 {
+			continue
+		}
+
+		hole := make([]engine.Card, 0, 2)
 		for _, s := range heroHole {
-			if c, ok := parse(s); ok {
-				h1 = append(h1, c)
+			if c, ok := parseCard(s); ok {
+				hole = append(hole, c)
 			}
 		}
-		if len(board) != 5 || len(h1) != 2 {
+		if len(hole) != 2 {
 			continue
 		}
 
 		start := time.Now()
 
-		// Build deck and enumerate villain combos (exact equity)
-		deck := make([]engine.Card, 0, 52)
-		suits := []byte{'c', 'd', 'h', 's'}
-		for _, su := range suits {
-			for rnk := 2; rnk <= 14; rnk++ {
-				deck = append(deck, engine.Card{Rank: rnk, Suit: su})
-			}
-		}
-		used := map[engine.Card]bool{}
+		used := make(map[engine.Card]bool, 7)
 		for _, c := range board {
 			used[c] = true
 		}
-		for _, c := range h1 {
+		for _, c := range hole {
 			used[c] = true
 		}
 
-		// Build poker lib cards
-		toPH := func(c engine.Card) poker.Card {
-			var s poker.Suit
-			switch c.Suit {
-			case 'c':
-				s = poker.Club
-			case 'd':
-				s = poker.Diamond
-			case 'h':
-				s = poker.Heart
-			default:
-				s = poker.Spade
-			}
-			var rnk poker.Rank
-			if c.Rank == 14 {
-				rnk = poker.Rank(1)
-			} else {
-				rnk = poker.Rank(c.Rank)
-			}
-			pc, _ := poker.MakeCard(s, rnk)
-			return pc
-		}
-		heroAllPH := make([]poker.Card, 0, 7)
-		for _, c := range h1 {
-			heroAllPH = append(heroAllPH, toPH(c))
-		}
+		boardPH := make([]poker.Card, 0, 5)
 		for _, c := range board {
-			heroAllPH = append(heroAllPH, toPH(c))
+			boardPH = append(boardPH, toPoker(c))
 		}
-		var a7 [7]poker.Card
-		copy(a7[:], heroAllPH)
-		heroScore := poker.Eval7(&a7)
 
-		var total int64
-		var win, tie int64
-		// enumerate pairs
-		avail := make([]engine.Card, 0, len(deck))
-		for _, c := range deck {
+		var heroAll [7]poker.Card
+		heroAll[0] = toPoker(hole[0])
+		heroAll[1] = toPoker(hole[1])
+		copy(heroAll[2:], boardPH)
+		heroScore := poker.Eval7(&heroAll)
+
+		avail := make([]engine.Card, 0, len(fullDeck))
+		for _, c := range fullDeck {
 			if !used[c] {
 				avail = append(avail, c)
 			}
 		}
+
+		var total int64
+		var win, tie int64
+		var combo [7]poker.Card
+		copy(combo[2:], boardPH)
 		for i := 0; i < len(avail); i++ {
 			for j := i + 1; j < len(avail); j++ {
 				total++
-				vAllPH := make([]poker.Card, 0, 7)
-				vAllPH = append(vAllPH, toPH(avail[i]), toPH(avail[j]))
-				for _, c := range board {
-					vAllPH = append(vAllPH, toPH(c))
-				}
-				var b7 [7]poker.Card
-				copy(b7[:], vAllPH)
-				vScore := poker.Eval7(&b7)
+				combo[0] = toPoker(avail[i])
+				combo[1] = toPoker(avail[j])
+				vScore := poker.Eval7(&combo)
 				if heroScore > vScore {
 					win++
 				} else if heroScore == vScore {
@@ -273,30 +367,23 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 		if total == 0 {
 			continue
 		}
-		eq := (float64(win) + 0.5*float64(tie)) / float64(total)
 
+		eq := (float64(win) + 0.5*float64(tie)) / float64(total)
 		P := float64(r.Pot)
 
 		if r.ToCall > 0 {
-			// Facing bet: call vs fold
 			b := float64(r.ToCall)
 			evFold := 0.0
-			// Hero invests b to call. Eq captures win probability plus half of ties,
-			// so eq*(P+b) is the expected return from the pot while the call always
-			// costs the full b chips. Avoid discounting the loss by (1-eq) because eq
-			// already prices the tie outcomes.
 			evCall := eq*(P+b) - b
 
 			bestAction := "call"
-			bestTo := (*int)(nil)
+			var bestTo *int
 			evBest := evCall
 			if evFold > evBest {
 				bestAction = "fold"
 				evBest = evFold
 			}
 
-			// chosen
-			// Use the action and amount captured in the main query for comparison.
 			chosenAction := r.Action
 			var chosenTo *int
 			if r.Amount.Valid {
@@ -307,6 +394,7 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			if chosenAction != "call" && chosenAction != "fold" {
 				continue
 			}
+
 			evChosen := evFold
 			if chosenAction == "call" {
 				evChosen = evCall
@@ -315,6 +403,7 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			gapChips := evBest - evChosen
 			gap := gapChips / float64(bb)
 			isTop := gapChips <= eps
+
 			var bestToVal any
 			if bestTo != nil {
 				bestToVal = *bestTo
@@ -323,6 +412,7 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			if chosenTo != nil {
 				chosenToVal = *chosenTo
 			}
+
 			computeMS := int(time.Since(start) / time.Millisecond)
 			inserts = append(inserts, []any{
 				r.ID, "MCJudge", nil, nil,
@@ -333,15 +423,13 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 				isTop, computeMS,
 			})
 		} else {
-			// Uncontested river: check vs bet (single size ~66% pot)
 			b := math.Max(float64(bb), math.Round(0.66*P))
-			F := 0.35 // assumed fold equity for 2/3 pot sizing
+			F := 0.35
 			evCheck := 0.0
-			// When villain folds we earn +P; when called we reach a showdown with pot
-			// P+2b and have already invested b ourselves.
 			evBet := F*P + (1.0-F)*(eq*(P+2*b)-b)
-			bestAction := "raise" // represent bet as raise
-			bestTo := (*int)(nil)
+
+			bestAction := "raise"
+			var bestTo *int
 			evBest := evBet
 			if evCheck > evBest {
 				bestAction = "check"
@@ -358,6 +446,7 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			if chosenAction != "check" && chosenAction != "raise" {
 				continue
 			}
+
 			evChosen := evCheck
 			if chosenAction == "raise" {
 				evChosen = evBet
@@ -366,6 +455,7 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			gapChips := evBest - evChosen
 			gap := gapChips / float64(bb)
 			isTop := gapChips <= eps
+
 			var bestToVal any
 			if bestTo != nil {
 				bestToVal = *bestTo
@@ -374,6 +464,7 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			if chosenTo != nil {
 				chosenToVal = *chosenTo
 			}
+
 			computeMS := int(time.Since(start) / time.Millisecond)
 			inserts = append(inserts, []any{
 				r.ID, "MCJudge", nil, nil,
@@ -385,17 +476,12 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			})
 		}
 	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return err
+
+	if len(inserts) == 0 {
+		return nil
 	}
-	rows = nil
-	for _, args := range inserts {
-		if _, err := conn.Exec(ctx, insertActionEvalSQL, args...); err != nil {
-			return err
-		}
-	}
-	return nil
+
+	return runner.ExecBatch(ctx, insertActionEvalSQL, inserts)
 }
 
 // (strptr removed; no longer needed)


### PR DESCRIPTION
## Summary
- add an mcDBRunner helper that retries on busy connections and falls back to a fresh pool when needed
- collect river action rows before computing equities and execute batched inserts through SendBatch to release connections promptly
- reuse shared deck/card conversions while preserving the existing river EV evaluation logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d350ced2b4832d8d105a85689f35c0