### PR TITLE
Hide desktop nav toggle

### DIFF
--- a/server/web/app.js
+++ b/server/web/app.js
@@ -84,10 +84,14 @@
           navToggle.setAttribute('aria-expanded', 'false');
           navToggle.setAttribute('aria-label', 'Menu');
           navToggle.setAttribute('title', 'Menu');
+          navToggle.hidden = true;
+          navToggle.setAttribute('aria-hidden', 'true');
           body?.classList.remove('has-open-mobile-nav');
           return;
         }
 
+        navToggle.hidden = false;
+        navToggle.removeAttribute('aria-hidden');
         navHost.classList.add('topnav--collapsible');
         if (isMenuOpen) {
           navHost.classList.add('topnav--menu-open');


### PR DESCRIPTION
## Summary
- hide the mobile navigation toggle when the viewport is not in mobile mode
- keep mobile accessibility attributes in sync when the toggle is shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d49599de78832daef0931ec87a5900