### PR TITLE
Clarify duel env overrides and drop duplicate accuracy pill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,16 @@ docker compose run --rm \
   duel
 ```
 
-> **Note:** `docker compose run` treats tokens after the service name as a command override. Use `-e` (or the `compose.env` file) for environment tweaks; otherwise values such as `STOP_IMMEDIATE=1` would replace `/app/ai-thunderdome --duel` entirely.
+> **Note:** `docker compose run` treats tokens after the service name as a command override. Use `-e` (or the `compose.env` file) for environment tweaks; otherwise values such as `STOP_IMMEDIATE=1` would replace `/app/ai-thunderdome --duel` entirely. To override the seat models for a one-off duel, pass them explicitly:
+>
+> ```bash
+> docker compose run --rm \
+>   -e OPENROUTER_MODEL_A="meta-llama/llama-3.1-70b-instruct" \
+>   -e OPENROUTER_MODEL_B="mistralai/mistral-nemo" \
+>   duel
+> ```
+>
+> The `-e` flags win over values defined inside `compose.env`, so each seat can be pointed at a different model even if `OPENROUTER_MODEL` is set globally.
 
 ---
 

--- a/server/web/leaderboard.html
+++ b/server/web/leaderboard.html
@@ -369,27 +369,6 @@ function rowHTML(i, r, metric){
           return 0;
         });
         $('#tbody').innerHTML = out.map((r,i)=>rowHTML(i,r,ratingMetric)).join('');
-
-        // Append judge accuracy pills next to model name
-        try {
-          document.querySelectorAll('tr.lb-row').forEach(tr => {
-            const href = tr.getAttribute('data-href')||'';
-            const idMatch = href.match(/id=(\d+)/);
-            if (!idMatch) return;
-            const botId = Number(idMatch[1]);
-            const row = rows.find(x => Number(x.bot_id) === botId);
-            const stats = judgeStatsFor(botId, row);
-            if (!stats.hasData) return;
-            const host = tr.querySelector('.lb-model');
-            if (!host) return;
-            const pill = document.createElement('span');
-            pill.className = 'pill ghost';
-            pill.style.marginLeft = '6px';
-            pill.title = `EV judge accuracy (${stats.good}/${stats.total})`;
-            pill.textContent = stats.display;
-            host.appendChild(pill);
-          });
-        } catch {}
         setHeaderIndicators();
       }
 
@@ -406,23 +385,6 @@ function rowHTML(i, r, metric){
             const botId = Number(idMatch[1]);
             const row = rows.find(x => Number(x.bot_id) === botId);
             const stats = judgeStatsFor(botId, row);
-            const host = tr.querySelector('.lb-model');
-            if (host){
-              const existing = host.querySelector('.pill.ghost');
-              if (stats.hasData) {
-                let pill = existing;
-                if (!pill){
-                  pill = document.createElement('span');
-                  pill.className='pill ghost';
-                  pill.style.marginLeft='6px';
-                  host.appendChild(pill);
-                }
-                pill.title = `EV judge accuracy (${stats.good}/${stats.total})`;
-                pill.textContent = stats.display;
-              } else if (existing) {
-                existing.remove();
-              }
-            }
             const tds = tr.querySelectorAll('td');
             if (tds.length >= 7){
               tds[6].textContent = stats.hasData ? stats.display : '—';


### PR DESCRIPTION
## Summary
- remove the redundant judge-accuracy pill next to each leaderboard entry and rely on the accuracy column only
- document how to override OPENROUTER_MODEL_A/OPENROUTER_MODEL_B with docker compose run -e flags so seat-specific models take effect even when OPENROUTER_MODEL is set globally

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4233169b0832d90299834409a7b8a