### PR TITLE
Improve top navigation responsiveness on mobile

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -319,15 +319,24 @@ p {
     width: min(100%, calc(100vw - 32px));
   }
   .topnav {
-    grid-template-columns: 1fr;
-    justify-items: center;
-    gap: 16px;
+    width: min(100%, calc(100vw - 32px));
+    grid-template-columns: auto auto;
+    justify-content: space-between;
+    align-items: start;
+    justify-items: stretch;
+    gap: 12px 16px;
+    padding: 14px 0 10px;
+  }
+  .topnav > .brand {
+    justify-self: start;
   }
   .topnav__links {
-    justify-content: center;
+    grid-column: 1 / -1;
+    justify-content: flex-start;
   }
   .topnav__actions {
-    justify-content: center;
+    justify-content: flex-end;
+    justify-self: end;
   }
   .elo-card__filters {
     flex-direction: column;
@@ -342,6 +351,60 @@ p {
   }
 }
 
+@media (max-width: 720px) {
+  .topnav {
+    padding-top: 12px;
+  }
+  .topnav__links {
+    margin-inline: -12px;
+    padding: 2px 12px 6px;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    gap: 12px;
+    scroll-snap-type: x mandatory;
+    position: relative;
+  }
+  .topnav__links::-webkit-scrollbar {
+    display: none;
+  }
+  .topnav__links::before,
+  .topnav__links::after {
+    content: "";
+    display: block;
+    position: sticky;
+    top: 0;
+    width: 24px;
+    flex: 0 0 24px;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+  }
+  .topnav__links::before {
+    left: 0;
+    background: linear-gradient(90deg, var(--header-bg-solid) 0%, transparent 100%);
+  }
+  .topnav__links::after {
+    right: 0;
+    background: linear-gradient(270deg, var(--header-bg-solid) 0%, transparent 100%);
+  }
+  .topnav__links .pill {
+    flex: 0 0 auto;
+    scroll-snap-align: center;
+  }
+  .brand {
+    gap: 10px;
+  }
+  .brand__text {
+    font-size: 1rem;
+  }
+  .logo-badge--sm {
+    width: 36px;
+    height: 36px;
+    border-radius: 11px;
+  }
+}
+
 @media (max-width: 640px) {
   .wrap,
   .wrap--wide {
@@ -352,7 +415,15 @@ p {
     grid-template-columns: 1fr;
   }
   .topnav {
-    gap: 12px;
+    width: min(100%, calc(100vw - 24px));
+    grid-template-columns: auto auto;
+  }
+  .topnav > .brand {
+    justify-self: start;
+  }
+  .topnav__actions {
+    gap: 8px;
+    justify-self: end;
   }
   .topnav__links .pill {
     padding: 0.5rem 0.85rem;
@@ -361,6 +432,19 @@ p {
   .nav-link__icon {
     width: 1rem;
     height: 1rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .brand__text {
+    display: none;
+  }
+  .logo-badge--sm {
+    width: 34px;
+    height: 34px;
+  }
+  .topnav__actions {
+    justify-content: flex-end;
   }
 }
 
@@ -468,6 +552,22 @@ p {
   opacity: 1;
   transform: translateY(0) scale(1);
   pointer-events: auto;
+}
+
+@media (max-width: 640px) {
+  .nav-settings {
+    padding-inline: 0.85rem;
+  }
+  .nav-settings__panel {
+    left: 50%;
+    right: auto;
+    width: min(360px, calc(100vw - 24px));
+    transform: translate(-50%, -6px) scale(0.96);
+    transform-origin: top center;
+  }
+  .topnav__actions.is-open .nav-settings__panel {
+    transform: translate(-50%, 0) scale(1);
+  }
 }
 
 .topnav__actions.is-open .nav-settings {


### PR DESCRIPTION
## Summary
- tighten the header layout on smaller screens so the brand and settings stay aligned
- add horizontal scrolling treatments for the pill navigation to improve usability on phones
- center the settings popover on mobile widths for easier access

## Testing
- not run (CSS-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d445ceaddc832d8b8eebd23deb5f1b