### PR TITLE
Add cost per 50 hands metric to bot page

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -446,16 +446,18 @@ func Router(db *store.DB) http.Handler {
 
 		// Career row
 		var career struct {
-			BotID   int64     `json:"bot_id"`
-			Model   string    `json:"model"`
-			Company string    `json:"company"`
-			Elo     float64   `json:"elo"`
-			GRating float64   `json:"g_rating"`
-			GRD     float64   `json:"g_rd"`
-			GSigma  float64   `json:"g_sigma"`
-			Matches int       `json:"matches"`
-			Hands   int       `json:"hands"`
-			Updated time.Time `json:"updated_at"`
+			BotID      int64     `json:"bot_id"`
+			Model      string    `json:"model"`
+			Company    string    `json:"company"`
+			Elo        float64   `json:"elo"`
+			GRating    float64   `json:"g_rating"`
+			GRD        float64   `json:"g_rd"`
+			GSigma     float64   `json:"g_sigma"`
+			Matches    int       `json:"matches"`
+			Hands      int       `json:"hands"`
+			NetChips   int       `json:"net_chips"`
+			TotalHands int       `json:"total_hands"`
+			Updated    time.Time `json:"updated_at"`
 		}
 		err := db.QueryRow(ctx, `
             SELECT id, name, company,
@@ -466,6 +468,29 @@ func Router(db *store.DB) http.Handler {
 		if err != nil {
 			http.Error(w, err.Error(), 404)
 			return
+		}
+
+		// Aggregate total hands and chips won/lost for per-hand summaries.
+		var totalHands, netChips int
+		err = db.QueryRow(ctx, `
+            SELECT COALESCE(SUM(total_hands),0), COALESCE(SUM(total_net_chips),0)
+              FROM v_bot_summary
+             WHERE bot_id = $1
+        `, botID).Scan(&totalHands, &netChips)
+		if err != nil {
+			err = db.QueryRow(ctx, `
+                SELECT COALESCE(SUM(hands_dealt),0), COALESCE(SUM(net_chips),0)
+                  FROM match_participants
+                 WHERE bot_id = $1
+            `, botID).Scan(&totalHands, &netChips)
+			if err != nil {
+				totalHands, netChips = 0, 0
+			}
+		}
+		career.TotalHands = totalHands
+		career.NetChips = netChips
+		if career.Hands == 0 && totalHands > 0 {
+			career.Hands = totalHands
 		}
 
 		// Recent matches for this bot
@@ -519,13 +544,13 @@ func Router(db *store.DB) http.Handler {
 		writeJSON(w, map[string]any{"career": career, "matches": list})
 	})
 
-        // Aggregated action mix for a bot across all matches.
-        //
-        // This powers the playstyle card on server/web/bot.html (and the
-        // static export that mirrors that page). No other surfaces depend on
-        // the response payload, so updating the aggregation only affects that
-        // visualization.
-        mux.HandleFunc("/api/bot-style", func(w http.ResponseWriter, r *http.Request) {
+	// Aggregated action mix for a bot across all matches.
+	//
+	// This powers the playstyle card on server/web/bot.html (and the
+	// static export that mirrors that page). No other surfaces depend on
+	// the response payload, so updating the aggregation only affects that
+	// visualization.
+	mux.HandleFunc("/api/bot-style", func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		idStr := r.URL.Query().Get("id")
 		if idStr == "" {

--- a/server/web/bot.html
+++ b/server/web/bot.html
@@ -111,6 +111,12 @@
       const d = await getJSON(`/api/bot?id=${encodeURIComponent(id)}`, `/web/data/bot-${encodeURIComponent(id)}.json`);
       if (!d) { document.body.innerHTML = '<div class="wrap wrap--wide"><div class="card">Bot not found</div></div>'; return; }
       const c = d.career || {};
+      const totalHands = Number(c.total_hands ?? c.hands ?? 0);
+      const netChips = Number(c.net_chips ?? 0);
+      const costPer50 = totalHands > 0 ? (netChips / totalHands) * 50 : null;
+      const costDisplay = (costPer50 == null || Number.isNaN(costPer50))
+        ? '&mdash;'
+        : Number(costPer50).toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
 
       // Header
       $('#title').textContent = c.model || 'Bot';
@@ -119,7 +125,8 @@
       // Meta KVs
       $('#meta').innerHTML = `
         <div class="muted">Matches</div><div>${sum(c.matches)}</div>
-        <div class="muted">Hands</div><div>${sum(c.hands)}</div>
+        <div class="muted">Hands</div><div>${sum(totalHands)}</div>
+        <div class="muted">Cost / 50 hands</div><div>${costDisplay}</div>
         <div class="muted">Accuracy</div><div id="meta-acc">&mdash;</div>
         <div class="muted">Updated</div><div>${c.updated_at ? new Date(c.updated_at).toLocaleString() : '-'}</div>`;
 


### PR DESCRIPTION
## Summary
- add aggregated net chip and hand totals to the bot API response
- surface a cost-per-50-hands metric on the bot detail page

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d46f0fbdf4832d81945b8eee33e76d