### PR TITLE
Expand MCJudge street coverage and reporting

### DIFF
--- a/server/judge/mc.go
+++ b/server/judge/mc.go
@@ -14,9 +14,165 @@ import (
 	poker "github.com/paulhankin/poker"
 )
 
-// EvaluateMatchMC computes river (exact) EV comparisons for each river decision
-// and writes rows into action_eval with solver='MCJudge'.
-// Minimal scope: only facing-bet decisions (to_call>0) on river; compares Call vs Fold.
+// heroEquityExact computes exact showdown equity for hero hole cards against a
+// random villain range given the current public board. The board must contain
+// 3 (flop), 4 (turn), or 5 (river) cards. When the board is not complete, the
+// function enumerates every possible runout to the river for both players. It
+// returns the probability of hero winning (counting ties as half wins).
+func heroEquityExact(heroHole, board []engine.Card) (float64, bool) {
+	if len(heroHole) != 2 {
+		return 0, false
+	}
+	if len(board) < 3 || len(board) > 5 {
+		return 0, false
+	}
+
+	// Build deck and remove the known cards.
+	deck := make([]engine.Card, 0, 52)
+	suits := []byte{'c', 'd', 'h', 's'}
+	for _, su := range suits {
+		for rnk := 2; rnk <= 14; rnk++ {
+			deck = append(deck, engine.Card{Rank: rnk, Suit: su})
+		}
+	}
+	used := map[engine.Card]bool{}
+	for _, c := range board {
+		used[c] = true
+	}
+	for _, c := range heroHole {
+		used[c] = true
+	}
+
+	toPH := func(c engine.Card) poker.Card {
+		var s poker.Suit
+		switch c.Suit {
+		case 'c':
+			s = poker.Club
+		case 'd':
+			s = poker.Diamond
+		case 'h':
+			s = poker.Heart
+		default:
+			s = poker.Spade
+		}
+		var rnk poker.Rank
+		if c.Rank == 14 {
+			rnk = poker.Rank(1)
+		} else {
+			rnk = poker.Rank(c.Rank)
+		}
+		pc, _ := poker.MakeCard(s, rnk)
+		return pc
+	}
+
+	avail := make([]engine.Card, 0, len(deck))
+	availPH := make([]poker.Card, 0, len(deck))
+	for _, c := range deck {
+		if used[c] {
+			continue
+		}
+		avail = append(avail, c)
+		availPH = append(availPH, toPH(c))
+	}
+
+	heroPH := []poker.Card{toPH(heroHole[0]), toPH(heroHole[1])}
+	boardPH := make([]poker.Card, 0, len(board))
+	for _, c := range board {
+		boardPH = append(boardPH, toPH(c))
+	}
+
+	needed := 5 - len(board)
+	if needed < 0 || needed > 2 {
+		return 0, false
+	}
+
+	baseHeroLen := len(heroPH) + len(boardPH)
+	baseVillainLen := 2 + len(boardPH)
+	if baseHeroLen+needed != 7 || baseVillainLen+needed != 7 {
+		return 0, false
+	}
+
+	var total, win, tie int64
+	n := len(avail)
+	if n < 2+needed {
+		return 0, false
+	}
+
+	for i := 0; i < n-1; i++ {
+		for j := i + 1; j < n; j++ {
+			var hero7 [7]poker.Card
+			copy(hero7[:len(heroPH)], heroPH)
+			copy(hero7[len(heroPH):baseHeroLen], boardPH)
+
+			var vill7 [7]poker.Card
+			vill7[0] = availPH[i]
+			vill7[1] = availPH[j]
+			copy(vill7[2:baseVillainLen], boardPH)
+
+			switch needed {
+			case 0:
+				heroScore := poker.Eval7(&hero7)
+				villScore := poker.Eval7(&vill7)
+				total++
+				if heroScore > villScore {
+					win++
+				} else if heroScore == villScore {
+					tie++
+				}
+			case 1:
+				for k := 0; k < n; k++ {
+					if k == i || k == j {
+						continue
+					}
+					hero7[baseHeroLen] = availPH[k]
+					vill7[baseVillainLen] = availPH[k]
+					heroScore := poker.Eval7(&hero7)
+					villScore := poker.Eval7(&vill7)
+					total++
+					if heroScore > villScore {
+						win++
+					} else if heroScore == villScore {
+						tie++
+					}
+				}
+			case 2:
+				for k := 0; k < n; k++ {
+					if k == i || k == j {
+						continue
+					}
+					for l := k + 1; l < n; l++ {
+						if l == i || l == j {
+							continue
+						}
+						hero7[baseHeroLen] = availPH[k]
+						hero7[baseHeroLen+1] = availPH[l]
+						vill7[baseVillainLen] = availPH[k]
+						vill7[baseVillainLen+1] = availPH[l]
+						heroScore := poker.Eval7(&hero7)
+						villScore := poker.Eval7(&vill7)
+						total++
+						if heroScore > villScore {
+							win++
+						} else if heroScore == villScore {
+							tie++
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if total == 0 {
+		return 0, false
+	}
+	eq := (float64(win) + 0.5*float64(tie)) / float64(total)
+	return eq, true
+}
+
+// EvaluateMatchMC computes EV comparisons for each flop/turn/river decision
+// and writes rows into action_eval with solver='MCJudge'. Facing-bet situations
+// (to_call>0) compare call versus fold, while uncontested nodes score check
+// versus a nominal 2/3-pot probe bet.
 func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 	var (
 		fallbackDB    *store.DB
@@ -96,6 +252,7 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 		ID         int64
 		HandID     string
 		ActorLabel string
+		Street     string
 		Pot        int
 		ToCall     int
 		Board      []string
@@ -139,9 +296,9 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
        `
 
 	rows, err := connRead.Query(ctx, `
-        SELECT id, hand_id, actor_label, pot, to_call, board, sb_hole, bb_hole, LOWER(action), amount
+        SELECT id, hand_id, actor_label, street, pot, to_call, board, sb_hole, bb_hole, LOWER(action), amount
           FROM action_logs
-         WHERE match_id = $1 AND street = 'river'
+         WHERE match_id = $1 AND street IN ('flop','turn','river')
          ORDER BY id
     `, matchID)
 	if err != nil {
@@ -157,10 +314,10 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 
 	for rows.Next() {
 		var r Row
-		if err := rows.Scan(&r.ID, &r.HandID, &r.ActorLabel, &r.Pot, &r.ToCall, &r.Board, &r.SBHole, &r.BBHole, &r.Action, &r.Amount); err != nil {
+		if err := rows.Scan(&r.ID, &r.HandID, &r.ActorLabel, &r.Street, &r.Pot, &r.ToCall, &r.Board, &r.SBHole, &r.BBHole, &r.Action, &r.Amount); err != nil {
 			return err
 		}
-		if len(r.Board) < 5 || len(r.SBHole) != 2 || len(r.BBHole) != 2 {
+		if len(r.SBHole) != 2 || len(r.BBHole) != 2 {
 			continue
 		}
 
@@ -218,11 +375,14 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 			}
 			return engine.Card{Rank: rank, Suit: suit}, true
 		}
-		board := make([]engine.Card, 0, 5)
-		for i := 0; i < 5; i++ {
-			if c, ok := parse(r.Board[i]); ok {
+		board := make([]engine.Card, 0, len(r.Board))
+		for _, s := range r.Board {
+			if c, ok := parse(strings.TrimSpace(s)); ok {
 				board = append(board, c)
 			}
+		}
+		if len(board) < 3 || len(board) > 5 {
+			continue
 		}
 		h1 := make([]engine.Card, 0, 2)
 		for _, s := range heroHole {
@@ -230,92 +390,15 @@ func EvaluateMatchMC(ctx context.Context, db *store.DB, matchID int64) error {
 				h1 = append(h1, c)
 			}
 		}
-		if len(board) != 5 || len(h1) != 2 {
+		if len(h1) != 2 {
 			continue
 		}
 
 		start := time.Now()
-
-		// Build deck and enumerate villain combos (exact equity)
-		deck := make([]engine.Card, 0, 52)
-		suits := []byte{'c', 'd', 'h', 's'}
-		for _, su := range suits {
-			for rnk := 2; rnk <= 14; rnk++ {
-				deck = append(deck, engine.Card{Rank: rnk, Suit: su})
-			}
-		}
-		used := map[engine.Card]bool{}
-		for _, c := range board {
-			used[c] = true
-		}
-		for _, c := range h1 {
-			used[c] = true
-		}
-
-		// Build poker lib cards
-		toPH := func(c engine.Card) poker.Card {
-			var s poker.Suit
-			switch c.Suit {
-			case 'c':
-				s = poker.Club
-			case 'd':
-				s = poker.Diamond
-			case 'h':
-				s = poker.Heart
-			default:
-				s = poker.Spade
-			}
-			var rnk poker.Rank
-			if c.Rank == 14 {
-				rnk = poker.Rank(1)
-			} else {
-				rnk = poker.Rank(c.Rank)
-			}
-			pc, _ := poker.MakeCard(s, rnk)
-			return pc
-		}
-		heroAllPH := make([]poker.Card, 0, 7)
-		for _, c := range h1 {
-			heroAllPH = append(heroAllPH, toPH(c))
-		}
-		for _, c := range board {
-			heroAllPH = append(heroAllPH, toPH(c))
-		}
-		var a7 [7]poker.Card
-		copy(a7[:], heroAllPH)
-		heroScore := poker.Eval7(&a7)
-
-		var total int64
-		var win, tie int64
-		// enumerate pairs
-		avail := make([]engine.Card, 0, len(deck))
-		for _, c := range deck {
-			if !used[c] {
-				avail = append(avail, c)
-			}
-		}
-		for i := 0; i < len(avail); i++ {
-			for j := i + 1; j < len(avail); j++ {
-				total++
-				vAllPH := make([]poker.Card, 0, 7)
-				vAllPH = append(vAllPH, toPH(avail[i]), toPH(avail[j]))
-				for _, c := range board {
-					vAllPH = append(vAllPH, toPH(c))
-				}
-				var b7 [7]poker.Card
-				copy(b7[:], vAllPH)
-				vScore := poker.Eval7(&b7)
-				if heroScore > vScore {
-					win++
-				} else if heroScore == vScore {
-					tie++
-				}
-			}
-		}
-		if total == 0 {
+		eq, ok := heroEquityExact(h1, board)
+		if !ok {
 			continue
 		}
-		eq := (float64(win) + 0.5*float64(tie)) / float64(total)
 
 		P := float64(r.Pot)
 

--- a/server/main.go
+++ b/server/main.go
@@ -2198,7 +2198,10 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 			return fmt.Sprintf("%d/%d (%.1f%%)", good, total, pct)
 		}
 
-		var judgeGoodA, judgeTotalA, judgeGoodB, judgeTotalB int
+		var (
+			judgeGoodA, judgeTotalA, judgeGoodB, judgeTotalB int
+			judgeBreakdown                                   map[int64]map[string]store.JudgeAccuracy
+		)
 		if db != nil && matchID != 0 {
 			if err := judge.EvaluateMatchMC(context.Background(), db, matchID); err != nil {
 				log.Printf("MCJudge failed for match %d: %v", matchID, err)
@@ -2214,12 +2217,55 @@ func runDuel(checkStop func(bool) bool, gracefulOnly bool, db *store.DB) {
 						judgeGoodB, judgeTotalB = acc.Good, acc.Total
 					}
 				}
+				if breakdown, err := db.MatchJudgeAccuracyByStreet(context.Background(), matchID); err != nil {
+					log.Printf("MatchJudgeAccuracyByStreet failed for match %d: %v", matchID, err)
+				} else {
+					judgeBreakdown = breakdown
+				}
 			}
+		}
+
+		streetAccString := func(acc store.JudgeAccuracy) string {
+			return accString(acc.Good, acc.Total)
+		}
+
+		formatBreakdown := func(breakdown map[string]store.JudgeAccuracy) string {
+			if len(breakdown) == 0 {
+				return ""
+			}
+			ordered := []struct {
+				key   string
+				label string
+			}{
+				{key: "flop", label: "Flop"},
+				{key: "turn", label: "Turn"},
+				{key: "river", label: "River"},
+			}
+			parts := make([]string, 0, len(ordered))
+			for _, st := range ordered {
+				acc, ok := breakdown[st.key]
+				if !ok {
+					parts = append(parts, fmt.Sprintf("%s %s", st.label, "n/a"))
+					continue
+				}
+				parts = append(parts, fmt.Sprintf("%s %s", st.label, streetAccString(acc)))
+			}
+			return strings.Join(parts, " | ")
 		}
 
 		fmt.Println(bold("MCJudge accuracy (this match):"))
 		fmt.Printf("  %s %s %s\n", bold("A"), a.Model, accString(judgeGoodA, judgeTotalA))
+		if judgeBreakdown != nil {
+			if parts := formatBreakdown(judgeBreakdown[botAID]); parts != "" {
+				fmt.Printf("    %s %s\n", bold("streets"), parts)
+			}
+		}
 		fmt.Printf("  %s %s %s\n", bold("B"), b.Model, accString(judgeGoodB, judgeTotalB))
+		if judgeBreakdown != nil {
+			if parts := formatBreakdown(judgeBreakdown[botBID]); parts != "" {
+				fmt.Printf("    %s %s\n", bold("streets"), parts)
+			}
+		}
 
 		// persist career ratings, hands, and judge accuracy
 		if err := db.UpdateBotRatings(context.Background(), botAID, elo.A, gA.Rating, gA.RD, gA.Volatility, 1, handsA, judgeGoodA, judgeTotalA); err != nil {

--- a/server/store/store.go
+++ b/server/store/store.go
@@ -126,6 +126,46 @@ func (db *DB) MatchJudgeAccuracy(ctx context.Context, matchID int64) (map[int64]
 	return db.judgeAccuracy(ctx, " AND a.match_id = $1", matchID)
 }
 
+func (db *DB) MatchJudgeAccuracyByStreet(ctx context.Context, matchID int64) (map[int64]map[string]JudgeAccuracy, error) {
+	query := `
+                SELECT p.bot_id,
+                       a.street,
+                       SUM(CASE WHEN e.is_top_action THEN 1 ELSE 0 END)::int AS good,
+                       COUNT(*)::int AS total
+                  FROM action_eval e
+                  JOIN action_logs a ON a.id = e.action_log_id
+                  JOIN match_participants p ON p.match_id = a.match_id AND p.label = a.actor_label
+                 WHERE e.solver = 'MCJudge' AND a.match_id = $1
+                 GROUP BY p.bot_id, a.street`
+
+	rows, err := db.Query(ctx, query, matchID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[int64]map[string]JudgeAccuracy)
+	for rows.Next() {
+		var (
+			botID  int64
+			street string
+			good   int
+			total  int
+		)
+		if err := rows.Scan(&botID, &street, &good, &total); err != nil {
+			return nil, err
+		}
+		if _, ok := out[botID]; !ok {
+			out[botID] = make(map[string]JudgeAccuracy)
+		}
+		out[botID][strings.ToLower(street)] = JudgeAccuracy{Good: good, Total: total}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (db *DB) AllJudgeAccuracy(ctx context.Context) (map[int64]JudgeAccuracy, error) {
 	res, err := db.judgeAccuracy(ctx, "")
 	if err != nil {


### PR DESCRIPTION
## Summary
- extend MCJudge evaluation to enumerate flop and turn equities alongside the river
- add a store helper to fetch MCJudge accuracy split by street
- print a street-by-street accuracy breakdown after each match while keeping the overall total front and center

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d4264b1fa0832d917d714aa3f4c98b