### PR TITLE
Fix Grok matrix label and shrink matrix cells

### DIFF
--- a/server/web/app.css
+++ b/server/web/app.css
@@ -1891,6 +1891,23 @@ p {
   background: var(--surface-alt);
 }
 
+.matrix-table th,
+.matrix-table td {
+  padding: clamp(6px, 0.9vw, 14px);
+}
+
+.matrix-table td.matrix-cell,
+.matrix-table td.matrix-diag {
+  min-width: clamp(42px, 4.4vw, 72px);
+  font-size: clamp(11px, 0.95vw, var(--fs-2));
+}
+
+.matrix-table th.rot {
+  padding-block: clamp(6px, 0.8vw, 12px);
+  padding-inline: clamp(4px, 0.6vw, 12px);
+  font-size: clamp(10px, 0.9vw, var(--fs-1));
+}
+
 .num {
   text-align: right;
   font-variant-numeric: tabular-nums;
@@ -2287,7 +2304,7 @@ p {
 }
 
 .matrix-table th.matrix-sticky {
-  min-width: 200px;
+  min-width: clamp(160px, 24vw, 220px);
   box-shadow: 4px 0 12px rgba(15, 23, 42, 0.08);
 }
 

--- a/server/web/matrix.html
+++ b/server/web/matrix.html
@@ -41,6 +41,7 @@
       const hue = 240*(1-x); // blue -> red
       return `background-color: hsl(${hue} 70% 42% / .22)`;
     }
+    const SHORT_NAME_SUFFIXES = new Set(['free', 'preview', 'latest', 'beta', 'experimental']);
     function escapeAttr(s = ''){
       return String(s)
         .replace(/&/g, '&amp;')
@@ -51,10 +52,32 @@
     function shortName(s){
       s = (s||'').trim().replace(/^"+|"+$/g,'');
       s = s.replace(/[\-_.]20\d{2}(?:[\-_.]?\d{2}){0,2}$/,'');
-      const parts = s.split(/[\/:@]/).filter(Boolean);
-      s = (parts[parts.length-1]||s).trim();
-      if (s.length>28) s = s.slice(0,28)+'…';
-      return s;
+      const slashParts = s.split('/').filter(Boolean);
+      let name = (slashParts[slashParts.length-1]||s).trim();
+      name = name.replace(/[\-_.]20\d{2}(?:[\-_.]?\d{2}){0,2}$/,'');
+      if(name.includes('@')){
+        const atParts = name.split('@').filter(Boolean);
+        if(atParts.length){
+          const last = atParts[atParts.length-1];
+          if(SHORT_NAME_SUFFIXES.has(last.toLowerCase())){
+            const kept = atParts.slice(0, -1);
+            name = kept.length ? kept.join('@') : atParts[0];
+          }
+        }
+      }
+      if(name.includes(':')){
+        const colonParts = name.split(':').filter(Boolean);
+        if(colonParts.length){
+          const filtered = colonParts.filter((part, idx)=> idx === 0 || !SHORT_NAME_SUFFIXES.has(part.toLowerCase()));
+          if(filtered.length){
+            name = filtered.join(':');
+          }else{
+            name = colonParts[0];
+          }
+        }
+      }
+      if (name.length>28) name = name.slice(0,28)+'…';
+      return name;
     }
     function eloProb(ra, rb){ return 1 / (1 + Math.pow(10, (rb - ra)/400)); }
     async function getJSON(url, fallback){


### PR DESCRIPTION
## Summary
- ensure Grok models keep their actual names by trimming redundant suffixes like :free when building the matrix labels
- tighten the matrix cell layout so additional models render smaller, uniform squares instead of stretching the table

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d49b230c88832dbfea6f185ac12874