### PR TITLE
Style settings shortcuts panel

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -539,6 +539,56 @@ p {
   color: var(--muted);
 }
 
+.nav-settings__shortcuts {
+  margin: 0;
+  padding: 2px 0;
+  display: grid;
+  gap: 10px;
+  list-style: none;
+}
+
+.nav-settings__shortcuts > div {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 0.7rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  transition: background var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.nav-settings__shortcuts > div:hover,
+.nav-settings__shortcuts > div:focus-within {
+  background: var(--surface);
+  border-color: var(--border-strong);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+}
+
+.nav-settings__shortcuts dt {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.28rem 0.6rem;
+  border-radius: 10px;
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  box-shadow: 0 2px 4px rgba(17, 17, 17, 0.08);
+  white-space: nowrap;
+}
+
+.nav-settings__shortcuts dd {
+  margin: 0;
+  font-size: var(--fs-0);
+  color: var(--muted);
+  text-align: right;
+}
+
 .brand {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- restyle the shortcuts block in the settings panel to read as discrete shortcut rows
- add keycap styling for shortcut keys so the guidance looks more intentional

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d36360f28c832db5013d2c7e472f53